### PR TITLE
Add colab tutorial 2 and Fix README to be viewable directly Youtube Tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ Plus, join our 📞 [Discord](https://discord.gg/P4DYXfmSAs) Community.
 
 ---
 
-📝 Colab Tutorial
+📌 Colab Tutorial
 - [Step 1: Auto optimize and deploy](https://colab.research.google.com/drive/19OEQXO_pHN6gnn2WdfPd4hjnS-4GurVd?usp=sharing)
 - [Step 2: Create evaluation dataset](https://colab.research.google.com/drive/1HXjVHCLTaX7mkmZp3IKlEPt0B3jVeHvP#scrollTo=cgFUCuaUZvTr)
 
 ---
-🎦 [Youtube Tutorial](https://youtu.be/2ojK8xjyXAU?si=UNYMXfXu-I1khoIh)
+🚨 Youtube Tutorial
+[![Youtube Tutorial](https://img.youtube.com/vi/2ojK8xjyXAU/0.jpg)](https://www.youtube.com/watch?v=2ojK8xjyXAU)
 
 # 📑 Index
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Plus, join our 📞 [Discord](https://discord.gg/P4DYXfmSAs) Community.
 
 📌 Colab Tutorial
 
-- [Step 1: Auto optimize and deploy](https://colab.research.google.com/drive/19OEQXO_pHN6gnn2WdfPd4hjnS-4GurVd?usp=sharing)
+- [Step 1: Basic of AutoRAG | Optimizing your RAG pipeline](https://colab.research.google.com/drive/19OEQXO_pHN6gnn2WdfPd4hjnS-4GurVd?usp=sharing)
 - [Step 2: Create evaluation dataset](https://colab.research.google.com/drive/1HXjVHCLTaX7mkmZp3IKlEPt0B3jVeHvP#scrollTo=cgFUCuaUZvTr)
 
 ---

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ Plus, join our 📞 [Discord](https://discord.gg/P4DYXfmSAs) Community.
 - [Step 2: Create evaluation dataset](https://colab.research.google.com/drive/1HXjVHCLTaX7mkmZp3IKlEPt0B3jVeHvP#scrollTo=cgFUCuaUZvTr)
 
 ---
-🚨 Youtube Tutorial
+🚨 YouTube Tutorial
 
 https://github.com/Marker-Inc-Korea/AutoRAG/assets/96727832/c0d23896-40c0-479f-a17b-aa2ec3183a26
 
 _Muted by default, enable sound for voice-over_
+
+You can see on [YouTube](https://youtu.be/2ojK8xjyXAU?feature=shared)
 
 # 📑 Index
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Plus, join our 📞 [Discord](https://discord.gg/P4DYXfmSAs) Community.
 ---
 🚨 Youtube Tutorial
 
-[![Youtube Tutorial](https://img.youtube.com/vi/2ojK8xjyXAU/0.jpg)](https://www.youtube.com/watch?v=2ojK8xjyXAU)
+https://github.com/Marker-Inc-Korea/AutoRAG/assets/96727832/c0d23896-40c0-479f-a17b-aa2ec3183a26
 
 # 📑 Index
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Plus, join our 📞 [Discord](https://discord.gg/P4DYXfmSAs) Community.
 ---
 🚨 Youtube Tutorial
 
-<iframe width="956" height="538" src="https://youtu.be/2ojK8xjyXAU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+[![Youtube Tutorial](https://img.youtube.com/vi/2ojK8xjyXAU/0.jpg)](https://www.youtube.com/watch?v=2ojK8xjyXAU)
 
 # 📑 Index
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ Plus, join our 📞 [Discord](https://discord.gg/P4DYXfmSAs) Community.
 ---
 
 📌 Colab Tutorial
+
 - [Step 1: Auto optimize and deploy](https://colab.research.google.com/drive/19OEQXO_pHN6gnn2WdfPd4hjnS-4GurVd?usp=sharing)
 - [Step 2: Create evaluation dataset](https://colab.research.google.com/drive/1HXjVHCLTaX7mkmZp3IKlEPt0B3jVeHvP#scrollTo=cgFUCuaUZvTr)
 
 ---
 🚨 Youtube Tutorial
-[![Youtube Tutorial](https://img.youtube.com/vi/2ojK8xjyXAU/0.jpg)](https://www.youtube.com/watch?v=2ojK8xjyXAU)
+
+<iframe width="956" height="538" src="https://youtu.be/2ojK8xjyXAU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 # 📑 Index
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ Explore our 📖 [Document](https://marker-inc-korea.github.io/AutoRAG/)!!
 
 Plus, join our 📞 [Discord](https://discord.gg/P4DYXfmSAs) Community.
 
-Colab Tutorial
+---
 
+📝 Colab Tutorial
 - [Step 1: Auto optimize and deploy](https://colab.research.google.com/drive/19OEQXO_pHN6gnn2WdfPd4hjnS-4GurVd?usp=sharing)
 - [Step 2: Create evaluation dataset](https://colab.research.google.com/drive/1HXjVHCLTaX7mkmZp3IKlEPt0B3jVeHvP#scrollTo=cgFUCuaUZvTr)
 
-=> [Youtube Tutorial](https://youtu.be/2ojK8xjyXAU?si=UNYMXfXu-I1khoIh)
+---
+🎦 [Youtube Tutorial](https://youtu.be/2ojK8xjyXAU?si=UNYMXfXu-I1khoIh)
 
 # 📑 Index
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Plus, join our 📞 [Discord](https://discord.gg/P4DYXfmSAs) Community.
 
 https://github.com/Marker-Inc-Korea/AutoRAG/assets/96727832/c0d23896-40c0-479f-a17b-aa2ec3183a26
 
+_Muted by default, enable sound for voice-over_
+
 # 📑 Index
 
 - [Introduction](#introduction)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ Explore our 📖 [Document](https://marker-inc-korea.github.io/AutoRAG/)!!
 
 Plus, join our 📞 [Discord](https://discord.gg/P4DYXfmSAs) Community.
 
-=> [Colab Tutorial](https://colab.research.google.com/drive/19OEQXO_pHN6gnn2WdfPd4hjnS-4GurVd?usp=sharing)
+Colab Tutorial
+
+- [Step 1: Auto optimize and deploy](https://colab.research.google.com/drive/19OEQXO_pHN6gnn2WdfPd4hjnS-4GurVd?usp=sharing)
+- [Step 2: Create evaluation dataset](https://colab.research.google.com/drive/1HXjVHCLTaX7mkmZp3IKlEPt0B3jVeHvP#scrollTo=cgFUCuaUZvTr)
 
 => [Youtube Tutorial](https://youtu.be/2ojK8xjyXAU?si=UNYMXfXu-I1khoIh)
 


### PR DESCRIPTION
close #256 
close #257 

- Add `extract_best_config` and `deploy` to tutorial Step 1
- Create tutorial Step 2: Create evaluation dataset
- Fix README to be viewable directly Youtube Tutorial

 + I didn't create `custom configs` because it didn't seem like a good fit for a colab tutorial.