### PR TITLE
Add additional options for bleu score.

### DIFF
--- a/autorag/evaluate/metric/generation.py
+++ b/autorag/evaluate/metric/generation.py
@@ -58,11 +58,11 @@ def huggingface_evaluate(instance, key: str,
 
 
 @generation_metric
-def bleu(gt: List[str], pred: str) -> float:
+def bleu(gt: List[str], pred: str, **kwargs) -> float:
     """
     Compute bleu score for generation.
     """
-    return sacrebleu.sentence_bleu(pred, gt).score
+    return sacrebleu.sentence_bleu(pred, gt, **kwargs).score
 
 
 def meteor(generation_gt: List[List[str]], generations: List[str]) -> List[float]:

--- a/tests/autorag/evaluate/metric/test_generation_metric.py
+++ b/tests/autorag/evaluate/metric/test_generation_metric.py
@@ -31,7 +31,7 @@ def test_bleu():
 
 
 def test_meteor():
-    base_test_generation_metrics(meteor, [0.853462, 0.5859375, 1.0])
+    base_test_generation_metrics(meteor, [0.454033, 0.2985435, 0.64077828], alpha=0.85, beta=0.2, gamma=0.6)
 
 
 def test_rouge():

--- a/tests/autorag/evaluate/metric/test_generation_metric.py
+++ b/tests/autorag/evaluate/metric/test_generation_metric.py
@@ -27,7 +27,7 @@ def base_test_generation_metrics(func, solution, **kwargs):
 
 
 def test_bleu():
-    base_test_generation_metrics(bleu, [51.1507, 23.5783, 100.0])
+    base_test_generation_metrics(bleu, [51.1507, 23.5783, 100.0], lowercase=True)
 
 
 def test_meteor():

--- a/tests/resources/full.yaml
+++ b/tests/resources/full.yaml
@@ -62,6 +62,7 @@ node_lines:
       strategy:
         metrics:
           - metric_name: bleu
+            lowercase: true
           - metric_name: meteor
           - metric_name: rouge
           - metric_name: sem_score


### PR DESCRIPTION
close #223
close #222

## Available parameters
:param smooth_method: The smoothing method to use ('floor', 'add-k', 'exp' or 'none')
:param smooth_value: The smoothing value for `floor` and `add-k` methods. `None` falls back to default value.
:param lowercase: Lowercase the data
:param tokenize: The tokenizer to use
:param use_effective_order: Don't take into account n-gram orders without any match.