### PR TITLE
feat(__init__.py): add Ollama class to the list of generator models

### DIFF
--- a/autorag/__init__.py
+++ b/autorag/__init__.py
@@ -10,6 +10,7 @@ from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.embeddings.openai import OpenAIEmbeddingModelType
 from llama_index.llms.huggingface import HuggingFaceLLM
 from llama_index.llms.openai import OpenAI
+from llama_index.llms.ollama import Ollama
 from llama_index.llms.openai_like import OpenAILike
 from rich.logging import RichHandler
 from swifter import set_defaults
@@ -56,6 +57,7 @@ generator_models = {
     'openai': OpenAI,
     'huggingfacellm': HuggingFaceLLM,
     'openailike': OpenAILike,
+    'ollama': Ollama,
     'mock': MockLLM,
 }
 

--- a/docs/source/local_model.md
+++ b/docs/source/local_model.md
@@ -32,6 +32,7 @@ To change the LLM model type, you can change the `llm` parameter to the followin
 |         OpenAI          |         openai          |
 |     HuggingFaceLLM      |     huggingfacellm      |
 |       OpenAILike        |       openailike        |
+|        Ollama           |         ollama          |
 
 
 For example, if you want to use `OpenAILike` model, you can set `llm` parameter to `openailike`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ llama-index-embeddings-huggingface
 llama-index-llms-openai
 llama-index-llms-huggingface
 llama-index-llms-openai-like
-llama_index.llms.ollama
+llama-index-llms-ollama
 # Retriever
 llama-index-retrievers-bm25
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ llama-index-embeddings-huggingface
 llama-index-llms-openai
 llama-index-llms-huggingface
 llama-index-llms-openai-like
+llama_index.llms.ollama
 # Retriever
 llama-index-retrievers-bm25
 


### PR DESCRIPTION
This PR helps ensure that the `run_web` command works even when using ollama.