### PR TITLE
add `process_batch()` function and add it to all llm related 

### DIFF
--- a/autorag/nodes/generator/base.py
+++ b/autorag/nodes/generator/base.py
@@ -34,6 +34,7 @@ def generator_node(func):
             if llm not in generator_models:
                 raise ValueError(f"{llm} is not a valid llm name. Please check the llm name."
                                  "You can check valid llm names from autorag.generator_models.")
+            batch = kwargs.pop('batch', 16)
             llm_instance = generator_models[llm](**kwargs)
-            return func(prompts=prompts, llm=llm_instance)
+            return func(prompts=prompts, llm=llm_instance, batch=batch)
     return wrapper

--- a/autorag/nodes/generator/llama_index_llm.py
+++ b/autorag/nodes/generator/llama_index_llm.py
@@ -5,16 +5,21 @@ from llama_index.llms.base import BaseLLM
 from transformers import AutoTokenizer
 
 from autorag.nodes.generator.base import generator_node
+from autorag.utils.util import process_batch
 
 
 @generator_node
-def llama_index_llm(prompts: List[str], llm: BaseLLM) -> Tuple[List[str], List[List[int]], List[List[float]]]:
+def llama_index_llm(prompts: List[str], llm: BaseLLM, batch: int = 16) -> Tuple[List[str], List[List[int]], List[List[float]]]:
     """
     Llama Index LLM module.
     It gets the LLM instance from llama index, and returns generated text by the input prompt.
     It does not generate the right log probs, but it returns the pseudo log probs,
     which is not meant to be used for other modules.
 
+    :param prompts: A list of prompts.
+    :param llm: A llama index LLM instance.
+    :param batch: The batch size for llm.
+        Set low if you face some errors.
     :return: A tuple of three elements.
         The first element is a list of generated text.
         The second element is a list of generated text's token ids, used tokenizer is GPT2Tokenizer.
@@ -22,7 +27,7 @@ def llama_index_llm(prompts: List[str], llm: BaseLLM) -> Tuple[List[str], List[L
     """
     tasks = [llm.acomplete(prompt) for prompt in prompts]
     loop = asyncio.get_event_loop()
-    results = loop.run_until_complete(asyncio.gather(*tasks))
+    results = loop.run_until_complete(process_batch(tasks, batch_size=batch))
 
     generated_texts = list(map(lambda x: x.text, results))
     tokenizer = AutoTokenizer.from_pretrained("gpt2", use_fast=False)

--- a/autorag/nodes/passagecompressor/base.py
+++ b/autorag/nodes/passagecompressor/base.py
@@ -31,6 +31,7 @@ def passage_compressor_node(func):
             param_dict = dict(filter(lambda x: x[0] in param_list, kwargs.items()))
             kwargs_dict = dict(filter(lambda x: x[0] not in param_list, kwargs.items()))
             llm_name = kwargs_dict.pop('llm')
+            batch_size = kwargs_dict.pop('batch', 16)
             llm = make_llm(llm_name, kwargs_dict)
             result = func(
                 queries=queries,
@@ -38,6 +39,7 @@ def passage_compressor_node(func):
                 scores=retrieve_scores,
                 ids=retrieved_ids,
                 llm=llm,
+                batch=batch_size,
                 **param_dict
             )
         else:

--- a/autorag/nodes/passagecompressor/base.py
+++ b/autorag/nodes/passagecompressor/base.py
@@ -27,11 +27,10 @@ def passage_compressor_node(func):
         retrieve_scores = previous_result['retrieve_scores'].tolist()
 
         if func.__name__ == 'tree_summarize':
-            param_list = ['prompt', 'chat_prompt', 'context_window', 'num_output']
+            param_list = ['prompt', 'chat_prompt', 'context_window', 'num_output', 'batch']
             param_dict = dict(filter(lambda x: x[0] in param_list, kwargs.items()))
             kwargs_dict = dict(filter(lambda x: x[0] not in param_list, kwargs.items()))
             llm_name = kwargs_dict.pop('llm')
-            batch_size = kwargs_dict.pop('batch', 16)
             llm = make_llm(llm_name, kwargs_dict)
             result = func(
                 queries=queries,
@@ -39,7 +38,6 @@ def passage_compressor_node(func):
                 scores=retrieve_scores,
                 ids=retrieved_ids,
                 llm=llm,
-                batch=batch_size,
                 **param_dict
             )
         else:

--- a/autorag/nodes/queryexpansion/base.py
+++ b/autorag/nodes/queryexpansion/base.py
@@ -35,6 +35,12 @@ def query_expansion_node(func):
         else:
             prompt = ""
 
+        # pop batch from kwargs
+        if "batch" in kwargs.keys():
+            batch = kwargs.pop("batch")
+        else:
+            batch = 16
+
         # set llm model for query expansion
         if llm_str in generator_models:
             llm = generator_models[llm_str](**kwargs)
