### PR TITLE
add global logger at __init__.py with RichHandler

### DIFF
--- a/autorag/__init__.py
+++ b/autorag/__init__.py
@@ -1,5 +1,11 @@
 __version__ = '0.0.1'
 
+import logging
+import logging.config
+import sys
+
+from rich.logging import RichHandler
+
 from .evaluator import Evaluator
 
 from llama_index import OpenAIEmbedding
@@ -12,3 +18,20 @@ embedding_models = {
 generator_models = {
     'openai': OpenAI(),
 }
+
+rich_format = "[%(filename)s:%(lineno)s] >> %(message)s"
+logging.basicConfig(
+    level="NOTSET",
+    format=rich_format,
+    handlers=[RichHandler(rich_tracebacks=True)]
+)
+logger = logging.getLogger("AutoRAG")
+
+
+def handle_exception(exc_type, exc_value, exc_traceback):
+    logger = logging.getLogger("AutoRAG")
+    logger.error("Unexpected exception",
+                 exc_info=(exc_type, exc_value, exc_traceback))
+
+
+sys.excepthook = handle_exception

--- a/autorag/evaluator.py
+++ b/autorag/evaluator.py
@@ -51,7 +51,7 @@ class Evaluator:
         self.__make_trial_dir(trial_name)
 
         node_lines = self._load_node_lines(yaml_path)
-        self.__ingest(node_lines)
+        self.__embed(node_lines)
 
         trial_summary_df = pd.DataFrame(columns=['node_line_name', 'node_type', 'best_module_filename'])
         for i, (node_line_name, node_line) in enumerate(node_lines.items()):
@@ -60,6 +60,7 @@ class Evaluator:
             os.makedirs(node_line_dir, exist_ok=False)
             if i == 0:
                 previous_result = self.qa_data
+            logger.info(f'Running node line {node_line_name}...')
             previous_result = run_node_line(node_line, node_line_dir, previous_result)
 
             summary_df = pd.read_csv(os.path.join(node_line_dir, 'summary.csv'))
@@ -69,18 +70,18 @@ class Evaluator:
 
         trial_summary_df.to_csv(os.path.join(self.project_dir, trial_name, 'summary.csv'), index=False)
 
-    def __ingest(self, node_lines: Dict[str, List[Node]]):
+    def __embed(self, node_lines: Dict[str, List[Node]]):
         if any(list(map(lambda nodes: module_type_exists(nodes, 'bm25'), node_lines.values()))):
             # ingest BM25 corpus
-            logger.info('Ingesting BM25 corpus...')
+            logger.info('Embedding BM25 corpus...')
             bm25_dir = os.path.join(self.project_dir, 'resources', 'bm25.pkl')
             if not os.path.exists(os.path.dirname(bm25_dir)):
                 os.makedirs(os.path.dirname(bm25_dir))
             if os.path.exists(bm25_dir):
-                logger.info('BM25 corpus already exists.')
+                logger.debug('BM25 corpus already exists.')
             else:
                 bm25_ingest(bm25_dir, self.corpus_data)
-            logger.info('BM25 corpus ingestion complete.')
+            logger.info('BM25 corpus embedding complete.')
             pass
         elif any(list(map(lambda nodes: module_type_exists(nodes, 'vector'), node_lines.values()))):
             # TODO: ingest vector DB

--- a/autorag/evaluator.py
+++ b/autorag/evaluator.py
@@ -1,9 +1,9 @@
 import json
+import logging
 import os
 import shutil
 from datetime import datetime
 from typing import List, Dict
-import logging
 
 import pandas as pd
 import yaml
@@ -14,7 +14,8 @@ from autorag.schema import Node
 from autorag.schema.node import module_type_exists
 from autorag.utils import cast_qa_dataset, cast_corpus_dataset
 
-logger = logging.getLogger(__name__)
+
+logger = logging.getLogger("AutoRAG")
 
 
 class Evaluator:

--- a/autorag/nodes/retrieval/run.py
+++ b/autorag/nodes/retrieval/run.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pathlib
 from typing import List, Callable, Dict
@@ -7,6 +8,8 @@ import pandas as pd
 from autorag.evaluate import evaluate_retrieval
 from autorag.strategy import measure_speed, filter_by_threshold, select_best_average
 from autorag.utils.util import make_module_file_name
+
+logger = logging.getLogger("AutoRAG")
 
 
 def run_retrieval_node(modules: List[Callable],

--- a/autorag/schema/node.py
+++ b/autorag/schema/node.py
@@ -1,4 +1,5 @@
 import itertools
+import logging
 from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Dict, List, Callable
@@ -11,6 +12,7 @@ from autorag.schema.module import Module
 SUPPORT_NODES = {
     'retrieval': run_retrieval_node,
 }
+logger = logging.getLogger("AutoRAG")
 
 
 @dataclass
@@ -53,6 +55,7 @@ class Node:
         return cls(node_type, strategy, node_params, modules)
 
     def run(self, previous_result: pd.DataFrame, node_line_dir: str) -> pd.DataFrame:
+        logger.info(f'Running node {self.node_type}...')
         return self.run_node(modules=list(map(lambda x: x.module, self.modules)),
                              module_params=self.get_param_combinations(),
                              previous_result=previous_result,

--- a/autorag/utils/util.py
+++ b/autorag/utils/util.py
@@ -1,6 +1,6 @@
 import functools
 import os
-from typing import List, Callable, Dict, Tuple
+from typing import List, Callable, Dict
 
 import pandas as pd
 import swifter

--- a/autorag/utils/util.py
+++ b/autorag/utils/util.py
@@ -47,23 +47,6 @@ def make_module_file_name(module_name: str, module_params: Dict) -> str:
     return f"{module_name}=>{module_params_str}.parquet"
 
 
-def decode_module_file_name(module_file_name: str) -> Tuple[str, Dict]:
-    """
-    Decode module parquet file name to module name and module parameters.
-
-    :param module_file_name: Module parquet file name.
-    :return: Module name and module parameters.
-    """
-    name = module_file_name.replace(".parquet", "")
-    module_name = name.split("=>")[0]
-    if len(name.split('=>')) >= 2:
-        module_params_str = name.split("=>")[1].split('-')
-        module_params = {param.split('_')[0]: param.split('_')[1] for param in module_params_str}
-    else:
-        module_params = {}
-    return module_name, module_params
-
-
 def find_best_result_path(node_dir: str) -> str:
     """
     Find the best result filepath from node directory.

--- a/autorag/utils/util.py
+++ b/autorag/utils/util.py
@@ -1,6 +1,6 @@
 import functools
 import os
-from typing import List, Callable, Dict
+from typing import List, Callable, Dict, Tuple
 
 import pandas as pd
 import swifter
@@ -45,6 +45,23 @@ def make_module_file_name(module_name: str, module_params: Dict) -> str:
     if len(module_params_str) <= 0:
         return f"{module_name}.parquet"
     return f"{module_name}=>{module_params_str}.parquet"
+
+
+def decode_module_file_name(module_file_name: str) -> Tuple[str, Dict]:
+    """
+    Decode module parquet file name to module name and module parameters.
+
+    :param module_file_name: Module parquet file name.
+    :return: Module name and module parameters.
+    """
+    name = module_file_name.replace(".parquet", "")
+    module_name = name.split("=>")[0]
+    if len(name.split('=>')) >= 2:
+        module_params_str = name.split("=>")[1].split('-')
+        module_params = {param.split('_')[0]: param.split('_')[1] for param in module_params_str}
+    else:
+        module_params = {}
+    return module_name, module_params
 
 
 def find_best_result_path(node_dir: str) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ fastparquet  # for pandas with parquet
 sacrebleu  # for bleu score
 evaluate  # for meteor and other scores
 rouge_score  # for rouge score
+rich  # for pretty logging

--- a/tests/autorag/utils/test_util.py
+++ b/tests/autorag/utils/test_util.py
@@ -4,11 +4,54 @@ import pathlib
 import tempfile
 
 import pandas as pd
+import pytest
 
 from autorag.utils import fetch_contents
-from autorag.utils.util import find_best_result_path
+from autorag.utils.util import find_best_result_path, make_module_file_name, decode_module_file_name
 
 root_dir = pathlib.PurePath(os.path.dirname(os.path.realpath(__file__))).parent.parent
+
+
+@pytest.fixture
+def module_name():
+    return "test_module"
+
+
+@pytest.fixture
+def module_params():
+    return {
+        "param1": "value1",
+        "param2": "value2",
+        "param3": "value3",
+    }
+
+
+def test_make_module_file_name(module_name, module_params):
+    module_file_name = make_module_file_name(module_name, module_params)
+    assert module_file_name == "test_module=>param1_value1-param2_value2-param3_value3.parquet"
+
+    module_file_name = make_module_file_name(module_name, {})
+    assert module_file_name == "test_module.parquet"
+
+    module_file_name = make_module_file_name(module_name, {"param1": "value1"})
+    assert module_file_name == "test_module=>param1_value1.parquet"
+
+
+def test_decode_module_file_name(module_name, module_params):
+    module_file_name = make_module_file_name(module_name, module_params)
+    decoded_module_name, decoded_module_params = decode_module_file_name(module_file_name)
+    assert decoded_module_name == module_name
+    assert decoded_module_params == module_params
+
+    module_file_name = make_module_file_name(module_name, {})
+    decoded_module_name, decoded_module_params = decode_module_file_name(module_file_name)
+    assert decoded_module_name == module_name
+    assert decoded_module_params == {}
+
+    module_file_name = make_module_file_name(module_name, {"param1": "value1"})
+    decoded_module_name, decoded_module_params = decode_module_file_name(module_file_name)
+    assert decoded_module_name == module_name
+    assert decoded_module_params == {"param1": "value1"}
 
 
 def test_fetch_contents():

--- a/tests/autorag/utils/test_util.py
+++ b/tests/autorag/utils/test_util.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 
 from autorag.utils import fetch_contents
-from autorag.utils.util import find_best_result_path, make_module_file_name, decode_module_file_name
+from autorag.utils.util import find_best_result_path, make_module_file_name
 
 root_dir = pathlib.PurePath(os.path.dirname(os.path.realpath(__file__))).parent.parent
 
@@ -35,23 +35,6 @@ def test_make_module_file_name(module_name, module_params):
 
     module_file_name = make_module_file_name(module_name, {"param1": "value1"})
     assert module_file_name == "test_module=>param1_value1.parquet"
-
-
-def test_decode_module_file_name(module_name, module_params):
-    module_file_name = make_module_file_name(module_name, module_params)
-    decoded_module_name, decoded_module_params = decode_module_file_name(module_file_name)
-    assert decoded_module_name == module_name
-    assert decoded_module_params == module_params
-
-    module_file_name = make_module_file_name(module_name, {})
-    decoded_module_name, decoded_module_params = decode_module_file_name(module_file_name)
-    assert decoded_module_name == module_name
-    assert decoded_module_params == {}
-
-    module_file_name = make_module_file_name(module_name, {"param1": "value1"})
-    decoded_module_name, decoded_module_params = decode_module_file_name(module_file_name)
-    assert decoded_module_name == module_name
-    assert decoded_module_params == {"param1": "value1"}
 
 
 def test_fetch_contents():

--- a/tests/resources/config.yaml
+++ b/tests/resources/config.yaml
@@ -27,7 +27,7 @@ node_lines:
       skip_evaluation: True
       modules:
         - module_type: default_prompt_maker
-          prompt: "This is a news dataset, cralwed from finance news site. You need to make detailed question about finance news. Do not make questions that not relevant to economy or finance domain.\n{{context}}\n\nQ: {{question}}\nA:"
+          prompt: "This is a news dataset, crawled from finance news site. You need to make detailed question about finance news. Do not make questions that not relevant to economy or finance domain.\n{{context}}\n\nQ: {{question}}\nA:"
     - node_type: generation
       strategy:
         metrics: [bleu, rouge, kf1]


### PR DESCRIPTION
close #42

I add global logger at autorag/__init__.py. 
But, when you use it, do not import directly from autorag/__init__.py because it will potentially occur circular import error.
Instead, you can get logger like below code. Remember logger instance have same name is singleton.
```python
import logging
logger = logging.getLogger("AutoRAG")
```

I use RichHandler instead of StreamHandler for beautiful formatting. 
Plus, I use rich exception for beautiful inspection while debugging.
You can see rich logging by deleting last two lines of your pytest.ini
Change pytest.ini looks like this.

```
[pytest]
env =
    OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxx

log_cli=true
log_cli_level=INFO
```
