### PR TITLE
Change summary csv file to parquet file

### DIFF
--- a/autorag/evaluator.py
+++ b/autorag/evaluator.py
@@ -65,7 +65,10 @@ class Evaluator:
             summary_df = pd.read_parquet(os.path.join(node_line_dir, 'summary.parquet'))
             summary_df = summary_df.assign(node_line_name=node_line_name)
             summary_df = summary_df[list(trial_summary_df.columns)]
-            trial_summary_df = pd.concat([trial_summary_df, summary_df], ignore_index=True)
+            if len(trial_summary_df) <= 0:
+                trial_summary_df = summary_df
+            else:
+                trial_summary_df = pd.concat([trial_summary_df, summary_df], ignore_index=True)
 
         trial_summary_df.to_parquet(os.path.join(self.project_dir, trial_name, 'summary.parquet'), index=False)
 

--- a/autorag/evaluator.py
+++ b/autorag/evaluator.py
@@ -61,7 +61,7 @@ class Evaluator:
                 previous_result = self.qa_data
             previous_result = run_node_line(node_line, node_line_dir, previous_result)
 
-            summary_df = pd.read_csv(os.path.join(node_line_dir, 'summary.csv'))
+            summary_df = pd.read_parquet(os.path.join(node_line_dir, 'summary.parquet'))
             summary_df = summary_df.assign(node_line_name=node_line_name)
             summary_df = summary_df[list(trial_summary_df.columns)]
             trial_summary_df = pd.concat([trial_summary_df, summary_df], ignore_index=True)

--- a/autorag/evaluator.py
+++ b/autorag/evaluator.py
@@ -52,7 +52,8 @@ class Evaluator:
         node_lines = self._load_node_lines(yaml_path)
         self.__ingest(node_lines)
 
-        trial_summary_df = pd.DataFrame(columns=['node_line_name', 'node_type', 'best_module_filename'])
+        trial_summary_df = pd.DataFrame(columns=['node_line_name', 'node_type', 'best_module_filename',
+                                                 'best_module_name', 'best_module_params', 'best_execution_time'])
         for i, (node_line_name, node_line) in enumerate(node_lines.items()):
             logger.info(f'Running node line {node_line_name}...')
             node_line_dir = os.path.join(self.project_dir, trial_name, node_line_name)
@@ -66,7 +67,7 @@ class Evaluator:
             summary_df = summary_df[list(trial_summary_df.columns)]
             trial_summary_df = pd.concat([trial_summary_df, summary_df], ignore_index=True)
 
-        trial_summary_df.to_csv(os.path.join(self.project_dir, trial_name, 'summary.csv'), index=False)
+        trial_summary_df.to_parquet(os.path.join(self.project_dir, trial_name, 'summary.parquet'), index=False)
 
     def __ingest(self, node_lines: Dict[str, List[Node]]):
         if any(list(map(lambda nodes: module_type_exists(nodes, 'bm25'), node_lines.values()))):

--- a/autorag/evaluator.py
+++ b/autorag/evaluator.py
@@ -56,7 +56,6 @@ class Evaluator:
         trial_summary_df = pd.DataFrame(columns=['node_line_name', 'node_type', 'best_module_filename',
                                                  'best_module_name', 'best_module_params', 'best_execution_time'])
         for i, (node_line_name, node_line) in enumerate(node_lines.items()):
-            logger.info(f'Running node line {node_line_name}...')
             node_line_dir = os.path.join(self.project_dir, trial_name, node_line_name)
             os.makedirs(node_line_dir, exist_ok=False)
             if i == 0:

