### PR TITLE
Compatible with Langchain version 0.3.0

### DIFF
--- a/autorag/__init__.py
+++ b/autorag/__init__.py
@@ -15,7 +15,7 @@ from llama_index.llms.huggingface import HuggingFaceLLM
 from llama_index.llms.ollama import Ollama
 from llama_index.llms.openai import OpenAI
 from llama_index.llms.openai_like import OpenAILike
-from langchain.embeddings import OpenAIEmbeddings
+from langchain_openai.embeddings import OpenAIEmbeddings
 from rich.logging import RichHandler
 
 version_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "VERSION")

--- a/autorag/data/__init__.py
+++ b/autorag/data/__init__.py
@@ -15,7 +15,7 @@ from langchain_community.document_loaders import (
 	DirectoryLoader,
 )
 from langchain_unstructured import UnstructuredLoader
-from langchain_upstage import UpstageLayoutAnalysisLoader
+from langchain_upstage import UpstageDocumentParseLoader
 
 from llama_index.core.node_parser import (
 	TokenTextSplitter,
@@ -56,7 +56,7 @@ parse_modules = {
 	# 6. All files
 	"directory": DirectoryLoader,
 	"unstructured": UnstructuredLoader,
-	"upstagelayoutanalysis": UpstageLayoutAnalysisLoader,
+	"upstagedocumentparse": UpstageDocumentParseLoader,
 }
 
 chunk_modules = {

--- a/autorag/data/parse/clova.py
+++ b/autorag/data/parse/clova.py
@@ -16,7 +16,7 @@ def clova_ocr(
 	data_path_list: List[str],
 	url: Optional[str] = None,
 	api_key: Optional[str] = None,
-	batch: int = 8,
+	batch: int = 5,
 	table_detection: bool = False,
 ) -> Tuple[List[str], List[str], List[int]]:
 	"""


### PR DESCRIPTION
close #721 
close #723

- Compatible with Langchain version 0.3.0
- Change UpstageLayoutAnalysis to DocumentParse
- Change clova default batch 8 to 5
-> Because clova's says it can only process 5 in a second