### PR TITLE
Add deploy module and Runner for running optimal pipeline directly from trial folder or yaml file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ pipeline_dict = extract_pipeline(trial_path='your/path/to/trial_folder', output_
 ```
 
 Then, you can use your RAG pipeline from extracted pipeline yaml file.
-Plus, you can easily share your RAG pipeline to others just by sharing pipeline yaml file.
+Plus, you can share your RAG pipeline to others just by sharing pipeline yaml file.
+You must run this at project folder.
+It will automatically find ingested corpus for retrieval and fetching data for RAG system.
 ```python
 from autorag.deploy import Runner
 
@@ -75,10 +77,18 @@ runner = Runner.from_yaml('your/path/to/pipeline.yaml')
 runner.run('your question')
 ```
 
+Or run from a trial folder that you want to run.
+```python
+from autorag.deploy import Runner
+
+runner = Runner.from_trial_folder('your/path/to/trial_folder')
+runner.run('your question')
+```
+
 Or, you can run this pipeline with command line interface. 
 You can input any parameters that your pipeline needs.
 ```bash
-autorag run --pipeline your/path/to/pipeline.yaml --query "your question"
+autorag run --yaml your/path/to/pipeline.yaml --query "your question"
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,11 @@ You can use a found optimal RAG pipeline right away.
 It needs just a few lines of code, and you are ready to use!
 
 First, you need to build pipeline yaml file from your evaluated trial folder.
-```python
-from autorag.deploy import extract_pipeline
 
-pipeline_dict = extract_pipeline(trial_path='your/path/to/trial_folder', output_path='your/path/to/pipeline.yaml')
+```python
+from autorag.deploy import extract_best_config
+
+pipeline_dict = extract_best_config(trial_path='your/path/to/trial_folder', output_path='your/path/to/pipeline.yaml')
 ```
 
 Then, you can use your RAG pipeline from extracted pipeline yaml file.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,33 @@ or you can use command line interface
 autorag evaluate --config your/path/to/default_config.yaml --qa_data_path your/path/to/qa.parquet --corpus_data_path your/path/to/corpus.parquet
 ```
 
+### Use a found optimal RAG pipeline
+You can use a found optimal RAG pipeline right away.
+It needs just a few lines of code, and you are ready to use!
+
+First, you need to build pipeline yaml file from your evaluated trial folder.
+```python
+from autorag.deploy import extract_pipeline
+
+pipeline_dict = extract_pipeline(trial_path='your/path/to/trial_folder', output_path='your/path/to/pipeline.yaml')
+```
+
+Then, you can use your RAG pipeline from extracted pipeline yaml file.
+Plus, you can easily share your RAG pipeline to others just by sharing pipeline yaml file.
+```python
+from autorag.deploy import Runner
+
+runner = Runner.from_yaml('your/path/to/pipeline.yaml')
+runner.run('your question')
+```
+
+Or, you can run this pipeline with command line interface. 
+You can input any parameters that your pipeline needs.
+```bash
+autorag run --pipeline your/path/to/pipeline.yaml --query "your question"
+```
+
+
 ### Evaluate your custom RAG pipeline
 
 ```python

--- a/autorag/deploy.py
+++ b/autorag/deploy.py
@@ -3,6 +3,9 @@ import os
 from typing import Optional, Dict
 
 import pandas as pd
+import yaml
+
+from autorag.utils.util import load_summary_file
 
 logger = logging.getLogger("AutoRAG")
 
@@ -53,16 +56,9 @@ def extract_pipeline(trial_path: str, output_path: Optional[str] = None) -> Dict
     summary_path = os.path.join(trial_path, 'summary.parquet')
     if not os.path.exists(summary_path):
         raise ValueError(f"summary.parquet does not exist in {trial_path}.")
-    trial_summary_df = pd.read_parquet(summary_path)
-
-    # config_path = os.path.join(trial_path, 'config.yaml')
-    # if not os.path.exists(config_path):
-    #     raise ValueError(f"config.yaml does not exist in {trial_path}.")
-    # try:
-    #     with open(config_path, 'r') as f:
-    #         config = yaml.safe_load(f)
-    # except yaml.YAMLError as exc:
-    #     logger.error(exc)
-    #     raise ValueError(f"config.yaml is invalid yaml file. {exc}")
-    #
-    # node_lines = config['node_lines']
+    trial_summary_df = load_summary_file(summary_path, dict_columns=['best_module_params'])
+    yaml_dict = summary_df_to_yaml(trial_summary_df)
+    if output_path is not None:
+        with open(output_path, 'w') as f:
+            yaml.dump(yaml_dict, f)
+    return yaml_dict

--- a/autorag/deploy.py
+++ b/autorag/deploy.py
@@ -1,10 +1,12 @@
 import logging
 import os
+import uuid
 from typing import Optional, Dict
 
 import pandas as pd
 import yaml
 
+from autorag.schema.module import SUPPORT_MODULES
 from autorag.utils.util import load_summary_file
 
 logger = logging.getLogger("AutoRAG")
@@ -62,3 +64,71 @@ def extract_pipeline(trial_path: str, output_path: Optional[str] = None) -> Dict
         with open(output_path, 'w') as f:
             yaml.dump(yaml_dict, f)
     return yaml_dict
+
+
+class Runner:
+    def __init__(self, config: Dict):
+        self.config = config
+        self.project_dir = os.getcwd()
+
+    @classmethod
+    def from_yaml(cls, yaml_path: str):
+        """
+        Load Runner from yaml file.
+        Must be extracted yaml file from evaluated trial using extract_pipeline method.
+
+        :param yaml_path: The path of the yaml file.
+        :return: Initialized Runner.
+        """
+        with open(yaml_path, 'r') as f:
+            try:
+                config = yaml.safe_load(f)
+            except yaml.YAMLError as exc:
+                logger.error(exc)
+                raise exc
+        return cls(config)
+
+    @classmethod
+    def from_trial_folder(cls, trial_path: str):
+        """
+        Load Runner from evaluated trial folder.
+        Must already be evaluated using Evaluator class.
+
+        :param trial_path: The path of the trial folder.
+        :return: Initialized Runner.
+        """
+        config = extract_pipeline(trial_path)
+        return cls(config)
+
+    def run(self, query: str, result_column: str = "answer"):
+        """
+        Run the pipeline with query.
+        The loaded pipeline must start with a single query,
+        so the first module of the pipeline must be `query_expansion` or `retrieval` module.
+
+        :param query: The query of the user.
+        :param result_column: The result column name for the answer.
+            Default is `answer`, which is the output of the `generation` and `answer_filter` module.
+        :return: The result of the pipeline.
+        """
+        node_lines = self.config['node_lines']
+        previous_result = pd.DataFrame({
+            'qid': str(uuid.uuid4()),
+            'query': [query],
+            'retrieval_gt': [[]],
+            'generation_gt': [''],
+        })  # pseudo qa data for execution
+        for node_line in node_lines:
+            for node in node_line['nodes']:
+                if len(node['modules']) != 1:
+                    raise ValueError("The number of modules in a node must be 1 for using runner."
+                                     "Please use extract_pipeline method for extracting yaml file from evaluated trial.")
+                module = node['modules'][0]
+                module_type = module.pop('module_type')
+                module_params = module
+                previous_result = SUPPORT_MODULES[module_type](
+                    project_dir=self.project_dir,
+                    previous_result=previous_result,
+                    **module_params
+                )
+        return previous_result[result_column].tolist()[0]

--- a/autorag/deploy.py
+++ b/autorag/deploy.py
@@ -43,7 +43,7 @@ def summary_df_to_yaml(summary_df: pd.DataFrame) -> Dict:
     return {'node_lines': node_lines}
 
 
-def extract_pipeline(trial_path: str, output_path: Optional[str] = None) -> Dict:
+def extract_best_config(trial_path: str, output_path: Optional[str] = None) -> Dict:
     """
     Extract the optimal pipeline from evaluated trial.
 
@@ -75,7 +75,7 @@ class Runner:
     def from_yaml(cls, yaml_path: str):
         """
         Load Runner from yaml file.
-        Must be extracted yaml file from evaluated trial using extract_pipeline method.
+        Must be extracted yaml file from evaluated trial using extract_best_config method.
 
         :param yaml_path: The path of the yaml file.
         :return: Initialized Runner.
@@ -97,7 +97,7 @@ class Runner:
         :param trial_path: The path of the trial folder.
         :return: Initialized Runner.
         """
-        config = extract_pipeline(trial_path)
+        config = extract_best_config(trial_path)
         return cls(config)
 
     def run(self, query: str, result_column: str = "answer"):
@@ -122,7 +122,7 @@ class Runner:
             for node in node_line['nodes']:
                 if len(node['modules']) != 1:
                     raise ValueError("The number of modules in a node must be 1 for using runner."
-                                     "Please use extract_pipeline method for extracting yaml file from evaluated trial.")
+                                     "Please use extract_best_config method for extracting yaml file from evaluated trial.")
                 module = node['modules'][0]
                 module_type = module.pop('module_type')
                 module_params = module

--- a/autorag/deploy.py
+++ b/autorag/deploy.py
@@ -1,0 +1,68 @@
+import logging
+import os
+from typing import Optional, Dict
+
+import pandas as pd
+
+logger = logging.getLogger("AutoRAG")
+
+
+def summary_df_to_yaml(summary_df: pd.DataFrame) -> Dict:
+    """
+    Convert trial summary dataframe to config yaml file.
+
+    :param summary_df:
+    :return: Dictionary of config yaml file.
+        You can save this dictionary to yaml file.
+    """
+    # summary_df columns : 'node_line_name', 'node_type', 'best_module_filename',
+    #                      'best_module_name', 'best_module_params', 'best_execution_time'
+    grouped = summary_df.groupby('node_line_name')
+
+    node_lines = [
+        {
+            'node_line_name': node_line_name,
+            'nodes': [
+                {
+                    'node_type': row['node_type'],
+                    'modules': [{
+                        'module_type': row['best_module_name'],
+                        **row['best_module_params']
+                    }]
+                }
+                for _, row in node_line.iterrows()
+            ]
+        }
+        for node_line_name, node_line in grouped
+    ]
+    return {'node_lines': node_lines}
+
+
+def extract_pipeline(trial_path: str, output_path: Optional[str] = None) -> Dict:
+    """
+    Extract the optimal pipeline from evaluated trial.
+
+    :param trial_path: The path to the trial directory that you want to extract the pipeline from.
+        Must already be evaluated.
+    :param output_path: Output path that pipeline yaml file will be saved.
+        Must be .yaml or .yml file.
+        If None, it does not save yaml file and just return dict values.
+        Default is None.
+    :return: The dictionary of the extracted pipeline.
+    """
+    summary_path = os.path.join(trial_path, 'summary.parquet')
+    if not os.path.exists(summary_path):
+        raise ValueError(f"summary.parquet does not exist in {trial_path}.")
+    trial_summary_df = pd.read_parquet(summary_path)
+
+    # config_path = os.path.join(trial_path, 'config.yaml')
+    # if not os.path.exists(config_path):
+    #     raise ValueError(f"config.yaml does not exist in {trial_path}.")
+    # try:
+    #     with open(config_path, 'r') as f:
+    #         config = yaml.safe_load(f)
+    # except yaml.YAMLError as exc:
+    #     logger.error(exc)
+    #     raise ValueError(f"config.yaml is invalid yaml file. {exc}")
+    #
+    # node_lines = config['node_lines']

--- a/autorag/evaluator.py
+++ b/autorag/evaluator.py
@@ -50,6 +50,8 @@ class Evaluator:
         trial_name = self.__get_new_trial_name()
         self.__make_trial_dir(trial_name)
 
+        # copy yaml file to trial directory
+        shutil.copy(yaml_path, os.path.join(self.project_dir, trial_name, 'config.yaml'))
         node_lines = self._load_node_lines(yaml_path)
         self.__embed(node_lines)
 

--- a/autorag/utils/util.py
+++ b/autorag/utils/util.py
@@ -79,6 +79,8 @@ def load_summary_file(summary_path: str,
         raise ValueError(f"summary.parquet does not exist in {summary_path}.")
     summary_df = pd.read_parquet(summary_path)
     if dict_columns is None:
+        logger.warning("dict_columns is None."
+                       "If your input summary_df has dictionary type columns, you must fill dict_columns.")
         return summary_df
 
     def delete_none_at_dict(elem):

--- a/autorag/utils/util.py
+++ b/autorag/utils/util.py
@@ -1,11 +1,12 @@
 import functools
 import os
-from typing import List, Callable, Dict
+from typing import List, Callable, Dict, Optional
 
 import pandas as pd
 import swifter
 
 import logging
+
 logger = logging.getLogger("AutoRAG")
 
 
@@ -61,3 +62,27 @@ def find_best_result_path(node_dir: str) -> str:
     :return: The filepath of the best result.
     """
     return list(filter(lambda x: x.endswith(".parquet") and x.startswith("best_"), os.listdir(node_dir)))[0]
+
+
+def load_summary_file(summary_path: str,
+                      dict_columns: Optional[List[str]] = None) -> pd.DataFrame:
+    """
+    Load summary file from summary_path.
+
+    :param summary_path: The path of the summary file.
+    :param dict_columns: The columns that are dictionary type.
+        You must fill this parameter if you want to load summary file properly.l
+        Default is None.
+    :return: The summary dataframe.
+    """
+    if not os.path.exists(summary_path):
+        raise ValueError(f"summary.parquet does not exist in {summary_path}.")
+    summary_df = pd.read_parquet(summary_path)
+    if dict_columns is None:
+        return summary_df
+
+    def delete_none_at_dict(elem):
+        return dict(filter(lambda item: item[1] is not None, elem.items()))
+
+    summary_df[dict_columns] = summary_df[dict_columns].applymap(delete_none_at_dict)
+    return summary_df

--- a/tests/autorag/test_deploy.py
+++ b/tests/autorag/test_deploy.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import shutil
 import tempfile
 
 import pandas as pd
@@ -7,10 +8,29 @@ import pytest
 import yaml
 
 from autorag.deploy import summary_df_to_yaml, extract_pipeline, Runner
-from test_evaluator import evaluator
+from autorag.evaluator import Evaluator
 
 root_dir = pathlib.PurePath(os.path.dirname(os.path.realpath(__file__))).parent
 resource_dir = os.path.join(root_dir, 'resources')
+
+
+@pytest.fixture
+def evaluator():
+    evaluator = Evaluator(os.path.join(resource_dir, 'qa_data_sample.parquet'),
+                          os.path.join(resource_dir, 'corpus_data_sample.parquet'))
+    yield evaluator
+    paths_to_remove = ['0', 'data', 'resources', 'trial.json']
+
+    for path in paths_to_remove:
+        full_path = os.path.join(os.getcwd(), path)
+        try:
+            if os.path.isdir(full_path):
+                shutil.rmtree(full_path)
+            else:
+                os.remove(full_path)
+        except FileNotFoundError:
+            pass
+
 
 summary_df = pd.DataFrame({
     'node_line_name': ['node_line_1', 'node_line_1', 'node_line_2'],

--- a/tests/autorag/test_deploy.py
+++ b/tests/autorag/test_deploy.py
@@ -1,0 +1,58 @@
+import pandas as pd
+
+from autorag.deploy import summary_df_to_yaml
+
+
+def test_summary_df_to_yaml():
+    summary_df = pd.DataFrame({
+        'node_line_name': ['node_line_1', 'node_line_1', 'node_line_2'],
+        'node_type': ['retrieval', 'rerank', 'generation'],
+        'best_module_filename': ['bm25=>top_k_50.parquet', 'upr=>model_llama-2-havertz_chelsea.parquet',
+                                 'gpt-4=>top_p_0.9.parquet'],
+        'best_module_name': ['bm25', 'upr', 'gpt-4'],
+        'best_module_params': [{'top_k': 50}, {'model': 'llama-2', 'havertz': 'chelsea'}, {'top_p': 0.9}],
+        'best_execution_time': [1.0, 0.5, 2.0]
+    })
+    yaml_dict = summary_df_to_yaml(summary_df)
+    assert yaml_dict == {
+        'node_lines': [
+            {
+                'node_line_name': 'node_line_1',
+                'nodes': [
+                    {
+                        'node_type': 'retrieval',
+                        'modules': [
+                            {
+                                'module_type': 'bm25',
+                                'top_k': 50
+                            }
+                        ]
+                    },
+                    {
+                        'node_type': 'rerank',
+                        'modules': [
+                            {
+                                'module_type': 'upr',
+                                'model': 'llama-2',
+                                'havertz': 'chelsea'
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                'node_line_name': 'node_line_2',
+                'nodes': [
+                    {
+                        'node_type': 'generation',
+                        'modules': [
+                            {
+                                'module_type': 'gpt-4',
+                                'top_p': 0.9
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }

--- a/tests/autorag/test_deploy.py
+++ b/tests/autorag/test_deploy.py
@@ -1,58 +1,89 @@
-import pandas as pd
+import os
+import pathlib
+import tempfile
 
-from autorag.deploy import summary_df_to_yaml
+import pandas as pd
+import pytest
+import yaml
+
+from autorag.deploy import summary_df_to_yaml, extract_pipeline
+
+root_dir = pathlib.PurePath(os.path.dirname(os.path.realpath(__file__))).parent
+resource_dir = os.path.join(root_dir, 'resources')
+
+summary_df = pd.DataFrame({
+    'node_line_name': ['node_line_1', 'node_line_1', 'node_line_2'],
+    'node_type': ['retrieval', 'rerank', 'generation'],
+    'best_module_filename': ['bm25=>top_k_50.parquet', 'upr=>model_llama-2-havertz_chelsea.parquet',
+                             'gpt-4=>top_p_0.9.parquet'],
+    'best_module_name': ['bm25', 'upr', 'gpt-4'],
+    'best_module_params': [{'top_k': 50}, {'model': 'llama-2', 'havertz': 'chelsea'}, {'top_p': 0.9}],
+    'best_execution_time': [1.0, 0.5, 2.0]
+})
+solution_dict = {
+    'node_lines': [
+        {
+            'node_line_name': 'node_line_1',
+            'nodes': [
+                {
+                    'node_type': 'retrieval',
+                    'modules': [
+                        {
+                            'module_type': 'bm25',
+                            'top_k': 50
+                        }
+                    ]
+                },
+                {
+                    'node_type': 'rerank',
+                    'modules': [
+                        {
+                            'module_type': 'upr',
+                            'model': 'llama-2',
+                            'havertz': 'chelsea'
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            'node_line_name': 'node_line_2',
+            'nodes': [
+                {
+                    'node_type': 'generation',
+                    'modules': [
+                        {
+                            'module_type': 'gpt-4',
+                            'top_p': 0.9
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}
+
+
+@pytest.fixture
+def pseudo_trial_path():
+    with tempfile.TemporaryDirectory() as project_dir:
+        trial_path = os.path.join(project_dir, '0')
+        os.makedirs(trial_path)
+        summary_df.to_parquet(os.path.join(trial_path, 'summary.parquet'), index=False)
+        yield trial_path
 
 
 def test_summary_df_to_yaml():
-    summary_df = pd.DataFrame({
-        'node_line_name': ['node_line_1', 'node_line_1', 'node_line_2'],
-        'node_type': ['retrieval', 'rerank', 'generation'],
-        'best_module_filename': ['bm25=>top_k_50.parquet', 'upr=>model_llama-2-havertz_chelsea.parquet',
-                                 'gpt-4=>top_p_0.9.parquet'],
-        'best_module_name': ['bm25', 'upr', 'gpt-4'],
-        'best_module_params': [{'top_k': 50}, {'model': 'llama-2', 'havertz': 'chelsea'}, {'top_p': 0.9}],
-        'best_execution_time': [1.0, 0.5, 2.0]
-    })
     yaml_dict = summary_df_to_yaml(summary_df)
-    assert yaml_dict == {
-        'node_lines': [
-            {
-                'node_line_name': 'node_line_1',
-                'nodes': [
-                    {
-                        'node_type': 'retrieval',
-                        'modules': [
-                            {
-                                'module_type': 'bm25',
-                                'top_k': 50
-                            }
-                        ]
-                    },
-                    {
-                        'node_type': 'rerank',
-                        'modules': [
-                            {
-                                'module_type': 'upr',
-                                'model': 'llama-2',
-                                'havertz': 'chelsea'
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                'node_line_name': 'node_line_2',
-                'nodes': [
-                    {
-                        'node_type': 'generation',
-                        'modules': [
-                            {
-                                'module_type': 'gpt-4',
-                                'top_p': 0.9
-                            }
-                        ]
-                    }
-                ]
-            }
-        ]
-    }
+    assert yaml_dict == solution_dict
+
+
+def test_extract_pipeline(pseudo_trial_path):
+    yaml_dict = extract_pipeline(pseudo_trial_path)
+    assert yaml_dict == solution_dict
+    with tempfile.NamedTemporaryFile(suffix='yaml', mode='w+t') as yaml_path:
+        yaml_dict = extract_pipeline(pseudo_trial_path, yaml_path.name)
+        assert yaml_dict == solution_dict
+        assert os.path.exists(yaml_path.name)
+        yaml_dict = yaml.safe_load(yaml_path)
+        assert yaml_dict == solution_dict

--- a/tests/autorag/test_deploy.py
+++ b/tests/autorag/test_deploy.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 import yaml
 
-from autorag.deploy import summary_df_to_yaml, extract_pipeline, Runner
+from autorag.deploy import summary_df_to_yaml, extract_best_config, Runner
 from autorag.evaluator import Evaluator
 
 root_dir = pathlib.PurePath(os.path.dirname(os.path.realpath(__file__))).parent
@@ -99,11 +99,11 @@ def test_summary_df_to_yaml():
     assert yaml_dict == solution_dict
 
 
-def test_extract_pipeline(pseudo_trial_path):
-    yaml_dict = extract_pipeline(pseudo_trial_path)
+def test_extract_best_config(pseudo_trial_path):
+    yaml_dict = extract_best_config(pseudo_trial_path)
     assert yaml_dict == solution_dict
     with tempfile.NamedTemporaryFile(suffix='yaml', mode='w+t') as yaml_path:
-        yaml_dict = extract_pipeline(pseudo_trial_path, yaml_path.name)
+        yaml_dict = extract_best_config(pseudo_trial_path, yaml_path.name)
         assert yaml_dict == solution_dict
         assert os.path.exists(yaml_path.name)
         yaml_dict = yaml.safe_load(yaml_path)
@@ -124,6 +124,6 @@ def test_runner(evaluator):
     runner_test(runner)
 
     with tempfile.NamedTemporaryFile(suffix='yaml', mode='w+t') as yaml_path:
-        extract_pipeline(os.path.join(os.getcwd(), '0'), yaml_path.name)
+        extract_best_config(os.path.join(os.getcwd(), '0'), yaml_path.name)
         runner = Runner.from_yaml(yaml_path.name)
         runner_test(runner)

--- a/tests/autorag/test_evaluator.py
+++ b/tests/autorag/test_evaluator.py
@@ -66,6 +66,7 @@ def test_start_trial(evaluator):
     assert os.path.exists(os.path.join(os.getcwd(), 'data'))
     assert os.path.exists(os.path.join(os.getcwd(), 'resources'))
     assert os.path.exists(os.path.join(os.getcwd(), 'trial.json'))
+    assert os.path.exists(os.path.join(os.getcwd(), '0', 'config.yaml'))
     assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line'))
     assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval'))
     assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval', 'bm25=>top_k_50.parquet'))

--- a/tests/autorag/test_evaluator.py
+++ b/tests/autorag/test_evaluator.py
@@ -69,17 +69,17 @@ def test_start_trial(evaluator):
     assert os.path.exists(os.path.join(os.getcwd(), '0', 'config.yaml'))
     assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line'))
     assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval', 'bm25=>top_k_50.parquet'))
+    assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval', 'bm25=>top_k_10.parquet'))
     expect_each_result_columns = ['retrieved_contents', 'retrieved_ids', 'retrieve_scores', 'retrieval_f1',
                                   'retrieval_recall']
     each_result = pd.read_parquet(
-        os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval', 'bm25=>top_k_50.parquet'))
+        os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval', 'bm25=>top_k_10.parquet'))
     assert all([expect_column in each_result.columns for expect_column in expect_each_result_columns])
     expect_best_result_columns = ['qid', 'query', 'retrieval_gt', 'generation_gt',
                                   'retrieved_contents', 'retrieved_ids', 'retrieve_scores', 'retrieval_f1',
                                   'retrieval_recall']
     best_result = pd.read_parquet(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval',
-                                               'best_bm25=>top_k_50.parquet'))
+                                               'best_bm25=>top_k_10.parquet'))
     assert all([expect_column in best_result.columns for expect_column in expect_best_result_columns])
 
     # test node line summary
@@ -90,9 +90,9 @@ def test_start_trial(evaluator):
     assert set(node_line_summary_df.columns) == {'node_type', 'best_module_filename',
                                                  'best_module_name', 'best_module_params', 'best_execution_time'}
     assert node_line_summary_df['node_type'][0] == 'retrieval'
-    assert node_line_summary_df['best_module_filename'][0] == 'bm25=>top_k_50.parquet'
+    assert node_line_summary_df['best_module_filename'][0] == 'bm25=>top_k_10.parquet'
     assert node_line_summary_df['best_module_name'][0] == 'bm25'
-    assert node_line_summary_df['best_module_params'][0] == {'top_k': 50}
+    assert node_line_summary_df['best_module_params'][0] == {'top_k': 10}
     assert node_line_summary_df['best_execution_time'][0] > 0
 
     # test trial summary
@@ -104,9 +104,9 @@ def test_start_trial(evaluator):
                                              'best_module_name', 'best_module_params', 'best_execution_time'}
     assert trial_summary_df['node_line_name'][0] == 'retrieve_node_line'
     assert trial_summary_df['node_type'][0] == 'retrieval'
-    assert trial_summary_df['best_module_filename'][0] == 'bm25=>top_k_50.parquet'
+    assert trial_summary_df['best_module_filename'][0] == 'bm25=>top_k_10.parquet'
     assert trial_summary_df['best_module_name'][0] == 'bm25'
-    assert trial_summary_df['best_module_params'][0] == {'top_k': 50}
+    assert trial_summary_df['best_module_params'][0] == {'top_k': 10}
     assert trial_summary_df['best_execution_time'][0] > 0
 
 
@@ -122,4 +122,4 @@ def test_evaluator_cli(evaluator):
     assert os.path.exists(os.path.join(os.getcwd(), 'trial.json'))
     assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line'))
     assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval', 'bm25=>top_k_50.parquet'))
+    assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval', 'bm25=>top_k_10.parquet'))

--- a/tests/resources/config.yaml
+++ b/tests/resources/config.yaml
@@ -1,5 +1,3 @@
-qa_data_path: ./qa_data_sample.parquet
-corpus_data_path: ./corpus_data_sample.parquet
 node_lines:
 - node_line_name: retrieve_node_line
   nodes:

--- a/tests/resources/simple.yaml
+++ b/tests/resources/simple.yaml
@@ -5,6 +5,6 @@ node_lines:
     - node_type: retrieval  # represents run_node function
       strategy:  # essential for every node
         metrics: [retrieval_f1, retrieval_recall]
-      top_k: 50 # node param, which adapt to every module in this node.
+      top_k: 10 # node param, which adapt to every module in this node.
       modules:
         - module_type: bm25


### PR DESCRIPTION
close #51

- add `extract_pipeline` for extracting best pipeline from evaluated trial folder. Must execute on the evaluated trial folder. 
- fix some typo and errors at config.yaml
- Change simple.yaml top_k to 10, because sample corpus data have less than 50 rows.
- Add `Runner` class for running evaluated (found) pipeline. You can initialize with extracted yaml file, or directly from trial folder.
- All test file included.
- `Runner` concept README.md explanation. 
- copy config.yaml file to trial_folder, as mentioned in eastsidegunn structure.
- add util function `load_summary_file` for loading summary.parquet files. 