### PR TITLE
Mock openai chat completion calls for preventing tons of openai usage.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           pip install -e .
       - name: Install dependencies
         run: |
-          pip install pytest pytest-xdist
+          pip install pytest pytest-xdist pytest-asyncio
       - name: delete tests package
         run: python3 tests/delete_tests.py
       - name: Run tests

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,3 +4,4 @@ twine
 build
 setuptools-scm
 pytest-xdist
+pytest-asyncio

--- a/tests/autorag/data/qacreation/test_base_qacreation.py
+++ b/tests/autorag/data/qacreation/test_base_qacreation.py
@@ -1,13 +1,17 @@
 import os
 import pathlib
+import re
 import tempfile
+from typing import Any
+from unittest.mock import patch
 
 import pandas as pd
 import pytest
-from llama_index.llms.openai import OpenAI
+from llama_index.core.base.llms.types import CompletionResponse
 
 from autorag.data.qacreation import make_single_content_qa, generate_qa_llama_index
 from autorag.utils import validate_qa_dataset
+from tests.mock import MockLLM
 
 root_dir = pathlib.PurePath(os.path.dirname(os.path.realpath(__file__))).parent.parent.parent
 resource_dir = os.path.join(root_dir, "resources")
@@ -19,6 +23,19 @@ def qa_parquet_filepath():
         yield f.name
 
 
+async def acomplete_qa_creation(self, messages, **kwargs: Any):
+    pattern = r'Output with (\d+) QnAs:'
+    matches = re.findall(pattern, messages)
+    num_questions = int(matches[-1])
+    return CompletionResponse(text=
+                              "[Q]: Is this the test question?\n[A]: Yes, this is the test answer." * num_questions)
+
+
+@patch.object(
+    MockLLM,
+    "acomplete",
+    acomplete_qa_creation,
+)
 def test_single_content_qa(qa_parquet_filepath):
     corpus_df = pd.read_parquet(os.path.join(resource_dir, "corpus_data_sample.parquet"))
     qa_df = make_single_content_qa(
@@ -26,15 +43,13 @@ def test_single_content_qa(qa_parquet_filepath):
         content_size=3,
         qa_creation_func=generate_qa_llama_index,
         output_filepath=qa_parquet_filepath,
-        llm=OpenAI(model="gpt-3.5-turbo", temperature=1.0),
+        llm=MockLLM(),
         question_num_per_content=2,
         upsert=True,
     )
     validate_qa_dataset(qa_df)
     assert len(qa_df) == 6
     assert qa_df['retrieval_gt'].tolist()[0] == qa_df['retrieval_gt'].tolist()[1]
-    assert qa_df['query'].tolist()[0] != qa_df['query'].tolist()[1]
-    assert qa_df['generation_gt'].tolist()[0] != qa_df['generation_gt'].tolist()[1]
 
     assert all([len(x) == 1 and len(x[0]) == 1 for x in qa_df['retrieval_gt'].tolist()])
     assert all([len(x) == 1 for x in qa_df['generation_gt'].tolist()])

--- a/tests/autorag/data/qacreation/test_simple.py
+++ b/tests/autorag/data/qacreation/test_simple.py
@@ -11,6 +11,7 @@ from autorag.data.corpus.llama_index import llama_documents_to_parquet
 from autorag.data.qacreation.simple import generate_simple_qa_dataset, generate_qa_row
 from autorag.data.utils.util import get_file_metadata
 from autorag.utils.preprocess import validate_qa_dataset, validate_corpus_dataset
+from tests.delete_tests import is_github_action
 
 root_dir = pathlib.PurePath(os.path.dirname(os.path.realpath(__file__))).parent.parent.parent
 
@@ -31,6 +32,7 @@ def output_filedir():
         yield temp_dir
 
 
+@pytest.mark.skipif(is_github_action(), reason="Skipping this test on GitHub Actions because it will be deprecated.")
 def test_generate_simple_qa_dataset(load_dir, output_filedir):
     loader = SimpleDirectoryReader(
         file_metadata=get_file_metadata,

--- a/tests/autorag/nodes/promptmaker/test_prompt_maker_run.py
+++ b/tests/autorag/nodes/promptmaker/test_prompt_maker_run.py
@@ -1,9 +1,12 @@
 import os
 import tempfile
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
 import pytest
+from llama_index.core.base.llms.types import CompletionResponse
+from llama_index.llms.openai import OpenAI
 
 from autorag import generator_models
 from autorag.evaluate.util import cast_metrics
@@ -119,6 +122,11 @@ def test_run_prompt_maker_node(node_line_dir):
     assert os.path.exists(os.path.join(node_line_dir, "prompt_maker", "1.parquet"))
 
 
+async def acomplete_qa_creation(*args, **kwargs):
+    return CompletionResponse(text="This is the test answer.")
+
+
+@patch.object(OpenAI, "acomplete", acomplete_qa_creation)
 def test_run_prompt_maker_node_default(node_line_dir):
     modules = [fstring, fstring]
     params = [{'prompt': 'Tell me something about the question: {query} \n\n {retrieved_contents}'},


### PR DESCRIPTION
close #333


## Add Mock object 

- test_single_content_qa
- test_async_qa_gen_llama_index
- test_qa_gen_llama_index
- test_qa_gen_llama_index_by_ratio
- test_evaluate_generation => mock G-eval
- test_run_prompt_maker_node_default
- test_restart_last_node
- test_restart_first_node

## Skip at github action

- test_generate_simple_qa_dataset 