@@ -43,7 +49,7 @@ def query_expansion_node(func):
             raise KeyError(f"llm_str {llm_str} does not exist.")
 
         # run query expansion function
-        expanded_queries = func(queries=queries, llm=llm, prompt=prompt)
+        expanded_queries = func(queries=queries, llm=llm, prompt=prompt, batch=batch)
 
         return expanded_queries
 

--- a/autorag/nodes/queryexpansion/hyde.py
+++ b/autorag/nodes/queryexpansion/hyde.py
@@ -4,13 +4,15 @@ from typing import List
 from llama_index.llms.llm import BaseLLM
 
 from autorag.nodes.queryexpansion.base import query_expansion_node
+from autorag.utils.util import process_batch
 
 hyde_prompt = "Please write a passage to answer the question"
 
 
 @query_expansion_node
 def hyde(queries: List[str], llm: BaseLLM,
-         prompt: str = hyde_prompt) -> List[List[str]]:
+         prompt: str = hyde_prompt,
+         batch: int = 16) -> List[List[str]]:
     """
     HyDE, which inspired by "Precise Zero-shot Dense Retrieval without Relevance Labels" (https://arxiv.org/pdf/2212.10496.pdf)
     LLM model creates hypothetical passage.
@@ -18,12 +20,14 @@ def hyde(queries: List[str], llm: BaseLLM,
     :param queries: List[str], queries to retrieve.
     :param llm: llm to use for hypothetical passage generation.
     :param prompt: prompt to use when generating hypothetical passage
+    :param batch: Batch size for llm.
+        Default is 16.
     :return: List[List[str]], List of hyde results.
     """
     # Run async query_decompose_pure function
     tasks = [hyde_pure(query, llm, prompt) for query in queries]
     loop = asyncio.get_event_loop()
-    results = loop.run_until_complete(asyncio.gather(*tasks))
+    results = loop.run_until_complete(process_batch(tasks, batch_size=batch))
     return results
 
 

--- a/autorag/nodes/queryexpansion/query_decompose.py
+++ b/autorag/nodes/queryexpansion/query_decompose.py
@@ -4,6 +4,7 @@ from typing import List
 from llama_index.llms.llm import BaseLLM
 
 from autorag.nodes.queryexpansion.base import query_expansion_node
+from autorag.utils.util import process_batch
 
 decompose_prompt = """Decompose a question in self-contained sub-questions. Use \"The question needs no decomposition\" when no decomposition is needed.
 
@@ -54,19 +55,22 @@ decompose_prompt = """Decompose a question in self-contained sub-questions. Use 
 
 @query_expansion_node
 def query_decompose(queries: List[str], llm: BaseLLM,
-                    prompt: str = decompose_prompt) -> List[List[str]]:
+                    prompt: str = decompose_prompt,
+                    batch: int = 16) -> List[List[str]]:
     """
     decompose query to little piece of questions.
     :param queries: List[str], queries to decompose.
     :param llm: BaseLLM, language model to use.
     :param prompt: str, prompt to use for query decomposition.
         default prompt comes from Visconde's StrategyQA few-shot prompt.
+    :param batch: int, batch size for llm.
+        Default is 16.
     :return: List[List[str]], list of decomposed query. Return input query if query is not decomposable.
     """
     # Run async query_decompose_pure function
     tasks = [query_decompose_pure(query, llm, prompt) for query in queries]
     loop = asyncio.get_event_loop()
-    results = loop.run_until_complete(asyncio.gather(*tasks))
+    results = loop.run_until_complete(process_batch(tasks, batch_size=batch))
     return results
 
 

--- a/autorag/utils/util.py
+++ b/autorag/utils/util.py
@@ -1,4 +1,5 @@
 import ast
+import asyncio
 import functools
 import itertools
 import os
@@ -200,3 +201,22 @@ def convert_string_to_tuple_in_dict(d):
             d[key] = ast.literal_eval(value)
 
     return d
+
+
+async def process_batch(tasks, batch_size: int = 64) -> List[Any]:
+    """
+    Processes tasks in batches asynchronously.
+
+    :param tasks: A list of no-argument functions or coroutines to be executed.
+    :param batch_size: The number of tasks to process in a single batch.
+        Default is 64.
+    :return: A list of results from the processed tasks.
+    """
+    results = []
+
+    for i in range(0, len(tasks), batch_size):
+        batch = tasks[i:i + batch_size]
+        batch_results = await asyncio.gather(*batch)
+        results.extend(batch_results)
+
+    return results

--- a/tests/autorag/nodes/generator/test_run_generator_node.py
+++ b/tests/autorag/nodes/generator/test_run_generator_node.py
@@ -44,8 +44,8 @@ def node_line_dir():
 
 def test_run_generator_node(node_line_dir):
     modules = [llama_index_llm, llama_index_llm]
