### PR TITLE
Prevent error that httpx uses different event loop at method chaining on the QA 

### DIFF
--- a/docs/source/data_creation/data_creation.md
+++ b/docs/source/data_creation/data_creation.md
@@ -1,14 +1,5 @@
 # Data Creation
 
-```{warning}
-This is the beta version of new Data Creation.
-This will be the main data creation pipeline at the AutoRAG v0.3 release.
-At the time, the legacy version of data creation will be deprecated.
-
-Plus, It is developing version. So there are some features that doesn't implemented yet.
-And have potential bugs.
-```
-
 Data creation is the crucial process to use AutoRAG. Because AutoRAG needs an evaluation dataset for optimizing the RAG pipelines.
 The following guide covers how to use LLM to create data in a form that AutoRAG can use.
 

--- a/docs/source/data_creation/qa_creation/answer_gen.md
+++ b/docs/source/data_creation/qa_creation/answer_gen.md
@@ -19,9 +19,8 @@ from autorag.data.qa.schema import QA
 from autorag.data.qa.generation_gt.openai_gen_gt import make_basic_gen_gt
 from openai import AsyncOpenAI
 
-client = AsyncOpenAI()
 qa = QA(qa_df)
-result_qa = qa.batch_apply(make_basic_gen_gt, client=client)
+result_qa = qa.batch_apply(make_basic_gen_gt, client=AsyncOpenAI())
 ```
 
 ### LlamaIndex
@@ -48,9 +47,8 @@ from autorag.data.qa.schema import QA
 from autorag.data.qa.generation_gt.openai_gen_gt import make_concise_gen_gt
 from openai import AsyncOpenAI
 
-client = AsyncOpenAI()
 qa = QA(qa_df)
-result_qa = qa.batch_apply(make_concise_gen_gt, client=client)
+result_qa = qa.batch_apply(make_concise_gen_gt, client=AsyncOpenAI())
 ```
 
 ### LlamaIndex

--- a/docs/source/data_creation/qa_creation/filter.md
+++ b/docs/source/data_creation/qa_creation/filter.md
@@ -52,9 +52,8 @@ from openai import AsyncOpenAI
 from autorag.data.qa.schema import QA
 from autorag.data.qa.filter.dontknow import dontknow_filter_openai
 
-openai_client = AsyncOpenAI()
 qa = QA(qa_df, corpus)
-filtered_qa = qa.batch_filter(dontknow_filter_openai, client=openai_client, lang="en").map(
+filtered_qa = qa.batch_filter(dontknow_filter_openai, client=AsyncOpenAI(), lang="en").map(
     lambda df: df.reset_index(drop=True)  # reset index
 )
 ```
@@ -92,10 +91,9 @@ from openai import AsyncOpenAI
 from autorag.data.qa.schema import QA
 from autorag.data.qa.filter.passage_dependency import passage_dependency_filter_openai
 
-client = AsyncOpenAI()
 en_qa = QA(en_qa_df)
 result_en_qa = en_qa.batch_filter(
-    passage_dependency_filter_openai, client=client, lang="en"
+    passage_dependency_filter_openai, client=AsyncOpenAI(), lang="en"
 ).map(lambda df: df.reset_index(drop=True))
 ```
 

--- a/docs/source/data_creation/qa_creation/query_gen.md
+++ b/docs/source/data_creation/qa_creation/query_gen.md
@@ -40,9 +40,8 @@ from openai import AsyncOpenAI
 from autorag.data.qa.schema import QA
 from autorag.data.qa.query.openai_gen_query import factoid_query_gen
 
-openai_client = AsyncOpenAI()
 qa = QA(qa_df)
-result_qa = qa.batch_apply(factoid_query_gen, client=openai_client, lang="ko")
+result_qa = qa.batch_apply(factoid_query_gen, client=AsyncOpenAI(), lang="ko")
 ```
 
 - LlamaIndex
@@ -71,9 +70,8 @@ from openai import AsyncOpenAI
 from autorag.data.qa.schema import QA
 from autorag.data.qa.query.openai_gen_query import concept_completion_query_gen
 
-openai_client = AsyncOpenAI()
 qa = QA(qa_df)
-result_qa = qa.batch_apply(concept_completion_query_gen, client=openai_client, lang="ko")
+result_qa = qa.batch_apply(concept_completion_query_gen, client=AsyncOpenAI(), lang="ko")
 ```
 
 - LlamaIndex
@@ -114,9 +112,8 @@ from openai import AsyncOpenAI
 from autorag.data.qa.schema import QA
 from autorag.data.qa.query.openai_gen_query import two_hop_incremental
 
-openai_client = AsyncOpenAI()
 qa = QA(qa_df)
-result_qa = qa.batch_apply(two_hop_incremental, client=openai_client)
+result_qa = qa.batch_apply(two_hop_incremental, client=AsyncOpenAI())
 ```
 
 - LlamaIndex


### PR DESCRIPTION
close #782

- Fix documentations
- Add test case

<Why did I didn't resolve it completely?>
Actually, I didn't resolve the issue. 
But, it is quite simple to resolve because you just use different AsyncClient at the each functions.

### Why this bug happened?

I think the most possible option is httpx connection pooling. httpx has this feature that stays SSL connection to the server for improving speed. Because of that, after request the connection maybe alive. 
But after we run other request right after it, it occured different event loop error. The error happened in connection pooling code, and I don't know why but the bug trace contained anyio. 
So might be anyio initialize different event loop from other thread, not OS thread, and try to use it on the new client connection. And get the collision??

But I didn't know why they are using anyio, and how to fix that.

Actually the simplest solution was the use different instance on the different methods. And the speed is not that effected (almost no effect) but no errors anymore.

So I just changed documentation and add test case zz

---

This pull request includes several changes to the `docs/source/data_creation` documentation and the `tests/autorag/data/qa/test_data_creation_piepline.py` test file. The main focus is on improving the usage of the `AsyncOpenAI` client and adding new tests.

### Documentation Improvements:
* Removed outdated warning about the beta version of Data Creation in `docs/source/data_creation/data_creation.md`.
* Simplified client instantiation by directly using `AsyncOpenAI()` in various documentation files (`qa_creation/answer_gen.md`, `qa_creation/filter.md`, `qa_creation/query_gen.md`). [[1]](diffhunk://#diff-dab26bf5786c8cc94485b31154519b3959d9e50626cec5385cc3c8b411cb4593L22-R23) [[2]](diffhunk://#diff-dab26bf5786c8cc94485b31154519b3959d9e50626cec5385cc3c8b411cb4593L51-R51) [[3]](diffhunk://#diff-bc16d15690cdb1e8d7a47435e379676dec6ce57626da5a67fddbd8b66ec753b7L55-R56) [[4]](diffhunk://#diff-bc16d15690cdb1e8d7a47435e379676dec6ce57626da5a67fddbd8b66ec753b7L95-R96) [[5]](diffhunk://#diff-6a6ac033e386e85834f8bc33d6646c46acb6501734163bd0c9fefead25112c3eL43-R44) [[6]](diffhunk://#diff-6a6ac033e386e85834f8bc33d6646c46acb6501734163bd0c9fefead25112c3eL74-R74) [[7]](diffhunk://#diff-6a6ac033e386e85834f8bc33d6646c46acb6501734163bd0c9fefead25112c3eL117-R116)

### Testing Enhancements:
* Added `pytest` and `AsyncOpenAI` imports to `tests/autorag/data/qa/test_data_creation_piepline.py`.
* Introduced a new test `test_make_dataset_from_raw_openai` to validate the data creation pipeline using `AsyncOpenAI`, with a conditional skip for GitHub Actions.