### PR TITLE
Replace FastAPI with Flask

### DIFF
--- a/autorag/deploy.py
+++ b/autorag/deploy.py
@@ -221,7 +221,7 @@ class Runner:
 		.. Code:: json
 
 		    {
-		        "Query": "your query",
+		        "query": "your query",
 		        "result_column": "generated_texts"
 		    }
 
@@ -235,7 +235,7 @@ class Runner:
 
 		:param host: The host of the api server.
 		:param port: The port of the api server.
-		:param kwargs: Other arguments for uvicorn.run.
+		:param kwargs: Other arguments for Flask app.run.
 		"""
 		logger.info(f"Run api server at {host}:{port}")
 		self.app.run(host=host, port=port, **kwargs)

--- a/autorag/deploy.py
+++ b/autorag/deploy.py
@@ -4,13 +4,11 @@ import uuid
 from copy import deepcopy
 from typing import Optional, Dict, List
 
-import nest_asyncio
 import pandas as pd
-import uvicorn
 import yaml
-from fastapi import FastAPI
 from pydantic import BaseModel
 import gradio as gr
+from flask import Flask, request
 
 from autorag.support import get_support_modules
 from autorag.utils.util import load_summary_file
@@ -128,7 +126,7 @@ class Runner:
 	def __init__(self, config: Dict, project_dir: Optional[str] = None):
 		self.config = config
 		self.project_dir = os.getcwd() if project_dir is None else project_dir
-		self.app = FastAPI()
+		self.app = Flask(__name__)
 		self.__add_api_route()
 
 	@classmethod
@@ -207,8 +205,9 @@ class Runner:
 		return previous_result[result_column].tolist()[0]
 
 	def __add_api_route(self):
-		@self.app.post("/run")
-		async def run_pipeline(runner_input: RunnerInput):
+		@self.app.route("/run", methods=["POST"])
+		def run_pipeline():
+			runner_input = RunnerInput(**request.json)
 			query = runner_input.query
 			result_column = runner_input.result_column
 			result = self.run(query, result_column)
@@ -238,9 +237,8 @@ class Runner:
 		:param port: The port of the api server.
 		:param kwargs: Other arguments for uvicorn.run.
 		"""
-		nest_asyncio.apply()
 		logger.info(f"Run api server at {host}:{port}")
-		uvicorn.run(self.app, host=host, port=port, loop="asyncio", **kwargs)
+		self.app.run(host=host, port=port, **kwargs)
 
 	def run_web(
 		self,

--- a/autorag/web.py
+++ b/autorag/web.py
@@ -70,9 +70,6 @@ def chat_box(runner: Runner):
 def run_web_server(
 	yaml_path: Optional[str], project_dir: Optional[str], trial_path: Optional[str]
 ):
-	import nest_asyncio
-
-	nest_asyncio.apply()
 	runner = get_runner(yaml_path, project_dir, trial_path)
 	set_initial_state()
 	set_page_config()

--- a/docs/source/deploy/api_endpoint.md
+++ b/docs/source/deploy/api_endpoint.md
@@ -2,8 +2,8 @@
 myst:
    html_meta:
       title: AutoRAG - Deploy API endpoint
-      description: Learn how to deploy optimized RAG pipeline to FastAPI API server in AutoRAG
-      keywords: AutoRAG,RAG,RAG deploy,RAG API,FastAPI
+      description: Learn how to deploy optimized RAG pipeline to Flask API server in AutoRAG
+      keywords: AutoRAG,RAG,RAG deploy,RAG API,Flask
 ---
 # API endpoint
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,7 +36,7 @@ AutoRAG supports
 
 - **Data Creation**: Create RAG evaluation data with your own raw documents.
 - **Optimization**: Automatically run experiments to find the best RAG pipeline for your own data.
-- **Deployment**: Deploy the best RAG pipeline with single yaml file. Supports FastAPI server as well.
+- **Deployment**: Deploy the best RAG pipeline with single yaml file. Supports Flask server as well.
 
 🏃‍♂️ Getting Started
 ************************************

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,6 @@ rouge_score  # for rouge score
 rich  # for pretty logging
 chromadb>=0.5.0 # for vectordb retrieval
 click  # for cli
-fastapi  # for api server
-uvicorn  # for api server
 Flask # for api server
 torch  # for monot5 reranker
 sentencepiece  # for monot5 reranker

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ chromadb>=0.5.0 # for vectordb retrieval
 click  # for cli
 fastapi  # for api server
 uvicorn  # for api server
+Flask # for api server
 torch  # for monot5 reranker
 sentencepiece  # for monot5 reranker
 guidance # for qa data creation

--- a/tests/autorag/test_deploy.py
+++ b/tests/autorag/test_deploy.py
@@ -2,11 +2,9 @@ import os
 import pathlib
 import tempfile
 
-import nest_asyncio
 import pandas as pd
 import pytest
 import yaml
-from fastapi.testclient import TestClient
 
 from autorag.deploy import (
 	summary_df_to_yaml,
@@ -194,13 +192,12 @@ def test_runner_full(evaluator):
 
 
 def test_runner_api_server(evaluator):
-	nest_asyncio.apply()
 	os.environ["BM25"] = "bm25"
 	project_dir = evaluator.project_dir
 	evaluator.start_trial(os.path.join(resource_dir, "simple.yaml"))
 	runner = Runner.from_trial_folder(os.path.join(project_dir, "0"))
 
-	client = TestClient(runner.app)
+	client = runner.app.test_client()
 
 	# Use the TestClient to make a request to the server
 	response = client.post(
@@ -211,8 +208,8 @@ def test_runner_api_server(evaluator):
 		},
 	)
 	assert response.status_code == 200
-	assert "retrieved_contents" in response.json()
-	retrieved_contents = response.json()["retrieved_contents"]
+	assert "retrieved_contents" in response.json
+	retrieved_contents = response.json["retrieved_contents"]
 	assert len(retrieved_contents) == 1
 	assert isinstance(retrieved_contents, list)
 	assert isinstance(retrieved_contents[0], str)


### PR DESCRIPTION
close #640 

- FastAPI makes it impossible to avoid asyncio event loop crashes without nest_asyncio.  
- To delete nest_asyncio dependency, I replace FastAPI with Flask.  
- Flask doesn't run the event loop itself, which fundamentally solves this issue.
