### PR TITLE
Use native Rouge Scorer instead of huggingface evaluate + async operation + additional options

### DIFF
--- a/autorag/evaluate/metric/generation.py
+++ b/autorag/evaluate/metric/generation.py
@@ -6,6 +6,8 @@ import evaluate
 import sacrebleu
 from llama_index.core.embeddings import BaseEmbedding
 from openai import OpenAI
+from rouge_score import tokenizers
+from rouge_score.rouge_scorer import RougeScorer
 
 from autorag import embedding_models
 from autorag.evaluate.metric.util import calculate_cosine_similarity
@@ -76,7 +78,10 @@ def meteor(generation_gt: List[List[str]], generations: List[str]) -> List[float
     return result
 
 
-def rouge(generation_gt: List[List[str]], generations: List[str]) -> List[float]:
+def rouge(generation_gt: List[List[str]], generations: List[str],
+          rouge_type: Optional[str] = 'rougeL',
+          use_stemmer: bool = False,
+          split_summaries: bool = False) -> List[float]:
     """
     Compute rouge score for generation.
 
@@ -84,10 +89,26 @@ def rouge(generation_gt: List[List[str]], generations: List[str]) -> List[float]
             Must be 2-d list of string.
             Because it can be a multiple ground truth.
     :param generations: A list of generations that LLM generated.
+    :param rouge_type: A rouge type to use for evaluation.
+        Default is 'RougeL'.
+        Choose between rouge1, rouge2, rougeL, and rougeLSum.
+        - rouge1: unigram (1-gram) based scoring.
+        - rouge2: bigram (2-gram) based scoring.
+        - rougeL: Longest Common Subsequence based scoring.
+        - rougeLSum: splits text using "\n"
+    :param use_stemmer: Bool indicating whether Porter stemmer should be used to
+        strip word suffixes to improve matching. This arg is used in the
+        DefaultTokenizer, but other tokenizers might or might not choose to
+        use this. Default is False.
+    :param split_summaries: Whether to add newlines between sentences for rougeLsum.
+        Default is False.
     :return: A list of computed metric scores.
     """
-    rouge_instance = evaluate.load("rouge")
-    result = huggingface_evaluate(rouge_instance, 'rougeL', generation_gt, generations)
+    rouge_instance = RougeScorer(rouge_types=[rouge_type], use_stemmer=use_stemmer,
+                                 split_summaries=split_summaries,
+                                 tokenizer=tokenizers.DefaultTokenizer(use_stemmer))
+    result = list(map(lambda x: rouge_instance.score_multi(targets=x[0], prediction=x[1])[rouge_type].fmeasure,
+                      zip(generation_gt, generations)))
     del rouge_instance
     return result
 


### PR DESCRIPTION
close #177

It partially include #44. 

- add n-gram and other options in rouge score
- async operation at rouge
- do not raise any warning(logging info) about 'using default tokenizer'