### PR TITLE
Add vllm Module at generator

### DIFF
--- a/autorag/nodes/generator/__init__.py
+++ b/autorag/nodes/generator/__init__.py
@@ -1,1 +1,2 @@
 from .llama_index_llm import llama_index_llm
+from .vllm import vllm

--- a/autorag/nodes/generator/base.py
+++ b/autorag/nodes/generator/base.py
@@ -39,4 +39,10 @@ def generator_node(func):
             result = func(prompts=prompts, llm=llm_instance, batch=batch)
             del llm_instance
             return result
+        elif func.__name__ == 'vllm':
+            return func(prompts=prompts, llm=llm, **kwargs)
+        else:
+            raise ValueError(f"{func.__name__} is not a valid generator node name. "
+                             "Please check the generator node name.")
+
     return wrapper

--- a/autorag/nodes/generator/vllm.py
+++ b/autorag/nodes/generator/vllm.py
@@ -6,7 +6,9 @@ from typing import List, Tuple
 import torch
 
 from autorag.nodes.generator.base import generator_node
+import logging
 
+logger = logging.getLogger("AutoRAG")
 
 @generator_node
 def vllm(prompts: List[str], llm: str, **kwargs) -> Tuple[List[str], List[List[int]], List[List[float]]]:
@@ -39,14 +41,15 @@ def vllm(prompts: List[str], llm: str, **kwargs) -> Tuple[List[str], List[List[i
 
     generate_params = SamplingParams(**input_kwargs)
     results: List[RequestOutput] = vllm_model.generate(prompts, generate_params)
-    flatten_outputs = list(itertools.chain.from_iterable(list(map(lambda x: x.outputs, results))))
-    generated_texts = list(map(lambda x: x.text, flatten_outputs))
-    generated_token_ids = list(map(lambda x: x.token_ids, flatten_outputs))
-    log_probs: List[SampleLogprobs] = list(map(lambda x: x.logprobs, flatten_outputs))
+    generated_texts  = list(map(lambda x: x.outputs[0].text, results))
+    generated_token_ids = list(map(lambda x: x.outputs[0].token_ids, results))
+    log_probs: List[SampleLogprobs] = list(map(lambda x: x.outputs[0].logprobs, results))
+    logger.info(generated_texts)
     generated_log_probs = list(map(lambda x: list(map(
-        lambda y: y[0][y[1]].logprob, x
+        lambda y: y[0][y[1]], zip(x[0], x[1])
     )), zip(log_probs, generated_token_ids)))
     destroy_vllm_instance(vllm_model)
+    logger.info(generated_texts)
     return generated_texts, generated_token_ids, generated_log_probs
 
 

--- a/autorag/nodes/generator/vllm.py
+++ b/autorag/nodes/generator/vllm.py
@@ -37,7 +37,7 @@ def vllm(prompts: List[str], llm: str, **kwargs) -> Tuple[List[str], List[List[i
     flatten_outputs = list(itertools.chain.from_iterable(list(map(lambda x: x.outputs, results))))
     generated_texts = list(map(lambda x: x.text, flatten_outputs))
     generated_token_ids = list(map(lambda x: x.token_ids, flatten_outputs))
-    log_probs: List[SampleLogprobs] = list(map(lambda x: x.log_probs, flatten_outputs))
+    log_probs: List[SampleLogprobs] = list(map(lambda x: x.logprobs, flatten_outputs))
     generated_log_probs = list(map(lambda x: list(map(
         lambda y: y[0].logprob, x
     )), log_probs))

--- a/autorag/nodes/generator/vllm.py
+++ b/autorag/nodes/generator/vllm.py
@@ -1,0 +1,67 @@
+import inspect
+import itertools
+from copy import deepcopy
+from typing import List, Tuple
+
+import torch
+from vllm.outputs import RequestOutput
+from vllm.sequence import SampleLogprobs
+
+from autorag.nodes.generator.base import generator_node
+from vllm import LLM, SamplingParams
+
+
+@generator_node
+def vllm(prompts: List[str], llm: str, **kwargs) -> Tuple[List[str], List[List[int]], List[List[float]]]:
+    """
+    Vllm module.
+    It gets the VLLM instance, and returns generated texts by the input prompt.
+
+    :param prompts: A list of prompts.
+    :param llm: Model name of vLLM.
+    :param kwargs: The extra parameters for generating the text.
+    :return: A tuple of three elements.
+        The first element is a list of generated text.
+        The second element is a list of generated text's token ids.
+        The third element is a list of generated text's log probs.
+    """
+    input_kwargs = deepcopy(kwargs)
+    vllm_model = make_vllm_instance(llm, input_kwargs)
+
+    generate_params = SamplingParams(**input_kwargs)
+    results: List[RequestOutput] = vllm_model.generate(prompts, generate_params)
+    flatten_outputs = list(itertools.chain.from_iterable(list(map(lambda x: x.outputs, results))))
+    generated_texts = list(map(lambda x: x.text, flatten_outputs))
+    generated_token_ids = list(map(lambda x: x.token_ids, flatten_outputs))
+    log_probs: List[SampleLogprobs] = list(map(lambda x: x.log_probs, flatten_outputs))
+    generated_log_probs = list(map(lambda x: list(map(
+        lambda y: y[0].logprob, x
+    )), log_probs))
+    destroy_vllm_instance(vllm_model)
+    return generated_texts, generated_token_ids, generated_log_probs
+
+
+def make_vllm_instance(llm: str, input_args):
+    model_from_args = input_args.pop('model', None)
+    model = llm if model_from_args is None else model_from_args
+    init_params = inspect.signature(LLM.__init__).parameters.values()
+    keyword_init_params = [param.name for param in init_params if param.kind == param.KEYWORD_ONLY]
+    input_kwargs = {}
+    for param in keyword_init_params:
+        v = input_args.pop(param, None)
+        if v is not None:
+            input_kwargs[param] = v
+    return LLM(model, **input_kwargs)
+
+
+def destroy_vllm_instance(vllm_instance):
+    if torch.cuda.is_available():
+        from vllm.model_executor.parallel_utils.parallel_state import (
+            destroy_model_parallel,
+        )
+
+        destroy_model_parallel()
+        del vllm_instance
+        torch.cuda.synchronize()
+    else:
+        del vllm_instance

--- a/autorag/nodes/generator/vllm.py
+++ b/autorag/nodes/generator/vllm.py
@@ -1,14 +1,11 @@
 import inspect
-import itertools
 from copy import deepcopy
 from typing import List, Tuple
 
 import torch
 
 from autorag.nodes.generator.base import generator_node
-import logging
 
-logger = logging.getLogger("AutoRAG")
 
 @generator_node
 def vllm(prompts: List[str], llm: str, **kwargs) -> Tuple[List[str], List[List[int]], List[List[float]]]:
@@ -41,15 +38,13 @@ def vllm(prompts: List[str], llm: str, **kwargs) -> Tuple[List[str], List[List[i
 
     generate_params = SamplingParams(**input_kwargs)
     results: List[RequestOutput] = vllm_model.generate(prompts, generate_params)
-    generated_texts  = list(map(lambda x: x.outputs[0].text, results))
+    generated_texts = list(map(lambda x: x.outputs[0].text, results))
     generated_token_ids = list(map(lambda x: x.outputs[0].token_ids, results))
     log_probs: List[SampleLogprobs] = list(map(lambda x: x.outputs[0].logprobs, results))
-    logger.info(generated_texts)
     generated_log_probs = list(map(lambda x: list(map(
         lambda y: y[0][y[1]], zip(x[0], x[1])
     )), zip(log_probs, generated_token_ids)))
     destroy_vllm_instance(vllm_model)
-    logger.info(generated_texts)
     return generated_texts, generated_token_ids, generated_log_probs
 
 

--- a/autorag/nodes/generator/vllm.py
+++ b/autorag/nodes/generator/vllm.py
@@ -4,11 +4,8 @@ from copy import deepcopy
 from typing import List, Tuple
 
 import torch
-from vllm.outputs import RequestOutput
-from vllm.sequence import SampleLogprobs
 
 from autorag.nodes.generator.base import generator_node
-from vllm import LLM, SamplingParams
 
 
 @generator_node
@@ -25,6 +22,13 @@ def vllm(prompts: List[str], llm: str, **kwargs) -> Tuple[List[str], List[List[i
         The second element is a list of generated text's token ids.
         The third element is a list of generated text's log probs.
     """
+    try:
+        from vllm.outputs import RequestOutput
+        from vllm.sequence import SampleLogprobs
+        from vllm import LLM, SamplingParams
+    except ImportError:
+        raise ImportError("Please install vllm library. You can install it by running `pip install vllm`.")
+
     input_kwargs = deepcopy(kwargs)
     vllm_model = make_vllm_instance(llm, input_kwargs)
 
@@ -42,6 +46,7 @@ def vllm(prompts: List[str], llm: str, **kwargs) -> Tuple[List[str], List[List[i
 
 
 def make_vllm_instance(llm: str, input_args):
+    from vllm import LLM
     model_from_args = input_args.pop('model', None)
     model = llm if model_from_args is None else model_from_args
     init_params = inspect.signature(LLM.__init__).parameters.values()

--- a/autorag/support.py
+++ b/autorag/support.py
@@ -20,6 +20,7 @@ def get_support_modules(module_name: str) -> Callable:
         'vectordb': ('autorag.nodes.retrieval', 'vectordb'),
         'fstring': ('autorag.nodes.promptmaker', 'fstring'),
         'llama_index_llm': ('autorag.nodes.generator', 'llama_index_llm'),
+        'vllm': ('autorag.nodes.generator', 'vllm'),
         'tree_summarize': ('autorag.nodes.passagecompressor', 'tree_summarize'),
         'monot5': ('autorag.nodes.passagereranker', 'monot5'),
         'tart': ('autorag.nodes.passagereranker', 'tart'),

--- a/tests/autorag/nodes/generator/test_generator_base.py
+++ b/tests/autorag/nodes/generator/test_generator_base.py
@@ -4,6 +4,7 @@ prompts = [
     "Who is the president of the United States?",
 ]
 
+
 def check_generated_texts(generated_texts):
     assert len(generated_texts) == len(prompts)
     assert isinstance(generated_texts[0], str)

--- a/tests/autorag/nodes/generator/test_generator_base.py
+++ b/tests/autorag/nodes/generator/test_generator_base.py
@@ -1,0 +1,22 @@
+prompts = [
+    "Who is the strongest Avenger?",
+    "Who is the best soccer player in the world?",
+    "Who is the president of the United States?",
+]
+
+def check_generated_texts(generated_texts):
+    assert len(generated_texts) == len(prompts)
+    assert isinstance(generated_texts[0], str)
+    assert all(bool(text) is True for text in generated_texts)
+
+
+def check_generated_tokens(tokens):
+    assert len(tokens) == len(prompts)
+    assert isinstance(tokens[0], list)
+    assert isinstance(tokens[0][0], int)
+
+
+def check_generated_log_probs(log_probs):
+    assert len(log_probs) == len(prompts)
+    assert isinstance(log_probs[0], list)
+    assert isinstance(log_probs[0][0], float)

--- a/tests/autorag/nodes/generator/test_llama_index_llm.py
+++ b/tests/autorag/nodes/generator/test_llama_index_llm.py
@@ -2,32 +2,9 @@ import pandas as pd
 
 from autorag import generator_models
 from autorag.nodes.generator import llama_index_llm
+from tests.autorag.nodes.generator.test_generator_base import (prompts, check_generated_texts, check_generated_tokens,
+                                                               check_generated_log_probs)
 from tests.mock import MockLLM
-
-prompts = [
-    "Who is the strongest Avenger?",
-    "Who is the best soccer player in the world?",
-    "Who is the president of the United States?",
-]
-
-
-def check_generated_texts(generated_texts):
-    assert len(generated_texts) == len(prompts)
-    assert isinstance(generated_texts[0], str)
-    assert all(bool(text) is True for text in generated_texts)
-
-
-def check_generated_tokens(tokens):
-    assert len(tokens) == len(prompts)
-    assert isinstance(tokens[0], list)
-    assert isinstance(tokens[0][0], int)
-
-
-def check_generated_log_probs(log_probs):
-    assert len(log_probs) == len(prompts)
-    assert isinstance(log_probs[0], list)
-    assert isinstance(log_probs[0][0], float)
-    assert all(all(log_prob == 0.5 for log_prob in log_prob_list) for log_prob_list in log_probs)
 
 
 def test_llama_index_llm():
@@ -36,6 +13,7 @@ def test_llama_index_llm():
     check_generated_texts(answers)
     check_generated_tokens(tokens)
     check_generated_log_probs(log_probs)
+    assert all(all(log_prob == 0.5 for log_prob in log_prob_list) for log_prob_list in log_probs)
     assert all(len(tokens[i]) == len(log_probs[i]) for i in range(len(tokens)))
 
 

--- a/tests/autorag/nodes/generator/test_vllm.py
+++ b/tests/autorag/nodes/generator/test_vllm.py
@@ -1,0 +1,16 @@
+import pytest
+
+from autorag.nodes.generator import vllm
+from tests.autorag.nodes.generator.test_generator_base import (prompts, check_generated_texts, check_generated_tokens,
+                                                               check_generated_log_probs)
+
+
+@pytest.mark.skip(reason="vllm have to run with CUDA supported device.")
+def test_vllm():
+    answers, tokens, log_probs = vllm(
+        prompts, llm='facebook/opt-125m', max_tokens=5, temperature=0.5,
+    )
+    check_generated_texts(answers)
+    check_generated_tokens(tokens)
+    check_generated_log_probs(log_probs)
+    assert all(len(tokens[i]) == len(log_probs[i]) for i in range(len(tokens)))

--- a/tests/autorag/nodes/generator/test_vllm.py
+++ b/tests/autorag/nodes/generator/test_vllm.py
@@ -3,10 +3,11 @@ import pytest
 
 from autorag.nodes.generator import vllm
 from tests.autorag.nodes.generator.test_generator_base import (prompts, check_generated_texts, check_generated_tokens,
-                                                               check_generated_log_probs)
+                                                           check_generated_log_probs)
+import logging
 
+logger = logging.getLogger("AutoRAG")
 
-@pytest.mark.skip(reason="vllm have to run with CUDA supported device.")
 def test_vllm():
     previous_result = pd.DataFrame(
         {
@@ -17,6 +18,7 @@ def test_vllm():
         project_dir='.', previous_result=previous_result,
         llm='facebook/opt-125m', max_tokens=5, temperature=0.5,
     )
+    logger.info(f"answers : {answers}")
     check_generated_texts(answers)
     check_generated_tokens(tokens)
     check_generated_log_probs(log_probs)

--- a/tests/autorag/nodes/generator/test_vllm.py
+++ b/tests/autorag/nodes/generator/test_vllm.py
@@ -1,10 +1,12 @@
 import pandas as pd
+import pytest
 
 from autorag.nodes.generator import vllm
 from tests.autorag.nodes.generator.test_generator_base import (prompts, check_generated_texts, check_generated_tokens,
                                                                check_generated_log_probs)
 
 
+@pytest.mark.skip(reason="This test needs CUDA enabled machine with vllm installed.")
 def test_vllm():
     previous_result = pd.DataFrame(
         {

--- a/tests/autorag/nodes/generator/test_vllm.py
+++ b/tests/autorag/nodes/generator/test_vllm.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import pytest
 
 from autorag.nodes.generator import vllm
@@ -7,8 +8,14 @@ from tests.autorag.nodes.generator.test_generator_base import (prompts, check_ge
 
 @pytest.mark.skip(reason="vllm have to run with CUDA supported device.")
 def test_vllm():
+    previous_result = pd.DataFrame(
+        {
+            'prompts': prompts,
+            'qid': ['id-1', 'id-2', 'id-3']
+        })
     answers, tokens, log_probs = vllm(
-        prompts, llm='facebook/opt-125m', max_tokens=5, temperature=0.5,
+        project_dir='.', previous_result=previous_result,
+        llm='facebook/opt-125m', max_tokens=5, temperature=0.5,
     )
     check_generated_texts(answers)
     check_generated_tokens(tokens)

--- a/tests/autorag/nodes/generator/test_vllm.py
+++ b/tests/autorag/nodes/generator/test_vllm.py
@@ -1,12 +1,9 @@
 import pandas as pd
-import pytest
 
 from autorag.nodes.generator import vllm
 from tests.autorag.nodes.generator.test_generator_base import (prompts, check_generated_texts, check_generated_tokens,
-                                                           check_generated_log_probs)
-import logging
+                                                               check_generated_log_probs)
 
-logger = logging.getLogger("AutoRAG")
 
 def test_vllm():
     previous_result = pd.DataFrame(
@@ -14,12 +11,13 @@ def test_vllm():
             'prompts': prompts,
             'qid': ['id-1', 'id-2', 'id-3']
         })
-    answers, tokens, log_probs = vllm(
+    result_df = vllm(
         project_dir='.', previous_result=previous_result,
         llm='facebook/opt-125m', max_tokens=5, temperature=0.5,
     )
-    logger.info(f"answers : {answers}")
-    check_generated_texts(answers)
+    tokens = result_df['generated_tokens'].tolist()
+    log_probs = result_df['generated_log_probs'].tolist()
+    check_generated_texts(result_df['generated_texts'].tolist())
     check_generated_tokens(tokens)
     check_generated_log_probs(log_probs)
     assert all(len(tokens[i]) == len(log_probs[i]) for i in range(len(tokens)))


### PR DESCRIPTION
- add `vllm` module in the generator node
- input all prompts at once inside the vllm instance. It looks like it control prompts parallel processing itself. 
- Make vllm test file, simplify both vllm test code and llama_index llm test code.
- I tested in CUDA environment and it works great.

close #214