### PR TITLE
[HotFix] do not join inner at hybrid_cc for consistent 'top_k' result. It can …

### DIFF
--- a/autorag/nodes/retrieval/hybrid_cc.py
+++ b/autorag/nodes/retrieval/hybrid_cc.py
@@ -55,8 +55,9 @@ def hybrid_cc(
 
 def cc_pure(ids: Tuple, scores: Tuple, weights: Tuple, top_k: int) -> Tuple[
     List[str], List[float]]:
-    df = pd.concat([pd.Series(dict(zip(_id, score))) for _id, score in zip(ids, scores)], axis=1, join="inner")
+    df = pd.concat([pd.Series(dict(zip(_id, score))) for _id, score in zip(ids, scores)], axis=1)
     normalized_scores = (df - df.min()) / (df.max() - df.min())
+    normalized_scores = normalized_scores.fillna(0)
     normalized_scores['weighted_sum'] = normalized_scores.mul(weights).sum(axis=1)
     normalized_scores = normalized_scores.sort_values(by='weighted_sum', ascending=False)
     return normalized_scores.index.tolist()[:top_k], normalized_scores['weighted_sum'][:top_k].tolist()

--- a/tests/autorag/nodes/retrieval/test_hybrid_cc.py
+++ b/tests/autorag/nodes/retrieval/test_hybrid_cc.py
@@ -16,6 +16,16 @@ def test_cc_pure():
     assert result_id == ['id-1', 'id-4', 'id-2']
 
 
+def test_cc_non_overlap():
+    sample_ids = (['id-1', 'id-2', 'id-3', 'id-4', 'id-5'],
+                  ['id-6', 'id-4', 'id-3', 'id-7', 'id-2'])
+    sample_scores = ([5, 3, 1, 0.4, 0.2], [6, 2, 1, 0.5, 0.1])
+    result_id, result_scores = cc_pure(sample_ids, sample_scores,
+                                       weights=(0.3, 0.7), top_k=3)
+    assert result_scores == pytest.approx([0.7, 0.3, 0.23792372])
+    assert result_id == ['id-6', 'id-1', 'id-4']
+
+
 def test_hybrid_cc():
     sample_ids = ([
                       ['id-1', 'id-2', 'id-3', 'id-4', 'id-5'],
@@ -58,7 +68,7 @@ def test_hybrid_cc_node(pseudo_project_dir, pseudo_node_dir):
                  ['id-1', 'id-2', 'id-3', 'id-4', 'id-5']],
                 [['id-1', 'id-4', 'id-3', 'id-5', 'id-2'],
                  ['id-1', 'id-4', 'id-3', 'id-5', 'id-2']]
-        ),
+                ),
         'scores': ([[5, 3, 1, 0.4, 0.2], [5, 3, 1, 0.4, 0.2]],
                    [[6, 2, 1, 0.5, 0.1], [6, 2, 1, 0.5, 0.1]]),
         'top_k': 3,


### PR DESCRIPTION
…prevent errors becuase of empty retrieved ids.


close #128