### PR TITLE
Add fstring module and make `make_combinations` and `explode` util functions.

### DIFF
--- a/autorag/nodes/promptmaker/__init__.py
+++ b/autorag/nodes/promptmaker/__init__.py
@@ -1,0 +1,1 @@
+from .fstring import fstring

--- a/autorag/nodes/promptmaker/base.py
+++ b/autorag/nodes/promptmaker/base.py
@@ -1,0 +1,29 @@
+import functools
+from pathlib import Path
+from typing import List, Union
+
+import pandas as pd
+
+from autorag.utils import result_to_dataframe
+
+
+def prompt_maker_node(func):
+    @functools.wraps(func)
+    @result_to_dataframe(["prompts"])
+    def wrapper(
+            project_dir: Union[str, Path],
+            previous_result: pd.DataFrame,
+            *args, **kwargs) -> List[str]:
+        # get query and retrieved contents from previous_result
+        assert "query" in previous_result.columns, "previous_result must have query column."
+        assert "retrieved_contents" in previous_result.columns, "previous_result must have retrieved_contents column."
+        query = previous_result["query"].tolist()
+        retrieved_contents = previous_result["retrieved_contents"].tolist()
+        prompt = kwargs.pop("prompt")
+
+        if func.__name__ == 'fstring':
+            return func(prompt, query, retrieved_contents)
+        else:
+            raise NotImplementedError(f"Module {func.__name__} is not implemented or not supported.")
+
+    return wrapper

--- a/autorag/nodes/promptmaker/fstring.py
+++ b/autorag/nodes/promptmaker/fstring.py
@@ -1,0 +1,27 @@
+from typing import List
+
+
+def fstring(prompt: str,
+            queries: List[str], retrieved_contents: List[List[str]]) -> List[str]:
+    """
+    Make a prompt using f-string from a query and retrieved_contents.
+    You must type a prompt or prompt list at config yaml file like this:
+
+    .. Code:: yaml
+    nodes:
+    - node_type: prompt_maker
+      modules:
+      - module_type: fstring
+        prompt: [Answer this question: {query} \n\n {retrieved_contents},
+        Read the passages carefully and answer this question: {query} \n\n Passages: {retrieved_contents}]
+
+    :param prompt: A prompt string.
+    :param queries: List of query strings.
+    :param retrieved_contents: List of retrieved contents.
+    :return: Prompts that made by f-string.
+    """
+    def fstring_row(_prompt: str, _query: str, _retrieved_contents: List[str]) -> str:
+        contents_str = "\n\n".join(_retrieved_contents)
+        return _prompt.format(query=_query, retrieved_contents=contents_str)
+
+    return list(map(lambda x: fstring_row(prompt, x[0], x[1]), zip(queries, retrieved_contents)))

--- a/autorag/nodes/promptmaker/fstring.py
+++ b/autorag/nodes/promptmaker/fstring.py
@@ -1,6 +1,9 @@
 from typing import List
 
+from autorag.nodes.promptmaker.base import prompt_maker_node
 
