### PR TITLE
Properly truncate to 8000 tokens when we use OpenAI Embeddings

### DIFF
--- a/autorag/data/legacy/qacreation/base.py
+++ b/autorag/data/legacy/qacreation/base.py
@@ -166,7 +166,7 @@ def make_qa_with_existing_qa(
 		content_size = len(corpus_df)
 
 	logger.info("Loading local embedding model...")
-	embeddings = autorag.embedding_models[embedding_model]
+	embeddings = autorag.embedding_models[embedding_model]()
 
 	# Vector DB creation
 	if collection is None:

--- a/autorag/evaluation/metric/generation.py
+++ b/autorag/evaluation/metric/generation.py
@@ -330,7 +330,7 @@ def sem_score(
 	generations = [metric_input.generated_texts for metric_input in metric_inputs]
 	generation_gt = [metric_input.generation_gt for metric_input in metric_inputs]
 	if embedding_model is None:
-		embedding_model = embedding_models["huggingface_all_mpnet_base_v2"]
+		embedding_model = embedding_models["huggingface_all_mpnet_base_v2"]()
 
 	embedding_model.embed_batch_size = batch
 

--- a/autorag/evaluation/metric/generation.py
+++ b/autorag/evaluation/metric/generation.py
@@ -334,7 +334,7 @@ def sem_score(
 
 	embedding_model.embed_batch_size = batch
 
-	openai_embedding_max_length = 8191
+	openai_embedding_max_length = 8000
 	if isinstance(embedding_model, OpenAIEmbedding):
 		generations = openai_truncate_by_token(
 			generations, openai_embedding_max_length, embedding_model.model_name

--- a/autorag/evaluation/util.py
+++ b/autorag/evaluation/util.py
@@ -38,6 +38,6 @@ def cast_metrics(
 
 def cast_embedding_model(key, value):
 	if key == "embedding_model":
-		return key, embedding_models[value]
+		return key, embedding_models[value]()
 	else:
 		return key, value

--- a/autorag/evaluator.py
+++ b/autorag/evaluator.py
@@ -220,7 +220,7 @@ class Evaluator:
 				)
 				# get embedding_model
 				if embedding_model_str in embedding_models:
-					embedding_model = embedding_models[embedding_model_str]
+					embedding_model = embedding_models[embedding_model_str]()
 				else:
 					logger.error(
 						f"embedding_model_str {embedding_model_str} does not exist."

--- a/autorag/nodes/passageaugmenter/prev_next_augmenter.py
+++ b/autorag/nodes/passageaugmenter/prev_next_augmenter.py
@@ -35,7 +35,7 @@ class PrevNextPassageAugmenter(BasePassageAugmenter):
 		self.slim_corpus_df = slim_corpus_df
 
 		# init embedding model
-		self.embedding_model = embedding_models[embedding_model]
+		self.embedding_model = embedding_models[embedding_model]()
 
 	def __del__(self):
 		del self.embedding_model

--- a/autorag/nodes/passagefilter/similarity_percentile_cutoff.py
+++ b/autorag/nodes/passagefilter/similarity_percentile_cutoff.py
@@ -25,7 +25,7 @@ class SimilarityPercentileCutoff(BasePassageFilter):
 		"""
 		super().__init__(project_dir, *args, **kwargs)
 		embedding_model_str = kwargs.pop("embedding_model", "openai")
-		self.embedding_model = embedding_models[embedding_model_str]
+		self.embedding_model = embedding_models[embedding_model_str]()
 
 	def __del__(self):
 		super().__del__()

--- a/autorag/nodes/passagefilter/similarity_threshold_cutoff.py
+++ b/autorag/nodes/passagefilter/similarity_threshold_cutoff.py
@@ -21,7 +21,7 @@ class SimilarityThresholdCutoff(BasePassageFilter):
 		"""
 		super().__init__(project_dir, *args, **kwargs)
 		embedding_model_str = kwargs.pop("embedding_model", "openai")
-		self.embedding_model = embedding_models[embedding_model_str]
+		self.embedding_model = embedding_models[embedding_model_str]()
 
 	def __del__(self):
 		super().__del__()

--- a/autorag/nodes/retrieval/vectordb.py
+++ b/autorag/nodes/retrieval/vectordb.py
@@ -106,7 +106,7 @@ class VectorDB(BaseRetrieval):
 			self.chroma_collection.count() > 0
 		), "collection must contain at least one document. Please check you ingested collection correctly."
 		# truncate queries and embedding execution here.
-		openai_embedding_limit = 8191
+		openai_embedding_limit = 8000
 		if isinstance(self.embedding_model, OpenAIEmbedding):
 			queries = list(
 				map(
@@ -195,7 +195,7 @@ def vectordb_ingest(
 ):
 	"""
 	Ingest given corpus data to the chromadb collection.
-	It truncates corpus content when the embedding model is OpenAIEmbedding to the 8191 tokens.
+	It truncates corpus content when the embedding model is OpenAIEmbedding to the 8000 tokens.
 	Plus, when the corpus content is empty (whitespace), it will be ignored.
 	And if there is a document id that already exists in the collection, it will be ignored.
 
@@ -220,9 +220,7 @@ def vectordb_ingest(
 
 		# truncate by token if embedding_model is OpenAIEmbedding
 		if isinstance(embedding_model, OpenAIEmbedding):
-			openai_embedding_limit = (
-				8191  # all openai embedding models have 8191 max token input
-			)
+			openai_embedding_limit = 8000
 			new_contents = openai_truncate_by_token(
 				new_contents, openai_embedding_limit, embedding_model.model_name
 			)

--- a/autorag/nodes/retrieval/vectordb.py
+++ b/autorag/nodes/retrieval/vectordb.py
@@ -56,7 +56,7 @@ class VectorDB(BaseRetrieval):
 
 		# init embedding model
 		if embedding_model in embedding_models:
-			self.embedding_model = embedding_models[embedding_model]
+			self.embedding_model = embedding_models[embedding_model]()
 		else:
 			logger.error(f"embedding_model_str {embedding_model} does not exist.")
 			raise KeyError(f"embedding_model_str {embedding_model} does not exist.")

--- a/autorag/utils/util.py
+++ b/autorag/utils/util.py
@@ -499,7 +499,7 @@ def embedding_query_content(
 	flatten_contents = list(itertools.chain.from_iterable(contents_list))
 
 	openai_embedding_limit = 8000  # all openai embedding model has 8000 max token input
-	if isinstance(embedding_model._instance, OpenAIEmbedding):
+	if isinstance(embedding_model, OpenAIEmbedding):
 		queries = openai_truncate_by_token(
 			queries, openai_embedding_limit, embedding_model.model_name
 		)

--- a/autorag/utils/util.py
+++ b/autorag/utils/util.py
@@ -499,7 +499,7 @@ def embedding_query_content(
 	flatten_contents = list(itertools.chain.from_iterable(contents_list))
 
 	openai_embedding_limit = 8191  # all openai embedding model has 8191 max token input
-	if isinstance(embedding_model, OpenAIEmbedding):
+	if isinstance(embedding_model._instance, OpenAIEmbedding):
 		queries = openai_truncate_by_token(
 			queries, openai_embedding_limit, embedding_model.model_name
 		)

--- a/autorag/utils/util.py
+++ b/autorag/utils/util.py
@@ -498,7 +498,7 @@ def embedding_query_content(
 ):
 	flatten_contents = list(itertools.chain.from_iterable(contents_list))
 
-	openai_embedding_limit = 8191  # all openai embedding model has 8191 max token input
+	openai_embedding_limit = 8000  # all openai embedding model has 8000 max token input
 	if isinstance(embedding_model._instance, OpenAIEmbedding):
 		queries = openai_truncate_by_token(
 			queries, openai_embedding_limit, embedding_model.model_name

--- a/tests/autorag/evaluate/test_evaluate_util.py
+++ b/tests/autorag/evaluate/test_evaluate_util.py
@@ -23,7 +23,7 @@ def test_cast_metrics():
 	]
 	metric_names, metric_params = cast_metrics(metric3)
 	assert metric_names == ["bleu", "sem_score"]
-	assert metric_params == [{}, {"embedding_model": embedding_models["openai"]}]
+	assert metric_params == [{}, {"embedding_model": embedding_models["openai"]()}]
 
 	metric4 = [
 		{"metric_name": "bleu", "extra_param": "extra"},
@@ -37,5 +37,5 @@ def test_cast_metrics():
 	assert metric_names == ["bleu", "sem_score"]
 	assert metric_params == [
 		{"extra_param": "extra"},
-		{"embedding_model": embedding_models["openai"], "extra_param": "extra"},
+		{"embedding_model": embedding_models["openai"](), "extra_param": "extra"},
 	]

--- a/tests/autorag/nodes/retrieval/test_vectordb.py
+++ b/tests/autorag/nodes/retrieval/test_vectordb.py
@@ -12,6 +12,7 @@ import pytest
 from llama_index.core import MockEmbedding
 from llama_index.embeddings.openai import OpenAIEmbedding
 
+from autorag import embedding_models
 from autorag.nodes.retrieval import VectorDB
 from autorag.nodes.retrieval.vectordb import vectordb_ingest, get_id_scores
 from tests.autorag.nodes.retrieval.test_retrieval_base import (

--- a/tests/autorag/utils/test_util.py
+++ b/tests/autorag/utils/test_util.py
@@ -371,16 +371,16 @@ def test_process_batch():
 def test_openai_truncate_by_token():
 	base_text = "This is a test text."
 	t1 = base_text * 5
-	t2 = base_text * 2000
+	t2 = base_text * 200000
 	t3 = base_text * 20
 
-	truncated = openai_truncate_by_token([t1, t2, t3], 8192, "text-embedding-ada-002")
+	truncated = openai_truncate_by_token([t1, t2, t3], 8000, "text-embedding-ada-002")
 	assert len(truncated) == 3
 	assert truncated[0] == base_text * 5
 	assert len(truncated[1]) < len(t2)
 	assert (
 		len(tiktoken.encoding_for_model("text-embedding-ada-002").encode(truncated[1]))
-		== 8192
+		== 8000
 	)
 	assert len(truncated[2]) == len(t3)
 


### PR DESCRIPTION
close #811

It will be great we can set truncate limit as parameter => It can be a new issue.

- Call embedding model before use
- Adjust embedding token limit to 8000