### PR TITLE
replace yaml.dump with yaml.safe_dump

### DIFF
--- a/autorag/dashboard.py
+++ b/autorag/dashboard.py
@@ -167,7 +167,7 @@ def yaml_to_markdown(yaml_filepath):
 	with open(yaml_filepath, "r", encoding="utf-8") as file:
 		try:
 			content = yaml.safe_load(file)
-			markdown_content += f"## {os.path.basename(yaml_filepath)}\n```yaml\n{yaml.dump(content, allow_unicode=True)}\n```\n\n"
+			markdown_content += f"## {os.path.basename(yaml_filepath)}\n```yaml\n{yaml.safe_dump(content, allow_unicode=True)}\n```\n\n"
 		except yaml.YAMLError as exc:
 			print(f"Error in {yaml_filepath}: {exc}")
 	return markdown_content

--- a/autorag/deploy.py
+++ b/autorag/deploy.py
@@ -118,7 +118,7 @@ def extract_best_config(trial_path: str, output_path: Optional[str] = None) -> D
 	yaml_dict = summary_df_to_yaml(trial_summary_df, config_dict)
 	if output_path is not None:
 		with open(output_path, "w") as f:
-			yaml.dump(yaml_dict, f)
+			yaml.safe_dump(yaml_dict, f)
 	return yaml_dict
 
 

--- a/tests/autorag/test_deploy.py
+++ b/tests/autorag/test_deploy.py
@@ -112,7 +112,7 @@ def pseudo_trial_path():
 		os.makedirs(trial_path)
 		summary_df.to_csv(os.path.join(trial_path, "summary.csv"), index=False)
 		with open(os.path.join(trial_path, "config.yaml"), "w") as f:
-			yaml.dump(solution_dict, f)
+			yaml.safe_dump(solution_dict, f)
 		yield trial_path
 
 


### PR DESCRIPTION
close #647 

As a default, `yaml.dump()` generates yaml tag such as `!!python/tuple`. But `yaml.safe_load()` cannot parse such language specific tag. Using `yaml.safe_dump()` instead, avoid generating language specific tag.