+
+@prompt_maker_node
 def fstring(prompt: str,
             queries: List[str], retrieved_contents: List[List[str]]) -> List[str]:
     """

--- a/autorag/schema/module.py
+++ b/autorag/schema/module.py
@@ -2,11 +2,13 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Callable, Dict
 
+from autorag.nodes.promptmaker import fstring
 from autorag.nodes.retrieval import bm25, vectordb
 
 SUPPORT_MODULES = {
     'bm25': bm25,
     'vectordb': vectordb,
+    'fstring': fstring,
 }
 
 

--- a/autorag/schema/node.py
+++ b/autorag/schema/node.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from autorag.nodes.retrieval.run import run_retrieval_node
 from autorag.schema.module import Module
+from autorag.utils.util import make_combinations, explode
 
 SUPPORT_NODES = {
     'retrieval': run_retrieval_node,
@@ -38,20 +39,11 @@ class Node:
 
         def make_single_combination(module: Module) -> List[Dict]:
             input_dict = {**self.node_params, **module.module_param}
-            dict_with_lists = dict(map(lambda x: (x[0], x[1] if isinstance(x[1], list) else [x[1]]),
-                                       input_dict.items()))
-            dict_with_lists = dict(map(lambda x: (x[0], list(set(x[1]))), dict_with_lists.items()))
-            combination = list(itertools.product(*dict_with_lists.values()))
-            combination_dicts = [dict(zip(dict_with_lists.keys(), combo)) for combo in combination]
-            return combination_dicts
+            return make_combinations(input_dict)
 
         combinations = list(map(make_single_combination, self.modules))
-        df = pd.DataFrame({
-            'module': self.modules,
-            'combinations': combinations
-        })
-        df = df.explode('combinations')
-        return list(map(lambda x: x.module, df['module'].tolist())), df['combinations'].tolist()
+        module_list, combination_list = explode(self.modules, combinations)
+        return list(map(lambda x: x.module, module_list)), combination_list
 
     @classmethod
     def from_dict(cls, node_dict: Dict) -> 'Node':

--- a/autorag/utils/util.py
+++ b/autorag/utils/util.py
@@ -31,7 +31,10 @@ def result_to_dataframe(column_names: List[str]):
         @functools.wraps(func)
         def wrapper(*args, **kwargs) -> pd.DataFrame:
             results = func(*args, **kwargs)
-            df_input = {column_name: result for result, column_name in zip(results, column_names)}
+            if len(column_names) == 1:
+                df_input = {column_names[0]: results}
+            else:
+                df_input = {column_name: result for result, column_name in zip(results, column_names)}
             result_df = pd.DataFrame(df_input)
             return result_df
 

--- a/autorag/utils/util.py
+++ b/autorag/utils/util.py
@@ -1,6 +1,7 @@
 import functools
+import itertools
 import os
-from typing import List, Callable, Dict, Optional
+from typing import List, Callable, Dict, Optional, Iterable, Union, Any
 
 import pandas as pd
 import swifter
@@ -91,3 +92,23 @@ def load_summary_file(summary_path: str,
 
     summary_df[dict_columns] = summary_df[dict_columns].applymap(delete_none_at_dict)
     return summary_df
+
+
+def make_combinations(target_dict: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """
+    Make combinations from target_dict.
+    The target_dict key value must be a string,
+    and the value can be list of values or single value.
+    If generates all combinations of values from target_dict,
+    which means generated dictionaries that contain only one value for each key,
+    and all dictionaries will be different from each other.
+
+    :param target_dict: The target dictionary.
+    :return: The list of generated dictionaries.
+    """
+    dict_with_lists = dict(map(lambda x: (x[0], x[1] if isinstance(x[1], list) else [x[1]]),
+                               target_dict.items()))
+    dict_with_lists = dict(map(lambda x: (x[0], list(set(x[1]))), dict_with_lists.items()))
+    combination = list(itertools.product(*dict_with_lists.values()))
+    combination_dicts = [dict(zip(dict_with_lists.keys(), combo)) for combo in combination]
+    return combination_dicts

--- a/autorag/utils/util.py
+++ b/autorag/utils/util.py
@@ -1,7 +1,7 @@
 import functools
 import itertools
 import os
-from typing import List, Callable, Dict, Optional, Iterable, Union, Any
+from typing import List, Callable, Dict, Optional, Any, Collection
 
 import pandas as pd
 import swifter
@@ -112,3 +112,22 @@ def make_combinations(target_dict: Dict[str, Any]) -> List[Dict[str, Any]]:
     combination = list(itertools.product(*dict_with_lists.values()))
     combination_dicts = [dict(zip(dict_with_lists.keys(), combo)) for combo in combination]
     return combination_dicts
+
+
+def explode(index_values: Collection[Any], explode_values: Collection[Collection[Any]]):
+    """
+    Explode index_values and explode_values.
+    The index_values and explode_values must have the same length.
+    It will flatten explode_values and keep index_values as a pair.
+
+    :param index_values: The index values.
+    :param explode_values: The exploded values.
+    :return: Tuple of exploded index_values and exploded explode_values.
+    """
+    assert len(index_values) == len(explode_values), "Index values and explode values must have same length"
+    df = pd.DataFrame({
+        'index_values': index_values,
+        'explode_values': explode_values
+    })
+    df = df.explode('explode_values')
+    return df['index_values'].tolist(), df['explode_values'].tolist()

--- a/tests/autorag/nodes/promptmaker/test_fstring.py
+++ b/tests/autorag/nodes/promptmaker/test_fstring.py
@@ -1,0 +1,14 @@
+from autorag.nodes.promptmaker import fstring
+
+prompt = "Answer this question: {query} \n\n {retrieved_contents}"
+queries = ["What is the capital of Japan?", "What is the capital of China?"]
+retrieved_contents = [
+    ["Tokyo is the capital of Japan.", "Tokyo, the capital of Japan, is a huge metropolitan city."],
+    ["Beijing is the capital of China.", "Beijing, the capital of China, is a huge metropolitan city."]]
+
+
+def test_fstring():
+    result_prompts = fstring(prompt, queries, retrieved_contents)
+    assert len(result_prompts) == 2
+    assert result_prompts[0] == "Answer this question: What is the capital of Japan? \n\n Tokyo is the capital of Japan.\n\nTokyo, the capital of Japan, is a huge metropolitan city."
+    assert result_prompts[1] == "Answer this question: What is the capital of China? \n\n Beijing is the capital of China.\n\nBeijing, the capital of China, is a huge metropolitan city."

--- a/tests/autorag/nodes/promptmaker/test_fstring.py
+++ b/tests/autorag/nodes/promptmaker/test_fstring.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 from autorag.nodes.promptmaker import fstring
 
 prompt = "Answer this question: {query} \n\n {retrieved_contents}"
@@ -8,7 +10,23 @@ retrieved_contents = [
 
 
 def test_fstring():
-    result_prompts = fstring(prompt, queries, retrieved_contents)
+    fstring_original = fstring.__wrapped__
+    result_prompts = fstring_original(prompt, queries, retrieved_contents)
     assert len(result_prompts) == 2
+    assert isinstance(result_prompts, list)
     assert result_prompts[0] == "Answer this question: What is the capital of Japan? \n\n Tokyo is the capital of Japan.\n\nTokyo, the capital of Japan, is a huge metropolitan city."
     assert result_prompts[1] == "Answer this question: What is the capital of China? \n\n Beijing is the capital of China.\n\nBeijing, the capital of China, is a huge metropolitan city."
+
+
+def test_fstring_node():
+    previous_result = pd.DataFrame({
+        "query": queries,
+        "retrieved_contents": retrieved_contents
+    })
+    result = fstring(project_dir="pseudo_project_dir",
+                     previous_result=previous_result,
+                     prompt=prompt)
+    assert len(result) == 2
+    assert result.columns == ["prompts"]
+    assert result['prompts'][0] == "Answer this question: What is the capital of Japan? \n\n Tokyo is the capital of Japan.\n\nTokyo, the capital of Japan, is a huge metropolitan city."
+    assert result['prompts'][1] == "Answer this question: What is the capital of China? \n\n Beijing is the capital of China.\n\nBeijing, the capital of China, is a huge metropolitan city."

--- a/tests/autorag/utils/test_util.py
+++ b/tests/autorag/utils/test_util.py
@@ -8,7 +8,7 @@ import pytest
 
 from autorag.utils import fetch_contents
 from autorag.utils.util import find_best_result_path, make_module_file_name, load_summary_file, result_to_dataframe, \
-    make_combinations
+    make_combinations, explode
 
 root_dir = pathlib.PurePath(os.path.dirname(os.path.realpath(__file__))).parent.parent
 
@@ -120,3 +120,15 @@ def test_make_combinations():
     combinations = make_combinations(target_dict)
     assert len(combinations) == len(solution)
     assert all([combination in solution for combination in combinations])
+
+
+def test_explode():
+    index_values = ['a', 'b', 'c']
+    explode_values = [
+        ['apple', 'banana', 'cherry'],
+        ['april', 'may'],
+        ['alpha'],
+    ]
+    result_index, result_values = explode(index_values, explode_values)
+    assert result_index == ['a', 'a', 'a', 'b', 'b', 'c']
+    assert result_values == ['apple', 'banana', 'cherry', 'april', 'may', 'alpha']

--- a/tests/autorag/utils/test_util.py
+++ b/tests/autorag/utils/test_util.py
@@ -7,7 +7,8 @@ import pandas as pd
 import pytest
 
 from autorag.utils import fetch_contents
-from autorag.utils.util import find_best_result_path, make_module_file_name, load_summary_file, result_to_dataframe
+from autorag.utils.util import find_best_result_path, make_module_file_name, load_summary_file, result_to_dataframe, \
+    make_combinations
 
 root_dir = pathlib.PurePath(os.path.dirname(os.path.realpath(__file__))).parent.parent
 
@@ -106,3 +107,16 @@ def test_result_to_dataframe():
     assert isinstance(result2, pd.DataFrame)
     assert result2.columns.tolist() == ['col_1']
     assert result2['col_1'].tolist() == [1, 2, 3]
+
+
+def test_make_combinations():
+    target_dict = {'key1': 'value1', 'key2': ['value1', 'value2'], 'key3': 'value3', 'key4': ['value4', 'value5']}
+    solution = [
+        {'key1': 'value1', 'key2': 'value1', 'key3': 'value3', 'key4': 'value4'},
+        {'key1': 'value1', 'key2': 'value1', 'key3': 'value3', 'key4': 'value5'},
+        {'key1': 'value1', 'key2': 'value2', 'key3': 'value3', 'key4': 'value4'},
+        {'key1': 'value1', 'key2': 'value2', 'key3': 'value3', 'key4': 'value5'}
+    ]
+    combinations = make_combinations(target_dict)
+    assert len(combinations) == len(solution)
+    assert all([combination in solution for combination in combinations])

--- a/tests/autorag/utils/test_util.py
+++ b/tests/autorag/utils/test_util.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 
 from autorag.utils import fetch_contents
-from autorag.utils.util import find_best_result_path, make_module_file_name, load_summary_file
+from autorag.utils.util import find_best_result_path, make_module_file_name, load_summary_file, result_to_dataframe
 
 root_dir = pathlib.PurePath(os.path.dirname(os.path.realpath(__file__))).parent.parent
 
@@ -85,3 +85,24 @@ def test_load_summary_file(summary_path):
     assert not df.equals(summary_df)
     df = load_summary_file(summary_path, ['best_module_params'])
     assert df.equals(summary_df)
+
+
+def test_result_to_dataframe():
+    @result_to_dataframe(['col_1', 'col_2'])
+    def func1():
+        return [1, 2], [3, 4]
+
+    result1 = func1()
+    assert isinstance(result1, pd.DataFrame)
+    assert result1.columns.tolist() == ['col_1', 'col_2']
+    assert result1['col_1'].tolist() == [1, 2]
+    assert result1['col_2'].tolist() == [3, 4]
+
+    @result_to_dataframe(['col_1'])
+    def func2():
+        return [1, 2, 3]
+
+    result2 = func2()
+    assert isinstance(result2, pd.DataFrame)
+    assert result2.columns.tolist() == ['col_1']
+    assert result2['col_1'].tolist() == [1, 2, 3]

--- a/tests/resources/config.yaml
+++ b/tests/resources/config.yaml
@@ -22,13 +22,25 @@ node_lines:
 - node_line_name:
   nodes:
     - node_type: prompt_maker
-      skip_evaluation: True
+      strategy:
+        metrics: [bleu, rouge]
+        generator_modules:
+          - module_type: llama_index_llm
+            llm: [openai]
+            model_name: [gpt-3.5-turbo, gpt-4-1106-preview]
+            temperature: 0.8
       modules:
-        - module_type: default_prompt_maker
-          prompt: "This is a news dataset, crawled from finance news site. You need to make detailed question about finance news. Do not make questions that not relevant to economy or finance domain.\n{{context}}\n\nQ: {{question}}\nA:"
+        - module_type: fstring
+          prompt: "This is a news dataset, crawled from finance news site. You need to make detailed question about finance news. Do not make questions that not relevant to economy or finance domain.\n{{retrieved_contents}}\n\nQ: {{query}}\nA:"
     - node_type: generation
       strategy:
         metrics: [bleu, rouge, kf1]
       modules:
-        - module_type: basic_llm
-          llm: [gpt-3.5-turbo, mixtral, llama-2]
+        - module_type: llama_index_llm
+          llm: [openai]
+          model_name: [gpt-3.5-turbo, gpt-4-1106-preview]
+          temperature: [0.5, 1.0, 1.5]
+        - module_type: llama_index_llm
+          llm: [huggingface]
+          model_name: [mixtral, llama-2]
+          top_p: [0.5, 0.8, 0.9]


### PR DESCRIPTION
- add fstring module 
- add prompt maker node decorator 
- add `make_combinations` util function for generating various combinations from input_dict
- add `explode` util function for flattening target collection with index collection.
- Fix config.yaml for generator and prompt maker. 
- Fix `result_to_dataframe` error when use only one column name.

Plus, I will sphinx apidoc at the end of this issue. This issue will not be closed.