### PR TITLE
Find a better way to using swifter

### DIFF
--- a/autorag/__init__.py
+++ b/autorag/__init__.py
@@ -1,19 +1,21 @@
-import os
 import logging
 import logging.config
+import os
 import sys
-
-from rich.logging import RichHandler
 
 from llama_index.embeddings import OpenAIEmbedding, HuggingFaceEmbedding
 from llama_index.embeddings.openai import OpenAIEmbeddingModelType
 from llama_index.llms import OpenAI, Anthropic, AzureOpenAI, HuggingFaceLLM, LangChainLLM, GradientBaseModelLLM, \
     GradientModelAdapterLLM, LiteLLM, LlamaCPP, OpenAILike, OpenLLM, PaLM, PredibaseLLM, Replicate, Xinference
+from rich.logging import RichHandler
+from swifter import set_defaults
 
 version_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'VERSION')
 
 with open(version_path, 'r') as f:
     __version__ = f.read().strip()
+
+set_defaults(allow_dask_on_strings=True)
 
 embedding_models = {
     'openai': OpenAIEmbedding(),  # default model is OpenAIEmbeddingModelType.TEXT_EMBED_ADA_002

--- a/autorag/evaluate/metric/generation.py
+++ b/autorag/evaluate/metric/generation.py
@@ -5,6 +5,7 @@ import evaluate
 import pandas as pd
 import sacrebleu
 from llama_index.core.embeddings.base import BaseEmbedding
+import swifter
 
 from autorag import embedding_models
 from autorag.evaluate.metric.util import calculate_cosine_similarity

--- a/autorag/evaluate/metric/generation.py
+++ b/autorag/evaluate/metric/generation.py
@@ -5,7 +5,6 @@ import evaluate
 import pandas as pd
 import sacrebleu
 from llama_index.core.embeddings.base import BaseEmbedding
-import swifter
 
 from autorag import embedding_models
 from autorag.evaluate.metric.util import calculate_cosine_similarity

--- a/autorag/evaluate/metric/retrieval.py
+++ b/autorag/evaluate/metric/retrieval.py
@@ -2,7 +2,6 @@ import functools
 from typing import List
 
 import pandas as pd
-import swifter  # do not delete this line
 
 
 def retrieval_metric(func):

--- a/autorag/evaluate/metric/retrieval_contents.py
+++ b/autorag/evaluate/metric/retrieval_contents.py
@@ -9,7 +9,6 @@ from typing import List
 
 import numpy as np
 import pandas as pd
-import swifter
 
 from autorag.utils.util import normalize_string
 

--- a/autorag/nodes/retrieval/hybrid_rrf.py
+++ b/autorag/nodes/retrieval/hybrid_rrf.py
@@ -1,7 +1,6 @@
 from typing import List, Tuple
 
 import pandas as pd
-import swifter
 
 from autorag.nodes.retrieval import retrieval_node
 

--- a/autorag/utils/util.py
+++ b/autorag/utils/util.py
@@ -1,4 +1,3 @@
-import ast
 import asyncio
 import functools
 import itertools
@@ -10,7 +9,6 @@ from typing import List, Callable, Dict, Optional, Any, Collection
 import ast
 
 import pandas as pd
-import swifter
 
 import logging
 

--- a/tests/autorag/nodes/retrieval/test_hybrid_rrf.py
+++ b/tests/autorag/nodes/retrieval/test_hybrid_rrf.py
@@ -7,11 +7,10 @@ import pandas as pd
 import pytest
 from llama_index import OpenAIEmbedding
 
+from autorag.nodes.retrieval import hybrid_rrf
 from autorag.nodes.retrieval.bm25 import bm25_ingest
 from autorag.nodes.retrieval.hybrid_rrf import rrf_pure
-from autorag.nodes.retrieval import hybrid_rrf
 from autorag.nodes.retrieval.vectordb import vectordb_ingest
-from tests.autorag.nodes.retrieval.test_run_retrieval_node import pseudo_node_dir
 
 
 def test_hybrid_rrf():


### PR DESCRIPTION
close #161

There was problem that we can't use Pycharm 'optimize import' feature because of swifter. 
It needs to be imported for using, while Pycharm recognize swifter is not using.

This occurs because, `import swifter` actually not using at that file. Here are the reasons.

### How swifter works?

At swifter __init__.py, there is a function for register swifter functions to pandas.

```python
if "modin.pandas" in sys.modules:
    register_modin()
```

So, when you import swifter, it runs `__init__.py` and run `register_modin()`. 
It register swifter package to pandas. Pandas has external api functions to register add-ons.

Because of that, without `import swifter` we couldn't use swifter. But once it is run at `AutoRAG` somewhere, we can use it.

### What I did

What I did is this.
First, import `swifter.set_defaults` for running swifter `__init__.py` (+fast processing for strings)
Second, remove `import swifter` at all files. 
Lastly, turn 'optimize import' feature again! 

It works because all AutoRAG functions must be run after highest `__init__.py` run. And it runs swifter `__init__.py`

So @Eastsidegunn @bwook00 
Don't forget to turn on 'optimize import' at commit option!!


FYI : I tested all test and it passed.