### PR TITLE
Resolve asyncio error at FastAPI server execution

### DIFF
--- a/autorag/deploy.py
+++ b/autorag/deploy.py
@@ -4,6 +4,7 @@ import uuid
 from copy import deepcopy
 from typing import Optional, Dict, List
 
+import nest_asyncio
 import pandas as pd
 import uvicorn
 import yaml
@@ -207,7 +208,7 @@ class Runner:
 
             {
                 "Query": "your query",
-                "result_column": "answer"
+                "result_column": "generated_texts"
             }
 
         And it returns json response like below:
@@ -222,10 +223,11 @@ class Runner:
         :param port: The port of the api server.
         :param kwargs: Other arguments for uvicorn.run.
         """
+        nest_asyncio.apply()
         logger.info(f"Run api server at {host}:{port}")
-        uvicorn.run(self.app, host=host, port=port, **kwargs)
+        uvicorn.run(self.app, host=host, port=port, loop="asyncio", **kwargs)
 
 
 class RunnerInput(BaseModel):
     query: str
-    result_column: str = "answer"
+    result_column: str = "generated_texts"

--- a/tests/autorag/test_cli.py
+++ b/tests/autorag/test_cli.py
@@ -39,6 +39,8 @@ def test_validator_cli():
 
 
 def test_run_api():
+    # This test code only tests cli function, not API server itself
+    # If you are looking for API server test code, please go to test_deploy.py test_runner_api_server()
     runner = CliRunner()
     result = runner.invoke(cli, ['run_api', '--config_path', 'test/path/test.yaml',
                                  '--host', '0.0.0.0', '--port', '8080'])

--- a/tests/autorag/test_deploy.py
+++ b/tests/autorag/test_deploy.py
@@ -173,8 +173,6 @@ def test_runner_full(evaluator):
 def test_runner_api_server(evaluator):
     os.environ['BM25'] = 'bm25'
     project_dir = evaluator.project_dir
-    import nest_asyncio
-    nest_asyncio.apply()
     evaluator.start_trial(os.path.join(resource_dir, 'simple.yaml'))
     runner = Runner.from_trial_folder(os.path.join(project_dir, '0'))
 


### PR DESCRIPTION
close #609

- add loop parameter at `uvicorn.run` for resolving error
- add nest_asyncio.apply at running api server code.
- delete nest_asyncio.apply at test code