### PR TITLE
fix ```Ollama``` default request_timeout from 30 to 3000

### DIFF
--- a/autorag/__init__.py
+++ b/autorag/__init__.py
@@ -63,11 +63,15 @@ embedding_models = {
 	"huggingface_bge_m3": LazyInit(HuggingFaceEmbedding, model_name="BAAI/bge-m3"),
 }
 
+class CustomOllama(Ollama):
+    def __init__(self, **kwargs):
+        super().__init__(request_timeout=3000, **kwargs)
+
 generator_models = {
 	"openai": OpenAI,
 	"huggingfacellm": HuggingFaceLLM,
 	"openailike": OpenAILike,
-	"ollama": Ollama,
+	"ollama": CustomOllama,
 	"mock": MockLLM,
 }
 


### PR DESCRIPTION
Relevant Issue
- #636 


It seems that the issue is related to the default setting of ```DEFAULT_REQUEST_TIMEOUT = 30.0``` in ```llama_index.llms.ollama```. When loading a model with [ollama](https://ollama.com/) and performing inference, if the process takes longer than 30 seconds, the coroutine fails to await and the request is immediately terminated.

To temporarily resolve this issue, you can either modify ```DEFAULT_REQUEST_TIMEOUT = 30.0``` in ```llama_index.llms.ollama.base``` (e.g., change it to 3000.0), or set the request_timeout in the config.yaml file under the generator node.

```
      modules:
        - module_type: llama_index_llm
          llm: ollama
          model: qwen2:72b
          temperature: 0.7
          request_timeout: 3000
          batch: 1
```

This PR temporarily changes the default ```request_timeout``` of the ```Ollama``` class to 3000 seconds.