### PR TITLE
Add project directory option at `Evaluator` and `Runner`

### DIFF
--- a/autorag/__init__.py
+++ b/autorag/__init__.py
@@ -1,14 +1,27 @@
-import os
 import logging
 import logging.config
+import os
 import sys
 
-from rich.logging import RichHandler
-
-from llama_index.embeddings import OpenAIEmbedding, HuggingFaceEmbedding
+from llama_index.embeddings.huggingface import HuggingFaceEmbedding
+from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.embeddings.openai import OpenAIEmbeddingModelType
-from llama_index.llms import OpenAI, Anthropic, AzureOpenAI, HuggingFaceLLM, LangChainLLM, GradientBaseModelLLM, \
-    GradientModelAdapterLLM, LiteLLM, LlamaCPP, OpenAILike, OpenLLM, PaLM, PredibaseLLM, Replicate, Xinference
+from llama_index.llms.anthropic import Anthropic
+from llama_index.llms.azure_openai import AzureOpenAI
+from llama_index.llms.gradient import GradientBaseModelLLM
+from llama_index.llms.gradient import GradientModelAdapterLLM
+from llama_index.llms.huggingface import HuggingFaceLLM
+from llama_index.llms.langchain import LangChainLLM
+from llama_index.llms.litellm import LiteLLM
+from llama_index.llms.llama_cpp import LlamaCPP
+from llama_index.llms.openai import OpenAI
+from llama_index.llms.openai_like import OpenAILike
+from llama_index.llms.openllm import OpenLLM
+from llama_index.llms.palm import PaLM
+from llama_index.llms.predibase import PredibaseLLM
+from llama_index.llms.replicate import Replicate
+from llama_index.llms.xinference import Xinference
+from rich.logging import RichHandler
 
 version_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'VERSION')
 

--- a/autorag/__init__.py
+++ b/autorag/__init__.py
@@ -6,21 +6,8 @@ import sys
 from llama_index.embeddings.huggingface import HuggingFaceEmbedding
 from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.embeddings.openai import OpenAIEmbeddingModelType
-from llama_index.llms.anthropic import Anthropic
-from llama_index.llms.azure_openai import AzureOpenAI
-from llama_index.llms.gradient import GradientBaseModelLLM
-from llama_index.llms.gradient import GradientModelAdapterLLM
 from llama_index.llms.huggingface import HuggingFaceLLM
-from llama_index.llms.langchain import LangChainLLM
-from llama_index.llms.litellm import LiteLLM
-from llama_index.llms.llama_cpp import LlamaCPP
 from llama_index.llms.openai import OpenAI
-from llama_index.llms.openai_like import OpenAILike
-from llama_index.llms.openllm import OpenLLM
-from llama_index.llms.palm import PaLM
-from llama_index.llms.predibase import PredibaseLLM
-from llama_index.llms.replicate import Replicate
-from llama_index.llms.xinference import Xinference
 from rich.logging import RichHandler
 
 version_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'VERSION')
@@ -42,20 +29,7 @@ embedding_models = {
 
 generator_models = {
     'openai': OpenAI,
-    'anthropic': Anthropic,
-    'azureopenai': AzureOpenAI,
     'huggingfacellm': HuggingFaceLLM,
-    'langchainllm': LangChainLLM,
-    'gradientbasemodelllm': GradientBaseModelLLM,
-    'gradientmodeladapterllm': GradientModelAdapterLLM,
-    'litellm': LiteLLM,
-    'llamacpp': LlamaCPP,
-    'openailike': OpenAILike,
-    'openllm': OpenLLM,
-    'palm': PaLM,
-    'predibasellm': PredibaseLLM,
-    'replicate': Replicate,
-    'xinference': Xinference,
 }
 
 rich_format = "[%(filename)s:%(lineno)s] >> %(message)s"

--- a/autorag/__init__.py
+++ b/autorag/__init__.py
@@ -8,6 +8,7 @@ from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.embeddings.openai import OpenAIEmbeddingModelType
 from llama_index.llms.huggingface import HuggingFaceLLM
 from llama_index.llms.openai import OpenAI
+from llama_index.llms.openai_like import OpenAILike
 from rich.logging import RichHandler
 
 version_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'VERSION')
