### PR TITLE
Directly watch each module result at dashboard

### DIFF
--- a/autorag/dashboard.py
+++ b/autorag/dashboard.py
@@ -81,7 +81,7 @@ def node_view(node_dir: str):
 
     each_module_df_widget = pn.widgets.Tabulator(pd.DataFrame(columns=first_df.columns), name='Module DataFrame',
                                                  formatters=bokeh_formatters,
-                                                 pagination='local', page_size=20)
+                                                 pagination='local', page_size=20, widths=150)
 
     def change_module_widget(event):
         if event.column == 'detail':
@@ -91,7 +91,7 @@ def node_view(node_dir: str):
             each_module_df_widget.stream(each_module_df)
 
     df_widget = pn.widgets.Tabulator(summary_df, name='Summary DataFrame', formatters=bokeh_formatters,
-                                     buttons={'detail': '<i class="fa fa-eye"></i>'})
+                                     buttons={'detail': '<i class="fa fa-eye"></i>'}, widths=150)
     df_widget.on_click(change_module_widget)
 
     try:

--- a/autorag/dashboard.py
+++ b/autorag/dashboard.py
@@ -88,7 +88,7 @@ def node_view(node_dir: str):
             filename = summary_df['filename'].iloc[event.row]
             filepath = os.path.join(node_dir, filename)
             each_module_df = pd.read_parquet(filepath)
-            each_module_df_widget.stream(each_module_df)
+            each_module_df_widget.value = each_module_df
 
     df_widget = pn.widgets.Tabulator(summary_df, name='Summary DataFrame', formatters=bokeh_formatters,
                                      buttons={'detail': '<i class="fa fa-eye"></i>'}, widths=150)

--- a/tests/autorag/test_dashboard.py
+++ b/tests/autorag/test_dashboard.py
@@ -30,5 +30,6 @@ def test_make_trial_summary_md():
     assert bool(md_text)
 
 
+@pytest.mark.skip(reason="Can't stop this test on the github action or pytest cli setup")
 def test_dashboard_run():
     dashboard.run(sample_trial_dir)

--- a/tests/autorag/test_dashboard.py
+++ b/tests/autorag/test_dashboard.py
@@ -4,6 +4,7 @@ import pathlib
 import pandas as pd
 import pytest
 
+from autorag import dashboard
 from autorag.dashboard import get_metric_values, make_trial_summary_md
 
 root_dir = pathlib.PurePath(os.path.dirname(os.path.realpath(__file__))).parent
@@ -28,5 +29,6 @@ def test_make_trial_summary_md():
     md_text = make_trial_summary_md(sample_trial_dir)
     assert bool(md_text)
 
-# def test_dashboard_run():
-#     dashboard.run(sample_trial_dir)
+
+def test_dashboard_run():
+    dashboard.run(sample_trial_dir)


### PR DESCRIPTION
close #447

### Default
<img width="1696" alt="Screenshot 2024-06-06 at 4 53 47 PM" src="https://github.com/Marker-Inc-Korea/AutoRAG/assets/28955029/58e8e3bd-da57-46a1-87ad-4d308d6be8a8">

### When click eye icon

<img width="1696" alt="Screenshot 2024-06-06 at 4 54 04 PM" src="https://github.com/Marker-Inc-Korea/AutoRAG/assets/28955029/19b58c87-6aeb-410b-a8c3-23ff2b1a28f4">