--- a/autorag/node_line.py
+++ b/autorag/node_line.py
@@ -43,7 +43,14 @@ def run_node_line(nodes: List[Node],
     summary_lst = []
     for node in nodes:
         previous_result = node.run(previous_result, node_line_dir)
-        best_module_filename = os.path.basename(find_best_result_path(os.path.join(node_line_dir, node.node_type)))
-        summary_lst.append({'node_type': node.node_type, 'best_module_filename': best_module_filename})
-    pd.DataFrame(summary_lst).to_csv(os.path.join(node_line_dir, 'summary.csv'), index=False)
+        node_summary_df = pd.read_parquet(os.path.join(node_line_dir, node.node_type, 'summary.parquet'))
+        best_node_row = node_summary_df.loc[node_summary_df['is_best']]
+        summary_lst.append({
+            'node_type': node.node_type,
+            'best_module_filename': best_node_row['filename'].values[0],
+            'best_module_name': best_node_row['module_name'].values[0],
+            'best_module_params': best_node_row['module_params'].values[0],
+            'best_execution_time': best_node_row['execution_time'].values[0],
+        })
+    pd.DataFrame(summary_lst).to_parquet(os.path.join(node_line_dir, 'summary.parquet'), index=False)
     return previous_result

--- a/autorag/nodes/retrieval/run.py
+++ b/autorag/nodes/retrieval/run.py
@@ -48,24 +48,28 @@ def run_retrieval_node(modules: List[Callable],
     filepaths = list(map(lambda x: os.path.join(save_dir, make_module_file_name(x[0].__name__, x[1])),
                          zip(modules, module_params)))
     list(map(lambda x: x[0].to_parquet(x[1], index=False), zip(results, filepaths)))  # execute save to parquet
+    filenames = list(map(lambda x: os.path.basename(x), filepaths))
 
     summary_df = pd.DataFrame({
-        'filename': list(map(lambda x: os.path.basename(x), filepaths)),
+        'filename': filenames,
+        'module_name': list(map(lambda module: module.__name__, modules)),
+        'module_params': module_params,
+        'execution_time': average_times,
         **{metric: list(map(lambda result: result[metric].mean(), results)) for metric in strategies.get('metrics')},
     })
-    summary_df.to_csv(os.path.join(save_dir, 'summary.csv'), index=False)
 
     # filter by strategies
-    module_filenames = list(map(lambda x: os.path.splitext(os.path.basename(x))[0], filepaths))
     if strategies.get('speed_threshold') is not None:
-        results, module_filenames = filter_by_threshold(results, average_times, strategies['speed_threshold'],
-                                                        module_filenames)
-    selected_result, selected_module_filename = select_best_average(results, strategies.get('metrics'),
-                                                                    module_filenames)
+        results, filenames = filter_by_threshold(results, average_times, strategies['speed_threshold'], filenames)
+    selected_result, selected_filename = select_best_average(results, strategies.get('metrics'), filenames)
     best_result = pd.concat([previous_result, selected_result], axis=1)
 
-    # save the best result to best.parquet
-    best_result.to_parquet(os.path.join(save_dir, f'best_{selected_module_filename}.parquet'), index=False)
+    # add summary.csv 'is_best' column
+    summary_df['is_best'] = summary_df['filename'] == selected_filename
+
+    # save the result files
+    best_result.to_parquet(os.path.join(save_dir, f'best_{os.path.splitext(selected_filename)[0]}.parquet'), index=False)
+    summary_df.to_parquet(os.path.join(save_dir, 'summary.parquet'), index=False)
     return best_result
 
 

--- a/autorag/strategy.py
+++ b/autorag/strategy.py
@@ -43,7 +43,9 @@ def filter_by_threshold(results, value, threshold, metadatas=None) -> Tuple[List
         It must have the same length with results.
     :param threshold: The threshold value.
     :param metadatas: The metadata of each result.
-    :return: Filtered list of results.
+    :return: Filtered list of results and filtered list of metadatas.
+        Metadatas will be returned even if you did not give input metadatas.
+    :rtype: Tuple[List, List]
     """
     if metadatas is None:
         metadatas = [None] * len(results)
@@ -63,7 +65,9 @@ def select_best_average(results: List[pd.DataFrame], columns: Iterable[str],
         Standard to select the best result.
     :param metadatas: The metadata of each result. 
         It will select one metadata with the best result.
-    :return: The best result.
+    :return: The best result and the best metadata.
+        The metadata will be returned even if you did not give input 'metadatas' parameter.
+    :rtype: Tuple[pd.DataFrame, Any]
     """
     if metadatas is None:
         metadatas = [None] * len(results)

--- a/autorag/strategy.py
+++ b/autorag/strategy.py
@@ -1,6 +1,6 @@
 import functools
 import time
-from typing import List, Iterable, Tuple
+from typing import List, Iterable, Tuple, Any, Optional
 
 import pandas as pd
 
@@ -20,8 +20,6 @@ def avoid_empty_result(func):
     Decorator for avoiding empty results from the function.
     When the func returns an empty result, it will return the origin results.
     It keeps the first input parameter of the function as the origin results.
-    :param func:
-    :return:
     """
 
     @functools.wraps(func)
@@ -36,7 +34,7 @@ def avoid_empty_result(func):
 
 
 @avoid_empty_result
-def filter_by_threshold(results, value, threshold, module_filename: Iterable[str]) -> Tuple[List, List[str]]:
+def filter_by_threshold(results, value, threshold, metadatas=None) -> Tuple[List, List]:
     """
     Filter results by value's threshold.
 
@@ -44,18 +42,18 @@ def filter_by_threshold(results, value, threshold, module_filename: Iterable[str
     :param value: The value list to be filtered.
         It must have the same length with results.
     :param threshold: The threshold value.
-    :param module_filename: The module filename list.
-        It uses to recognize which module is filtered or not.
+    :param metadatas: The metadata of each result.
     :return: Filtered list of results.
     """
+    if metadatas is None:
+        metadatas = [None] * len(results)
     assert len(results) == len(value), "results and value must have the same length."
-    filtered_results, _, filtered_module_filename = zip(*filter(lambda x: x[1] <= threshold,
-                                                                zip(results, value, module_filename)))
-    return list(filtered_results), list(filtered_module_filename)
+    filtered_results, _, filtered_metadatas = zip(*filter(lambda x: x[1] <= threshold, zip(results, value, metadatas)))
+    return list(filtered_results), list(filtered_metadatas)
 
 
 def select_best_average(results: List[pd.DataFrame], columns: Iterable[str],
-                        module_filename: List[str]) -> Tuple[pd.DataFrame, str]:
+                        metadatas: Optional[List[Any]] = None) -> Tuple[pd.DataFrame, Any]:
     """
     Select the best result by average value among given columns.
 
@@ -63,15 +61,17 @@ def select_best_average(results: List[pd.DataFrame], columns: Iterable[str],
         Each result must be pd.DataFrame.
     :param columns: Column names to be averaged.
         Standard to select the best result.
-    :param module_filename: The module filename list.
-        It uses to recognize which module is selected.
+    :param metadatas: The metadata of each result. 
+        It will select one metadata with the best result.
     :return: The best result.
     """
-    assert len(results) == len(module_filename), "results and module_filename must have the same length."
+    if metadatas is None:
+        metadatas = [None] * len(results)
+    assert len(results) == len(metadatas), "results and module_filename must have the same length."
     assert all([isinstance(result, pd.DataFrame) for result in results]), \
         "results must be pd.DataFrame."
     assert all([column in result.columns for result in results for column in columns]), \
         "columns must be in the columns of results."
     each_average = [df[columns].mean(axis=1).mean() for df in results]
     best_index = each_average.index(max(each_average))
-    return results[best_index], module_filename[best_index]
+    return results[best_index], metadatas[best_index]

--- a/docs/source/api_spec/autorag.evaluate.metric.rst
+++ b/docs/source/api_spec/autorag.evaluate.metric.rst
@@ -4,6 +4,14 @@ autorag.evaluate.metric package
 Submodules
 ----------
 
+autorag.evaluate.metric.generation module
+-----------------------------------------
+
+.. automodule:: autorag.evaluate.metric.generation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 autorag.evaluate.metric.retrieval module
 ----------------------------------------
 

--- a/docs/source/api_spec/autorag.evaluate.rst
+++ b/docs/source/api_spec/autorag.evaluate.rst
@@ -12,6 +12,14 @@ Subpackages
 Submodules
 ----------
 
+autorag.evaluate.generation module
+----------------------------------
+
+.. automodule:: autorag.evaluate.generation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 autorag.evaluate.retrieval module
 ---------------------------------
 

--- a/tests/autorag/nodes/retrieval/test_run_retrieval_node.py
+++ b/tests/autorag/nodes/retrieval/test_run_retrieval_node.py
@@ -44,17 +44,24 @@ def test_run_retrieval_node(node_line_dir):
                       'retrieved_contents', 'retrieved_ids', 'retrieve_scores', 'retrieval_f1', 'retrieval_recall']
     assert all([expect_column in best_result.columns for expect_column in expect_columns])
     # test summary feature
-    summary_path = os.path.join(node_line_dir, "retrieval", "summary.csv")
+    summary_path = os.path.join(node_line_dir, "retrieval", "summary.parquet")
     bm25_top_k_path = os.path.join(node_line_dir, "retrieval", "bm25=>top_k_4.parquet")
     assert os.path.exists(os.path.join(node_line_dir, "retrieval", "bm25=>top_k_4.parquet"))
     bm25_top_k_df = pd.read_parquet(bm25_top_k_path)
     assert os.path.exists(summary_path)
-    summary_df = pd.read_csv(summary_path)
-    assert ['filename', 'retrieval_f1', 'retrieval_recall'] == summary_df.columns.tolist()
+    summary_df = pd.read_parquet(summary_path)
+    assert set(summary_df.columns) == {'filename', 'retrieval_f1', 'retrieval_recall',
+                                       'module_name', 'module_params', 'execution_time', 'is_best'}
     assert len(summary_df) == 1
     assert summary_df['filename'][0] == "bm25=>top_k_4.parquet"
     assert summary_df['retrieval_f1'][0] == bm25_top_k_df['retrieval_f1'].mean()
     assert summary_df['retrieval_recall'][0] == bm25_top_k_df['retrieval_recall'].mean()
+    assert summary_df['module_name'][0] == "bm25"
+    assert summary_df['module_params'][0] == {'top_k': 4}
+    assert summary_df['execution_time'][0] > 0
+    assert summary_df['is_best'][0] == True # is_best is np.bool_
     # test the best file is saved properly
     best_path = os.path.join(node_line_dir, "retrieval", "best_bm25=>top_k_4.parquet")
     assert os.path.exists(best_path)
+    best_df = pd.read_parquet(best_path)
+    assert all([expect_column in best_df.columns for expect_column in expect_columns])

--- a/tests/autorag/test_evaluator.py
+++ b/tests/autorag/test_evaluator.py
@@ -68,23 +68,30 @@ def test_start_trial(evaluator):
     assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line'))
     assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval'))
     assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval', 'bm25=>top_k_50.parquet'))
-    expect_each_result_columns = ['retrieved_contents', 'retrieved_ids', 'retrieve_scores', 'retrieval_f1', 'retrieval_recall']
-    each_result = pd.read_parquet(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval', 'bm25=>top_k_50.parquet'))
+    expect_each_result_columns = ['retrieved_contents', 'retrieved_ids', 'retrieve_scores', 'retrieval_f1',
+                                  'retrieval_recall']
+    each_result = pd.read_parquet(
+        os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval', 'bm25=>top_k_50.parquet'))
     assert all([expect_column in each_result.columns for expect_column in expect_each_result_columns])
     expect_best_result_columns = ['qid', 'query', 'retrieval_gt', 'generation_gt',
-                      'retrieved_contents', 'retrieved_ids', 'retrieve_scores', 'retrieval_f1', 'retrieval_recall']
+                                  'retrieved_contents', 'retrieved_ids', 'retrieve_scores', 'retrieval_f1',
+                                  'retrieval_recall']
     best_result = pd.read_parquet(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval',
                                                'best_bm25=>top_k_50.parquet'))
     assert all([expect_column in best_result.columns for expect_column in expect_best_result_columns])
 
     # test node line summary
-    node_line_summary_path = os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'summary.csv')
+    node_line_summary_path = os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'summary.parquet')
     assert os.path.exists(node_line_summary_path)
-    node_line_summary_df = pd.read_csv(node_line_summary_path)
+    node_line_summary_df = pd.read_parquet(node_line_summary_path)
     assert len(node_line_summary_df) == 1
-    assert set(node_line_summary_df.columns) == {'node_type', 'best_module_filename'}
+    assert set(node_line_summary_df.columns) == {'node_type', 'best_module_filename',
+                                                 'best_module_name', 'best_module_params', 'best_execution_time'}
     assert node_line_summary_df['node_type'][0] == 'retrieval'
-    assert node_line_summary_df['best_module_filename'][0] == 'best_bm25=>top_k_50.parquet'
+    assert node_line_summary_df['best_module_filename'][0] == 'bm25=>top_k_50.parquet'
+    assert node_line_summary_df['best_module_name'][0] == 'bm25'
+    assert node_line_summary_df['best_module_params'][0] == {'top_k': 50}
+    assert node_line_summary_df['best_execution_time'][0] > 0
 
     # test trial summary
     trial_summary_path = os.path.join(os.getcwd(), '0', 'summary.csv')
@@ -94,4 +101,4 @@ def test_start_trial(evaluator):
     assert set(trial_summary_df.columns) == {'node_line_name', 'node_type', 'best_module_filename'}
     assert trial_summary_df['node_line_name'][0] == 'retrieve_node_line'
     assert trial_summary_df['node_type'][0] == 'retrieval'
-    assert trial_summary_df['best_module_filename'][0] == 'best_bm25=>top_k_50.parquet'
+    assert trial_summary_df['best_module_filename'][0] == 'bm25=>top_k_50.parquet'

--- a/tests/autorag/test_evaluator.py
+++ b/tests/autorag/test_evaluator.py
@@ -94,11 +94,15 @@ def test_start_trial(evaluator):
     assert node_line_summary_df['best_execution_time'][0] > 0
 
     # test trial summary
-    trial_summary_path = os.path.join(os.getcwd(), '0', 'summary.csv')
+    trial_summary_path = os.path.join(os.getcwd(), '0', 'summary.parquet')
     assert os.path.exists(trial_summary_path)
-    trial_summary_df = pd.read_csv(trial_summary_path)
+    trial_summary_df = pd.read_parquet(trial_summary_path)
     assert len(trial_summary_df) == 1
-    assert set(trial_summary_df.columns) == {'node_line_name', 'node_type', 'best_module_filename'}
+    assert set(trial_summary_df.columns) == {'node_line_name', 'node_type', 'best_module_filename',
+                                             'best_module_name', 'best_module_params', 'best_execution_time'}
     assert trial_summary_df['node_line_name'][0] == 'retrieve_node_line'
     assert trial_summary_df['node_type'][0] == 'retrieval'
     assert trial_summary_df['best_module_filename'][0] == 'bm25=>top_k_50.parquet'
+    assert trial_summary_df['best_module_name'][0] == 'bm25'
+    assert trial_summary_df['best_module_params'][0] == {'top_k': 50}
+    assert trial_summary_df['best_execution_time'][0] > 0

--- a/tests/autorag/test_strategy.py
+++ b/tests/autorag/test_strategy.py
@@ -21,6 +21,9 @@ def test_filter_by_threshold():
     assert filtered_results == [1, 2, 3]
     assert filtered_filenames == ['a', 'b', 'c']
 
+    filtered_results, _ = filter_by_threshold(results, values, threshold)
+    assert filtered_results == [1, 2, 3]
+
 
 def test_avoid_empty_result():
     results = [1, 2, 3, 4]
@@ -38,9 +41,12 @@ def test_select_best_average():
         pd.DataFrame({'content': ['d', 'e', 'f'], 'retrieval_f1': [0.2, 0.3, 0.4], 'retrieval_recall': [0.2, 0.3, 0.4]}),
         pd.DataFrame({'content': ['g', 'h', 'i'], 'retrieval_f1': [0.3, 0.4, 0.5], 'retrieval_recall': [0.3, 0.4, 0.5]}),
     ]
-    sample_filenames = ['a', 'b', 'c']
-    best_df, best_filename = select_best_average(sample_dfs, ['retrieval_f1', 'retrieval_recall'], sample_filenames)
+    sample_metadatas = ['a', 'b', 'c']
+    best_df, best_filename = select_best_average(sample_dfs, ['retrieval_f1', 'retrieval_recall'], sample_metadatas)
     assert best_df['content'].tolist() == ['g', 'h', 'i']
     assert best_df['retrieval_f1'].tolist() == [0.3, 0.4, 0.5]
     assert best_df['retrieval_recall'].tolist() == [0.3, 0.4, 0.5]
     assert best_filename == 'c'
+
+    best_df, _ = select_best_average(sample_dfs, ['retrieval_f1', 'retrieval_recall'])
+    assert best_df['content'].tolist() == ['g', 'h', 'i']


### PR DESCRIPTION
close #46

- add metadatas at strategy.py `select_best_average` and `filter_by_threshold`. Now, that functions can retrieve filtered or selected metadata, which is corresponding with result inputs.
This feature is effective to preserve module's name and module's params when selecting best module & params with strategy.
- change all summary.csv to parquet files. csv file can't store dict params as dict type.
- add module_name, module_params at summary.parquet files. 
It was hard to classify underscore that divide param key and value, or underscore in param's key itself.
Now, we store dict itself to summary.parquet, so it will be no error or malfunctions.
- add 'is_best' column to node summary.parquet, so you can find best module name and module params easily with only look up node summary.parquet file.