### PR TITLE
limit max length of all-mpnet-base-v2 model to 512 for preventing err…

### DIFF
--- a/autorag/__init__.py
+++ b/autorag/__init__.py
@@ -49,7 +49,8 @@ embedding_models = {
     'huggingface_baai_bge_small': LazyInit(HuggingFaceEmbedding, model_name="BAAI/bge-small-en-v1.5"),
     'huggingface_cointegrated_rubert_tiny2': LazyInit(HuggingFaceEmbedding, model_name="cointegrated/rubert-tiny2"),
     'huggingface_all_mpnet_base_v2': LazyInit(HuggingFaceEmbedding,
-                                              model_name="sentence-transformers/all-mpnet-base-v2")
+                                              model_name="sentence-transformers/all-mpnet-base-v2",
+                                              max_length=512, )
 }
 
 generator_models = {


### PR DESCRIPTION
…or at CUDA processing.

close #215

Please look at the description at the issue tab.
Actually LlamaIndex handles itself about token limit when embedding.
But all-mpnet-v2 models `config.json` was wrong. It does not working more than 512 token dimension.