@@ -30,6 +31,7 @@ embedding_models = {
 generator_models = {
     'openai': OpenAI,
     'huggingfacellm': HuggingFaceLLM,
+    'openailike': OpenAILike,
 }
 
 rich_format = "[%(filename)s:%(lineno)s] >> %(message)s"

--- a/autorag/data/utils/llamaindex.py
+++ b/autorag/data/utils/llamaindex.py
@@ -1,14 +1,13 @@
+import mimetypes
 import os
 import pathlib
-import mimetypes
 import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
 import pandas as pd
-
-from llama_index.schema import Document as LlamaDocument
+from llama_index.core.schema import Document as LlamaDocument
 
 
 def get_file_metadata(file_path: str) -> Dict:

--- a/autorag/deploy.py
+++ b/autorag/deploy.py
@@ -120,12 +120,14 @@ class Runner:
         self.__add_api_route()
 
     @classmethod
-    def from_yaml(cls, yaml_path: str):
+    def from_yaml(cls, yaml_path: str, project_dir: Optional[str] = None):
         """
         Load Runner from yaml file.
         Must be extracted yaml file from evaluated trial using extract_best_config method.
 
         :param yaml_path: The path of the yaml file.
+        :param project_dir: The path of the project directory.
+            Default is the current directory.
         :return: Initialized Runner.
         """
         with open(yaml_path, 'r') as f:
@@ -134,7 +136,7 @@ class Runner:
             except yaml.YAMLError as exc:
                 logger.error(exc)
                 raise exc
-        return cls(config)
+        return cls(config, project_dir=project_dir)
 
     @classmethod
     def from_trial_folder(cls, trial_path: str):

--- a/autorag/evaluate/metric/generation.py
+++ b/autorag/evaluate/metric/generation.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 import evaluate
 import pandas as pd
 import sacrebleu
-from llama_index.core.embeddings.base import BaseEmbedding
+from llama_index.core.embeddings import BaseEmbedding
 
 from autorag import embedding_models
 from autorag.evaluate.metric.util import calculate_cosine_similarity

--- a/autorag/evaluator.py
+++ b/autorag/evaluator.py
@@ -3,16 +3,16 @@ import logging
 import os
 import shutil
 from datetime import datetime
-from typing import List, Dict
 from itertools import chain
+from typing import List, Dict, Optional
 
 import chromadb
 import click
 import pandas as pd
 import yaml
 
-from autorag.deploy import Runner
 from autorag import embedding_models
+from autorag.deploy import Runner
 from autorag.node_line import run_node_line
 from autorag.nodes.retrieval.bm25 import bm25_ingest
 from autorag.nodes.retrieval.vectordb import vectordb_ingest
@@ -25,7 +25,17 @@ logger = logging.getLogger("AutoRAG")
 
 
 class Evaluator:
-    def __init__(self, qa_data_path: str, corpus_data_path: str):
+    def __init__(self, qa_data_path: str, corpus_data_path: str, project_dir: Optional[str] = None):
+        """
+        Initialize an Evaluator object.
+
+        :param qa_data_path: The path to the QA dataset.
+            Must be parquet file.
+        :param corpus_data_path: The path to the corpus dataset.
+            Must be parquet file.
+        :param project_dir: The path to the project directory.
+            Default is the current directory.
+        """
         # validate data paths
         if not os.path.exists(qa_data_path):
             raise ValueError(f"QA data path {qa_data_path} does not exist.")
@@ -39,18 +49,19 @@ class Evaluator:
         self.corpus_data = pd.read_parquet(corpus_data_path)
         self.qa_data = cast_qa_dataset(self.qa_data)
         self.corpus_data = cast_corpus_dataset(self.corpus_data)
+        self.project_dir = project_dir if project_dir is not None else os.getcwd()
+        if not os.path.exists(self.project_dir):
+            os.makedirs(self.project_dir)
 
         # copy dataset to project directory
-        if not os.path.exists(os.path.join(os.getcwd(), 'data')):
-            os.makedirs(os.path.join(os.getcwd(), 'data'))
-        qa_path_in_project = os.path.join(os.getcwd(), 'data', 'qa.parquet')
+        if not os.path.exists(os.path.join(self.project_dir, 'data')):
+            os.makedirs(os.path.join(self.project_dir, 'data'))
+        qa_path_in_project = os.path.join(self.project_dir, 'data', 'qa.parquet')
         if not os.path.exists(qa_path_in_project):
             shutil.copy(qa_data_path, qa_path_in_project)
-        corpus_path_in_project = os.path.join(os.getcwd(), 'data', 'corpus.parquet')
+        corpus_path_in_project = os.path.join(self.project_dir, 'data', 'corpus.parquet')
         if not os.path.exists(corpus_path_in_project):
             shutil.copy(corpus_data_path, corpus_path_in_project)
-
-        self.project_dir = os.getcwd()
 
     def start_trial(self, yaml_path: str):
         trial_name = self.__get_new_trial_name()

--- a/autorag/evaluator.py
+++ b/autorag/evaluator.py
@@ -185,12 +185,13 @@ def cli():
 @click.option('--config', '-c', help='Path to config yaml file. Must be yaml or yml file.', type=str)
 @click.option('--qa_data_path', help='Path to QA dataset. Must be parquet file.', type=str)
 @click.option('--corpus_data_path', help='Path to corpus dataset. Must be parquet file.', type=str)
-def evaluate(config, qa_data_path, corpus_data_path):
+@click.option('--project_dir', help='Path to project directory.', type=str, default=None)
+def evaluate(config, qa_data_path, corpus_data_path, project_dir):
     if not config.endswith('.yaml') and not config.endswith('.yml'):
         raise ValueError(f"Config file {config} is not a parquet file.")
     if not os.path.exists(config):
         raise ValueError(f"Config file {config} does not exist.")
-    evaluator = Evaluator(qa_data_path, corpus_data_path)
+    evaluator = Evaluator(qa_data_path, corpus_data_path, project_dir=project_dir)
     evaluator.start_trial(config)
     logger.info('Evaluation complete.')
 
@@ -199,8 +200,9 @@ def evaluate(config, qa_data_path, corpus_data_path):
 @click.option('--config_path', type=str, help='Path to extracted config yaml file.')
 @click.option('--host', type=str, default='0.0.0.0', help='Host address')
 @click.option('--port', type=int, default=8000, help='Port number')
-def run_api(config_path, host, port):
-    runner = Runner.from_yaml(config_path)
+@click.option('--project_dir', help='Path to project directory.', type=str, default=None)
+def run_api(config_path, host, port, project_dir):
+    runner = Runner.from_yaml(config_path, project_dir=project_dir)
     logger.info(f"Running API server at {host}:{port}...")
     runner.run_api_server(host, port)
 

--- a/autorag/nodes/generator/llama_index_llm.py
+++ b/autorag/nodes/generator/llama_index_llm.py
@@ -1,7 +1,7 @@
 import asyncio
 from typing import List, Tuple
 
-from llama_index.core.llms.base import BaseLLM
+from llama_index.core.service_context_elements.llm_predictor import LLMPredictorType
 from transformers import AutoTokenizer
 
 from autorag.nodes.generator.base import generator_node
@@ -9,7 +9,7 @@ from autorag.utils.util import process_batch
 
 
 @generator_node
-def llama_index_llm(prompts: List[str], llm: BaseLLM, batch: int = 16) -> Tuple[List[str], List[List[int]], List[List[float]]]:
+def llama_index_llm(prompts: List[str], llm: LLMPredictorType, batch: int = 16) -> Tuple[List[str], List[List[int]], List[List[float]]]:
     """
     Llama Index LLM module.
     It gets the LLM instance from llama index, and returns generated text by the input prompt.

--- a/autorag/nodes/generator/llama_index_llm.py
+++ b/autorag/nodes/generator/llama_index_llm.py
@@ -1,7 +1,7 @@
 import asyncio
 from typing import List, Tuple
 
-from llama_index.llms.base import BaseLLM
+from llama_index.core.llms.base import BaseLLM
 from transformers import AutoTokenizer
 
 from autorag.nodes.generator.base import generator_node

--- a/autorag/nodes/passagecompressor/base.py
+++ b/autorag/nodes/passagecompressor/base.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import List, Union, Dict
 
 import pandas as pd
-from llama_index.llms.base import BaseLLM
+from llama_index.core.llms.base import BaseLLM
 
 from autorag import generator_models
 from autorag.utils import result_to_dataframe

--- a/autorag/nodes/passagecompressor/base.py
+++ b/autorag/nodes/passagecompressor/base.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import List, Union, Dict
 
 import pandas as pd
-from llama_index.core.llms.base import BaseLLM
+from llama_index.core.service_context_elements.llm_predictor import LLMPredictorType
 
 from autorag import generator_models
 from autorag.utils import result_to_dataframe
@@ -48,7 +48,7 @@ def passage_compressor_node(func):
     return wrapper
 
 
-def make_llm(llm_name: str, kwargs: Dict) -> BaseLLM:
+def make_llm(llm_name: str, kwargs: Dict) -> LLMPredictorType:
     if llm_name not in generator_models:
         raise KeyError(f"{llm_name} is not supported. "
                        "You can add it manually by calling autorag.generator_models.")

--- a/autorag/nodes/passagecompressor/tree_summarize.py
+++ b/autorag/nodes/passagecompressor/tree_summarize.py
@@ -1,11 +1,11 @@
 import asyncio
 from typing import List, Optional
 
-from llama_index import PromptTemplate, ServiceContext
-from llama_index.llms.base import BaseLLM
-from llama_index.prompts import PromptType
-from llama_index.prompts.utils import is_chat_model
-from llama_index.response_synthesizers import TreeSummarize
+from llama_index.core import PromptTemplate, ServiceContext
+from llama_index.core.llms.base import BaseLLM
+from llama_index.core.prompts import PromptType
+from llama_index.core.prompts.utils import is_chat_model
+from llama_index.core.response_synthesizers import TreeSummarize
 
 from autorag.nodes.passagecompressor.base import passage_compressor_node
 from autorag.utils.util import process_batch

--- a/autorag/nodes/queryexpansion/hyde.py
+++ b/autorag/nodes/queryexpansion/hyde.py
@@ -1,7 +1,7 @@
 import asyncio
 from typing import List
 
-from llama_index.core.llms.llm import BaseLLM
+from llama_index.core.service_context_elements.llm_predictor import LLMPredictorType
 
 from autorag.nodes.queryexpansion.base import query_expansion_node
 from autorag.utils.util import process_batch
@@ -10,13 +10,13 @@ hyde_prompt = "Please write a passage to answer the question"
 
 
 @query_expansion_node
-def hyde(queries: List[str], llm: BaseLLM,
+def hyde(queries: List[str], llm: LLMPredictorType,
          prompt: str = hyde_prompt,
          batch: int = 16) -> List[List[str]]:
     """
     HyDE, which inspired by "Precise Zero-shot Dense Retrieval without Relevance Labels" (https://arxiv.org/pdf/2212.10496.pdf)
-    LLM model creates hypothetical passage.
-    And then, retrieve passages using hypothetical passage as query.
+    LLM model creates a hypothetical passage.
+    And then, retrieve passages using hypothetical passage as a query.
     :param queries: List[str], queries to retrieve.
     :param llm: llm to use for hypothetical passage generation.
     :param prompt: prompt to use when generating hypothetical passage
@@ -31,7 +31,7 @@ def hyde(queries: List[str], llm: BaseLLM,
     return results
 
 
-async def hyde_pure(query: str, llm: BaseLLM,
+async def hyde_pure(query: str, llm: LLMPredictorType,
                     prompt: str = hyde_prompt) -> List[str]:
     if prompt is "":
         prompt = hyde_prompt

--- a/autorag/nodes/queryexpansion/hyde.py
+++ b/autorag/nodes/queryexpansion/hyde.py
@@ -1,7 +1,7 @@
 import asyncio
 from typing import List
 
-from llama_index.llms.llm import BaseLLM
+from llama_index.core.llms.llm import BaseLLM
 
 from autorag.nodes.queryexpansion.base import query_expansion_node
 from autorag.utils.util import process_batch

--- a/autorag/nodes/queryexpansion/query_decompose.py
+++ b/autorag/nodes/queryexpansion/query_decompose.py
@@ -1,7 +1,7 @@
 import asyncio
 from typing import List
 
-from llama_index.core.llms.llm import BaseLLM
+from llama_index.core.service_context_elements.llm_predictor import LLMPredictorType
 
 from autorag.nodes.queryexpansion.base import query_expansion_node
 from autorag.utils.util import process_batch
@@ -54,13 +54,13 @@ decompose_prompt = """Decompose a question in self-contained sub-questions. Use 
 
 
 @query_expansion_node
-def query_decompose(queries: List[str], llm: BaseLLM,
+def query_decompose(queries: List[str], llm: LLMPredictorType,
                     prompt: str = decompose_prompt,
                     batch: int = 16) -> List[List[str]]:
     """
     decompose query to little piece of questions.
     :param queries: List[str], queries to decompose.
-    :param llm: BaseLLM, language model to use.
+    :param llm: LLMPredictorType, language model to use.
     :param prompt: str, prompt to use for query decomposition.
         default prompt comes from Visconde's StrategyQA few-shot prompt.
     :param batch: int, batch size for llm.
@@ -74,15 +74,15 @@ def query_decompose(queries: List[str], llm: BaseLLM,
     return results
 
 
-async def query_decompose_pure(query: str, llm: BaseLLM,
+async def query_decompose_pure(query: str, llm: LLMPredictorType,
                                prompt: str = decompose_prompt) -> List[str]:
     """
     decompose query to little piece of questions.
     :param query: str, query to decompose.
-    :param llm: BaseLLM, language model to use.
+    :param llm: LLMPredictorType, language model to use.
     :param prompt: str, prompt to use for query decomposition.
         default prompt comes from Visconde's StrategyQA few-shot prompt.
-    :return: List[str], list of decomposed query. Return input query if query is not decomposable.
+    :return: List[str], list of a decomposed query. Return input query if query is not decomposable.
     """
     if prompt == "":
         prompt = decompose_prompt

--- a/autorag/nodes/queryexpansion/query_decompose.py
+++ b/autorag/nodes/queryexpansion/query_decompose.py
@@ -1,7 +1,7 @@
 import asyncio
 from typing import List
 
-from llama_index.llms.llm import BaseLLM
+from llama_index.core.llms.llm import BaseLLM
 
 from autorag.nodes.queryexpansion.base import query_expansion_node
 from autorag.utils.util import process_batch

--- a/autorag/nodes/retrieval/vectordb.py
+++ b/autorag/nodes/retrieval/vectordb.py
@@ -3,7 +3,7 @@ from typing import List, Tuple
 
 import chromadb
 import pandas as pd
-from llama_index.embeddings import BaseEmbedding
+from llama_index.core.embeddings import BaseEmbedding
 
 from autorag.nodes.retrieval.base import retrieval_node, evenly_distribute_passages
 from autorag.utils import validate_corpus_dataset

--- a/docs/source/local_model.md
+++ b/docs/source/local_model.md
@@ -30,20 +30,9 @@ To change the LLM model type, you can change the `llm` parameter to the followin
 |     LLM Model Type      |      llm parameter      |
 |:-----------------------:|:-----------------------:|
 |         OpenAI          |         openai          |
-|        Anthropic        |        anthropic        |
-|       AzureOpenAI       |       azureopenai       |
 |     HuggingFaceLLM      |     huggingfacellm      |
-|      LangChainLLM       |      langchainllm       |
-|  GradientBaseModelLLM   |  gradientbasemodelllm   |
-| GradientModelAdapterLLM | gradientmodeladapterllm |
-|         LiteLLM         |         litellm         |
-|        LlamaCPP         |        llamacpp         |
 |       OpenAILike        |       openailike        |
-|         OpenLLM         |         openllm         |
-|          PaLM           |          palm           |
-|      PredibaseLLM       |      predibasellm       |
-|        Replicate        |        replicate        |
-|       Xinference        |       xinference        |
+
 
 For example, if you want to use `OpenAILike` model, you can set `llm` parameter to `openailike`.
 
@@ -71,9 +60,16 @@ You can add more LLM models for AutoRAG.
 You can add it by simply calling `autorag.generator_models` and add new key and value.
 For example, if you want to add `MockLLM` model for testing, execute the following code.
 
+```{attention}
+It was major update for LlamaIndex to v0.10.0. 
+The integration of llms must be installed to different packages.
+So, before add your model, you should find and install the right package for your model.
+You can find the package at [here](https://pretty-sodium-5e0.notion.site/ce81b247649a44e4b6b35dfb24af28a6?v=53b3c2ced7bb4c9996b81b83c9f01139).
+```
+
 ```python
 import autorag
-from llama_index.llms import MockLLM
+from llama_index.legacy.llms import MockLLM
 
 autorag.generator_models['mockllm'] = MockLLM
 ```
@@ -137,7 +133,7 @@ execute the following code.
 
 ```python
 import autorag
-from llama_index.embeddings import HuggingFaceEmbedding
+from llama_index.embeddings.huggingface import HuggingFaceEmbedding
 
 autorag.generator_models['kosimcse'] = HuggingFaceEmbedding("BM-K/KoSimCSE-roberta-multitask")
 ```

--- a/docs/source/tutorial.md
+++ b/docs/source/tutorial.md
@@ -79,6 +79,9 @@ You can check out which module and parameters are the best for your dataset.
 And there are lots of details inside node line and node folders.
 You can find out more information about folder structure and result files at [here](structure.md).
 
+```{admonition} Want to specify project folder?
+You can specify project directory with `--project_dir` option or project_dir parameter.
+```
 
 ## Extract pipeline and evaluate test dataset
 
@@ -131,6 +134,10 @@ runner.run_api_server()
 
 ```bash
 autorag run_api --config_path your/path/to/pipeline.yaml --host 0.0.0.0 --port 8000
+```
+
+```{admonition} Want to specify project folder?
+You can specify project directory with `--project_dir` option or project_dir parameter.
 ```
 
 ```{hint}

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ llama-index-embeddings-huggingface
 # LLMs
 llama-index-llms-openai
 llama-index-llms-huggingface
+llama-index-llms-openai-like

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ rouge_score  # for rouge score
 rich  # for pretty logging
 chromadb==0.4.9 # for vectordb retrieval
 click  # for cli
-fastapi>=0.109.2  # for api server
+fastapi  # for api server
 uvicorn  # for api server
 torch  # for monot5 reranker
 sentencepiece  # for monot5 reranker
@@ -29,16 +29,4 @@ llama-index-embeddings-openai
 llama-index-embeddings-huggingface
 # LLMs
 llama-index-llms-openai
-llama-index-llms-anthropic
-llama-index-llms-azure-openai
 llama-index-llms-huggingface
-llama-index-llms-langchain
-llama-index-llms-gradient
-llama-index-llms-litellm
-llama-index-llms-llama-cpp
-llama-index-llms-openai-like
-llama-index-llms-openllm
-llama-index-llms-palm
-llama-index-llms-predibase
-llama-index-llms-replicate
-llama-index-llms-xinference

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ pandas
 tqdm
 tiktoken  # for counting token
 openai>=1.0.0
-llama-index>=0.10.1
 rank_bm25  # for bm25 retrieval
 transformers
 swifter  # for parallel pandas apply
@@ -16,9 +15,30 @@ rouge_score  # for rouge score
 rich  # for pretty logging
 chromadb==0.4.9 # for vectordb retrieval
 click  # for cli
-fastapi  # for api server
+fastapi>=0.109.2  # for api server
 uvicorn  # for api server
 torch  # for monot5 reranker
 sentencepiece  # for monot5 reranker
 guidance # for qa data creation
+
+### LlamaIndex ###
+llama-index>=0.10.1
 llama-index-core>=0.10.1
+# Embeddings
+llama-index-embeddings-openai
+llama-index-embeddings-huggingface
+# LLMs
+llama-index-llms-openai
+llama-index-llms-anthropic
+llama-index-llms-azure-openai
+llama-index-llms-huggingface
+llama-index-llms-langchain
+llama-index-llms-gradient
+llama-index-llms-litellm
+llama-index-llms-llama-cpp
+llama-index-llms-openai-like
+llama-index-llms-openllm
+llama-index-llms-palm
+llama-index-llms-predibase
+llama-index-llms-replicate
+llama-index-llms-xinference

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pandas
 tqdm
 tiktoken  # for counting token
 openai>=1.0.0
-llama-index>=0.9.32
+llama-index>=0.10.1
 rank_bm25  # for bm25 retrieval
 transformers
 swifter  # for parallel pandas apply
@@ -21,3 +21,4 @@ uvicorn  # for api server
 torch  # for monot5 reranker
 sentencepiece  # for monot5 reranker
 guidance # for qa data creation
+llama-index-core>=0.10.1

--- a/tests/autorag/data/qacreation/test_simple.py
+++ b/tests/autorag/data/qacreation/test_simple.py
@@ -1,16 +1,15 @@
+import os
+import pathlib
 import tempfile
 
 import pandas as pd
 import pytest
-import os
-import pathlib
+from guidance import models
+from llama_index.core import SimpleDirectoryReader
 
 from autorag.data.qacreation.simple import generate_simple_qa_dataset, generate_qa_row
-from autorag.utils.preprocess import validate_qa_dataset, validate_corpus_dataset
 from autorag.data.utils.llamaindex import get_file_metadata, llama_documents_to_parquet
-
-from llama_index import SimpleDirectoryReader
-from guidance import models
+from autorag.utils.preprocess import validate_qa_dataset, validate_corpus_dataset
 
 root_dir = pathlib.PurePath(os.path.dirname(os.path.realpath(__file__))).parent.parent.parent
 

--- a/tests/autorag/evaluate/metric/test_generation_metric.py
+++ b/tests/autorag/evaluate/metric/test_generation_metric.py
@@ -1,5 +1,5 @@
 import pytest
-from llama_index import OpenAIEmbedding
+from llama_index.embeddings.openai import OpenAIEmbedding
 
 from autorag.evaluate.metric.generation import bleu, meteor, rouge, sem_score
 

--- a/tests/autorag/evaluate/test_evaluate_util.py
+++ b/tests/autorag/evaluate/test_evaluate_util.py
@@ -1,4 +1,4 @@
-from llama_index import OpenAIEmbedding
+from llama_index.embeddings.openai import OpenAIEmbedding
 
 from autorag.evaluate.util import cast_metrics
 

--- a/tests/autorag/nodes/generator/test_llama_index_llm.py
+++ b/tests/autorag/nodes/generator/test_llama_index_llm.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from llama_index.llms import OpenAI
+from llama_index.llms.openai import OpenAI
 
 from autorag.nodes.generator import llama_index_llm
 

--- a/tests/autorag/nodes/passagecompressor/test_tree_summarize.py
+++ b/tests/autorag/nodes/passagecompressor/test_tree_summarize.py
@@ -1,7 +1,8 @@
 from typing import List
 
 import pandas as pd
-from llama_index.llms import OpenAI, MockLLM
+from llama_index.legacy.llms import MockLLM
+from llama_index.llms.openai import OpenAI
 
 from autorag import generator_models
 from autorag.nodes.passagecompressor import tree_summarize

--- a/tests/autorag/nodes/queryexpansion/test_query_expansion_base.py
+++ b/tests/autorag/nodes/queryexpansion/test_query_expansion_base.py
@@ -1,16 +1,13 @@
 import os
 import pathlib
-
 import shutil
 
-import pytest
-import pandas as pd
-
 import chromadb
-from llama_index.embeddings import OpenAIEmbedding
+import pandas as pd
+import pytest
+from llama_index.embeddings.openai import OpenAIEmbedding
 
 from autorag.nodes.retrieval.vectordb import vectordb_ingest
-
 
 root_dir = pathlib.PurePath(os.path.dirname(os.path.realpath(__file__))).parent.parent.parent
 project_dir = os.path.join(root_dir, "resources", "sample_project")

--- a/tests/autorag/nodes/queryexpansion/test_query_expansion_run.py
+++ b/tests/autorag/nodes/queryexpansion/test_query_expansion_run.py
@@ -4,11 +4,11 @@ import shutil
 
 import pandas as pd
 import pytest
-from llama_index.llms import MockLLM
+from llama_index.legacy.llms import MockLLM
 
 from autorag import generator_models
-from autorag.nodes.queryexpansion.run import evaluate_one_query_expansion_node
 from autorag.nodes.queryexpansion import query_decompose, hyde
+from autorag.nodes.queryexpansion.run import evaluate_one_query_expansion_node
 from autorag.nodes.queryexpansion.run import run_query_expansion_node
 from autorag.nodes.retrieval import bm25
 from autorag.utils.util import load_summary_file

--- a/tests/autorag/nodes/retrieval/test_hybrid_rrf.py
+++ b/tests/autorag/nodes/retrieval/test_hybrid_rrf.py
@@ -5,13 +5,12 @@ from datetime import datetime
 import chromadb
 import pandas as pd
 import pytest
-from llama_index import OpenAIEmbedding
+from llama_index.embeddings.openai import OpenAIEmbedding
 
+from autorag.nodes.retrieval import hybrid_rrf
 from autorag.nodes.retrieval.bm25 import bm25_ingest
 from autorag.nodes.retrieval.hybrid_rrf import rrf_pure
-from autorag.nodes.retrieval import hybrid_rrf
 from autorag.nodes.retrieval.vectordb import vectordb_ingest
-from tests.autorag.nodes.retrieval.test_run_retrieval_node import pseudo_node_dir
 
 
 def test_hybrid_rrf():

--- a/tests/autorag/nodes/retrieval/test_run_retrieval_node.py
+++ b/tests/autorag/nodes/retrieval/test_run_retrieval_node.py
@@ -6,7 +6,7 @@ import tempfile
 import chromadb
 import pandas as pd
 import pytest
-from llama_index import OpenAIEmbedding
+from llama_index.embeddings.openai import OpenAIEmbedding
 
 from autorag.nodes.retrieval import bm25, vectordb, hybrid_rrf, hybrid_cc
 from autorag.nodes.retrieval.run import run_retrieval_node, select_result_for_hybrid, get_ids_and_scores

--- a/tests/autorag/nodes/retrieval/test_vectordb.py
+++ b/tests/autorag/nodes/retrieval/test_vectordb.py
@@ -2,11 +2,10 @@ import os
 import pathlib
 import shutil
 
-import pytest
-import pandas as pd
-
 import chromadb
-from llama_index.embeddings import OpenAIEmbedding
+import pandas as pd
+import pytest
+from llama_index.embeddings.openai import OpenAIEmbedding
 
 from autorag.nodes.retrieval import vectordb
 from autorag.nodes.retrieval.vectordb import vectordb_ingest

--- a/tests/autorag/test_evaluator.py
+++ b/tests/autorag/test_evaluator.py
@@ -125,19 +125,21 @@ def test_start_trial(evaluator):
     assert trial_summary_df['best_execution_time'][0] > 0
 
 
-def test_evaluator_cli(evaluator):
-    result = subprocess.run(['autorag', 'evaluate', '--config', os.path.join(resource_dir, 'simple.yaml'),
-                             '--qa_data_path', os.path.join(resource_dir, 'qa_data_sample.parquet'),
-                             '--corpus_data_path', os.path.join(resource_dir, 'corpus_data_sample.parquet')])
-    assert result.returncode == 0
-    # check if the files are created
-    assert os.path.exists(os.path.join(os.getcwd(), '0'))
-    assert os.path.exists(os.path.join(os.getcwd(), 'data'))
-    assert os.path.exists(os.path.join(os.getcwd(), 'resources'))
-    assert os.path.exists(os.path.join(os.getcwd(), 'trial.json'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval', '0.parquet'))
+def test_evaluator_cli():
+    with tempfile.TemporaryDirectory() as project_dir:
+        result = subprocess.run(['autorag', 'evaluate', '--config', os.path.join(resource_dir, 'simple.yaml'),
+                                 '--qa_data_path', os.path.join(resource_dir, 'qa_data_sample.parquet'),
+                                 '--corpus_data_path', os.path.join(resource_dir, 'corpus_data_sample.parquet'),
+                                 '--project_dir', project_dir])
+        assert result.returncode == 0
+        # check if the files are created
+        assert os.path.exists(os.path.join(project_dir, '0'))
+        assert os.path.exists(os.path.join(project_dir, 'data'))
+        assert os.path.exists(os.path.join(project_dir, 'resources'))
+        assert os.path.exists(os.path.join(project_dir, 'trial.json'))
+        assert os.path.exists(os.path.join(project_dir, '0', 'retrieve_node_line'))
+        assert os.path.exists(os.path.join(project_dir, '0', 'retrieve_node_line', 'retrieval'))
+        assert os.path.exists(os.path.join(project_dir, '0', 'retrieve_node_line', 'retrieval', '0.parquet'))
 
 
 def start_trial_full(evaluator):

--- a/tests/autorag/test_evaluator.py
+++ b/tests/autorag/test_evaluator.py
@@ -1,6 +1,5 @@
 import os.path
 import pathlib
-import shutil
 import subprocess
 import tempfile
 
@@ -30,20 +29,11 @@ def evaluator():
 
 @pytest.fixture
 def test_evaluator():
-    evaluator = Evaluator(os.path.join(resource_dir, 'qa_test_data_sample.parquet'),
-                          os.path.join(resource_dir, 'corpus_data_sample.parquet'))
-    yield evaluator
-    paths_to_remove = ['0', 'data', 'resources', 'trial.json']
-
-    for path in paths_to_remove:
-        full_path = os.path.join(os.getcwd(), path)
-        try:
-            if os.path.isdir(full_path):
-                shutil.rmtree(full_path)
-            else:
-                os.remove(full_path)
-        except FileNotFoundError:
-            pass
+    with tempfile.TemporaryDirectory() as project_dir:
+        evaluator = Evaluator(os.path.join(resource_dir, 'qa_test_data_sample.parquet'),
+                              os.path.join(resource_dir, 'corpus_data_sample.parquet'),
+                              project_dir)
+        yield evaluator
 
 
 def test_evaluator_init(evaluator):
@@ -83,31 +73,32 @@ def test_load_node_line(evaluator):
 
 def test_start_trial(evaluator):
     evaluator.start_trial(os.path.join(resource_dir, 'simple.yaml'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0'))
-    assert os.path.exists(os.path.join(os.getcwd(), 'data'))
-    assert os.path.exists(os.path.join(os.getcwd(), 'resources'))
-    assert os.path.exists(os.path.join(os.getcwd(), 'trial.json'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'config.yaml'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval', '0.parquet'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval', '1.parquet'))
+    project_dir = evaluator.project_dir
+    assert os.path.exists(os.path.join(project_dir, '0'))
+    assert os.path.exists(os.path.join(project_dir, 'data'))
+    assert os.path.exists(os.path.join(project_dir, 'resources'))
+    assert os.path.exists(os.path.join(project_dir, 'trial.json'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'config.yaml'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'retrieve_node_line'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'retrieve_node_line', 'retrieval'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'retrieve_node_line', 'retrieval', '0.parquet'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'retrieve_node_line', 'retrieval', '1.parquet'))
     expect_each_result_columns = ['retrieved_contents', 'retrieved_ids', 'retrieve_scores', 'retrieval_f1',
                                   'retrieval_recall']
     each_result_bm25 = pd.read_parquet(
-        os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval', '0.parquet'))
+        os.path.join(project_dir, '0', 'retrieve_node_line', 'retrieval', '0.parquet'))
     each_result_vectordb = pd.read_parquet(
-        os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval', '1.parquet'))
+        os.path.join(project_dir, '0', 'retrieve_node_line', 'retrieval', '1.parquet'))
     assert all([expect_column in each_result_bm25.columns for expect_column in expect_each_result_columns])
     assert all([expect_column in each_result_vectordb.columns for expect_column in expect_each_result_columns])
     expect_best_result_columns = ['qid', 'query', 'retrieval_gt', 'generation_gt',
                                   'retrieved_contents', 'retrieved_ids', 'retrieve_scores', 'retrieval_f1',
                                   'retrieval_recall']
-    best_result = pd.read_parquet(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval', 'best_0.parquet'))
+    best_result = pd.read_parquet(os.path.join(project_dir, '0', 'retrieve_node_line', 'retrieval', 'best_0.parquet'))
     assert all([expect_column in best_result.columns for expect_column in expect_best_result_columns])
 
     # test node line summary
-    node_line_summary_path = os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'summary.csv')
+    node_line_summary_path = os.path.join(project_dir, '0', 'retrieve_node_line', 'summary.csv')
     assert os.path.exists(node_line_summary_path)
     node_line_summary_df = load_summary_file(node_line_summary_path, ["best_module_params"])
     assert len(node_line_summary_df) == 1
@@ -120,7 +111,7 @@ def test_start_trial(evaluator):
     assert node_line_summary_df['best_execution_time'][0] > 0
 
     # test trial summary
-    trial_summary_path = os.path.join(os.getcwd(), '0', 'summary.csv')
+    trial_summary_path = os.path.join(project_dir, '0', 'summary.csv')
     assert os.path.exists(trial_summary_path)
     trial_summary_df = load_summary_file(trial_summary_path, ["best_module_params"])
     assert len(trial_summary_df) == 1
@@ -154,43 +145,44 @@ def start_trial_full(evaluator):
     Function name doesn't start with 'test' because full test takes too long time.
     """
     evaluator.start_trial(os.path.join(resource_dir, 'full.yaml'))
+    project_dir = evaluator.project_dir
     # full path check
-    assert os.path.exists(os.path.join(os.getcwd(), '0'))
-    assert os.path.exists(os.path.join(os.getcwd(), 'data'))
-    assert os.path.exists(os.path.join(os.getcwd(), 'resources'))
-    assert os.path.exists(os.path.join(os.getcwd(), 'trial.json'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'config.yaml'))
+    assert os.path.exists(os.path.join(project_dir, '0'))
+    assert os.path.exists(os.path.join(project_dir, 'data'))
+    assert os.path.exists(os.path.join(project_dir, 'resources'))
+    assert os.path.exists(os.path.join(project_dir, 'trial.json'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'config.yaml'))
 
     # node line path check
     # 1. pre_retrieve_node_line
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'pre_retrieve_node_line'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'pre_retrieve_node_line', 'query_expansion'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'pre_retrieve_node_line', 'query_expansion', "0.parquet"))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'pre_retrieve_node_line', 'query_expansion', "1.parquet"))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'pre_retrieve_node_line', 'query_expansion', '2.parquet'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'pre_retrieve_node_line'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'pre_retrieve_node_line', 'query_expansion'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'pre_retrieve_node_line', 'query_expansion', "0.parquet"))
+    assert os.path.exists(os.path.join(project_dir, '0', 'pre_retrieve_node_line', 'query_expansion', "1.parquet"))
+    assert os.path.exists(os.path.join(project_dir, '0', 'pre_retrieve_node_line', 'query_expansion', '2.parquet'))
     # 2. retrieve_node_line
-    retrieval_node_line_path = os.path.join(os.getcwd(), '0', 'retrieve_node_line')
+    retrieval_node_line_path = os.path.join(project_dir, '0', 'retrieve_node_line')
     assert os.path.exists(retrieval_node_line_path)
     retrieval_node_path = os.path.join(retrieval_node_line_path, 'retrieval')
     assert os.path.exists(retrieval_node_path)
     assert all([os.path.exists(os.path.join(retrieval_node_path, f'{i}.parquet')) for i in range(8)])
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'passage_reranker'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'passage_reranker', '0.parquet'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'passage_reranker', '1.parquet'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'passage_compressor'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'passage_compressor', '0.parquet'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'retrieve_node_line', 'passage_reranker'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'retrieve_node_line', 'passage_reranker', '0.parquet'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'retrieve_node_line', 'passage_reranker', '1.parquet'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'retrieve_node_line', 'passage_compressor'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'retrieve_node_line', 'passage_compressor', '0.parquet'))
     # 3. post_retrieve_node_line
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'post_retrieve_node_line'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'post_retrieve_node_line', 'prompt_maker'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'post_retrieve_node_line', 'prompt_maker', '0.parquet'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'post_retrieve_node_line', 'prompt_maker', '1.parquet'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'post_retrieve_node_line', 'generator'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'post_retrieve_node_line', 'generator', '0.parquet'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'post_retrieve_node_line', 'generator', '1.parquet'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'post_retrieve_node_line', 'generator', '2.parquet'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'post_retrieve_node_line', 'generator', '3.parquet'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'post_retrieve_node_line', 'generator', '4.parquet'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'post_retrieve_node_line', 'generator', '5.parquet'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'post_retrieve_node_line'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'post_retrieve_node_line', 'prompt_maker'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'post_retrieve_node_line', 'prompt_maker', '0.parquet'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'post_retrieve_node_line', 'prompt_maker', '1.parquet'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'post_retrieve_node_line', 'generator'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'post_retrieve_node_line', 'generator', '0.parquet'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'post_retrieve_node_line', 'generator', '1.parquet'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'post_retrieve_node_line', 'generator', '2.parquet'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'post_retrieve_node_line', 'generator', '3.parquet'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'post_retrieve_node_line', 'generator', '4.parquet'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'post_retrieve_node_line', 'generator', '5.parquet'))
 
 
 def test_test_data_evaluate(test_evaluator):
@@ -199,20 +191,22 @@ def test_test_data_evaluate(test_evaluator):
         extract_best_config(trial_folder, yaml_file.name)
         test_evaluator.start_trial(yaml_file.name)
 
-    assert os.path.exists(os.path.join(os.getcwd(), '0'))
-    assert os.path.exists(os.path.join(os.getcwd(), 'data'))
-    assert os.path.exists(os.path.join(os.getcwd(), 'resources'))
-    assert os.path.exists(os.path.join(os.getcwd(), 'trial.json'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'config.yaml'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval', '0.parquet'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'retrieval', 'best_0.parquet'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'retrieve_node_line', 'summary.csv'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'pre_retrieve_node_line'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'pre_retrieve_node_line', 'query_expansion'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'pre_retrieve_node_line', 'query_expansion', "0.parquet"))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'post_retrieve_node_line'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'post_retrieve_node_line', 'prompt_maker'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'post_retrieve_node_line', 'generator'))
-    assert os.path.exists(os.path.join(os.getcwd(), '0', 'summary.csv'))
+    project_dir = test_evaluator.project_dir
+
+    assert os.path.exists(os.path.join(project_dir, '0'))
+    assert os.path.exists(os.path.join(project_dir, 'data'))
+    assert os.path.exists(os.path.join(project_dir, 'resources'))
+    assert os.path.exists(os.path.join(project_dir, 'trial.json'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'config.yaml'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'retrieve_node_line'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'retrieve_node_line', 'retrieval'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'retrieve_node_line', 'retrieval', '0.parquet'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'retrieve_node_line', 'retrieval', 'best_0.parquet'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'retrieve_node_line', 'summary.csv'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'pre_retrieve_node_line'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'pre_retrieve_node_line', 'query_expansion'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'pre_retrieve_node_line', 'query_expansion', "0.parquet"))
+    assert os.path.exists(os.path.join(project_dir, '0', 'post_retrieve_node_line'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'post_retrieve_node_line', 'prompt_maker'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'post_retrieve_node_line', 'generator'))
+    assert os.path.exists(os.path.join(project_dir, '0', 'summary.csv'))

--- a/tests/autorag/utils/test_util.py
+++ b/tests/autorag/utils/test_util.py
@@ -6,8 +6,8 @@ import tempfile
 
 import pandas as pd
 import pytest
-from llama_index.core.llms.types import CompletionResponse
-from llama_index.llms import MockLLM
+from llama_index.core.llms import CompletionResponse
+from llama_index.legacy.llms import MockLLM
 
 from autorag.utils import fetch_contents
 from autorag.utils.util import find_best_result_path, load_summary_file, result_to_dataframe, \


### PR DESCRIPTION
close this after merge #166 

close #164 

- Add `project_dir` option to `Evaluator` and `Runner` initialization.
- Add ‘—project_dir’ option to cli commands.
- Refactor test codes using temp directory.
- Add documentation about specify project directory.