-    module_params = [{'llm': 'openai', 'temperature': 0.5, 'top_p': 0.9, 'max_tokens': 128},
-                     {'llm': 'openai', 'temperature': 1.5, 'top_p': 0.9, 'max_tokens': 128}]
+    module_params = [{'llm': 'openai', 'temperature': 0.5, 'top_p': 0.9, 'max_tokens': 128, 'batch': 8},
+                     {'llm': 'openai', 'temperature': 1.5, 'top_p': 0.9, 'max_tokens': 128, 'batch': 8}]
     strategies = {
         'metrics': ['bleu', 'meteor', 'rouge'],
         'speed_threshold': 5,
@@ -63,7 +63,8 @@ def test_run_generator_node(node_line_dir):
                       'is_best'}
     assert set(summary_df.columns) == expect_columns
     assert len(summary_df) == 2
-    assert summary_df['module_params'][0] == {'llm': 'openai', 'temperature': 0.5, 'top_p': 0.9, 'max_tokens': 128}
+    assert summary_df['module_params'][0] == {'llm': 'openai', 'temperature': 0.5, 'top_p': 0.9, 'max_tokens': 128,
+                                              'batch': 8}
 
     first_path = os.path.join(node_line_dir, "generator", "0.parquet")
     assert os.path.exists(first_path)

--- a/tests/autorag/nodes/passagecompressor/test_run_passage_compressor_node.py
+++ b/tests/autorag/nodes/passagecompressor/test_run_passage_compressor_node.py
@@ -75,7 +75,7 @@ def node_line_dir():
 
 def test_run_passage_compressor_node(node_line_dir):
     modules = [tree_summarize, tree_summarize]
-    module_params = [{'llm': 'openai', 'model': 'gpt-3.5-turbo-16k'},
+    module_params = [{'llm': 'openai', 'model': 'gpt-3.5-turbo-16k', 'batch': 4},
                      {'llm': 'openai', 'model': 'gpt-3.5-turbo'}]
     strategies = {
         'metrics': ['retrieval_token_f1', 'retrieval_token_precision'],
@@ -104,7 +104,7 @@ def test_run_passage_compressor_node(node_line_dir):
     assert summary_df['passage_compressor_retrieval_token_precision'][0] == pytest.approx(single_result_df[
         'retrieval_token_precision'].mean())
     assert summary_df['module_name'][0] == "tree_summarize"
-    assert summary_df['module_params'][0] == {'llm': 'openai', 'model': 'gpt-3.5-turbo-16k'}
+    assert summary_df['module_params'][0] == {'llm': 'openai', 'model': 'gpt-3.5-turbo-16k', 'batch': 4}
     assert summary_df['execution_time'][0] > 0
     # test the best file is saved properly
     best_path = summary_df[summary_df['is_best']]['filename'].values[0]

--- a/tests/autorag/nodes/queryexpansion/test_query_expansion_run.py
+++ b/tests/autorag/nodes/queryexpansion/test_query_expansion_run.py
@@ -78,7 +78,7 @@ def base_query_expansion_test(best_result, node_line_dir):
     assert len(summary_df) == 2
     assert summary_df['filename'][0] == "0.parquet"
     assert summary_df['module_name'][0] == "query_decompose"
-    assert summary_df['module_params'][0] == {'llm': "openai", 'temperature': 0.2}
+    assert summary_df['module_params'][0] == {'llm': "openai", 'temperature': 0.2, 'batch': 7}
     assert summary_df['execution_time'][0] > 0
     assert summary_df['is_best'][0] == True  # is_best is np.bool_
     # test the best file is saved properly
@@ -95,7 +95,7 @@ def test_run_query_expansion_node(node_line_dir):
 
     generator_models['mock'] = MockLLM
     modules = [query_decompose, hyde]
-    module_params = [{'llm': "openai", 'temperature': 0.2}, {'llm': "mock"}]
+    module_params = [{'llm': "openai", 'temperature': 0.2, 'batch': 7}, {'llm': "mock"}]
     strategies = {
         'metrics': metrics,
         'speed_threshold': 5,
@@ -113,7 +113,7 @@ def test_run_query_expansion_node_default(node_line_dir):
 
     generator_models['mock'] = MockLLM
     modules = [query_decompose, hyde]
-    module_params = [{'llm': "openai", 'temperature': 0.2}, {'llm': "mock"}]
+    module_params = [{'llm': "openai", 'temperature': 0.2, 'batch': 7}, {'llm': "mock"}]
     strategies = {
         'metrics': metrics
     }


### PR DESCRIPTION
close #114

I add `process_batch()` for effectively processing llm async operations.
If not, it occurs so many error when try to run thousands of rows.
You can set with `batch` params.

<Modules that adapt batch processing>
- `llama_index_llm`
- `hyde`
- `query_decompose`
- `vectordb`
- `tree_summarize`

I passed all test.

After this is merged, I will deploy v0.0.3 with hotfixes.