### PR TITLE
Run validation at the start_trial 

### DIFF
--- a/autorag/cli.py
+++ b/autorag/cli.py
@@ -39,13 +39,19 @@ def cli():
 @click.option(
 	"--project_dir", help="Path to project directory.", type=str, default=None
 )
-def evaluate(config, qa_data_path, corpus_data_path, project_dir):
+@click.option(
+	"--skip_validation",
+	help="Skip validation or not. Default is False.",
+	type=bool,
+	default=False,
+)
+def evaluate(config, qa_data_path, corpus_data_path, project_dir, skip_validation):
 	if not config.endswith(".yaml") and not config.endswith(".yml"):
 		raise ValueError(f"Config file {config} is not a parquet file.")
 	if not os.path.exists(config):
 		raise ValueError(f"Config file {config} does not exist.")
 	evaluator = Evaluator(qa_data_path, corpus_data_path, project_dir=project_dir)
-	evaluator.start_trial(config)
+	evaluator.start_trial(config, skip_validation=skip_validation)
 
 
 @click.command()

--- a/autorag/evaluator.py
+++ b/autorag/evaluator.py
@@ -105,7 +105,7 @@ class Evaluator:
 			logger.info(ascii_art)
 			logger.info(
 				"Start Validation input data and config YAML file first. "
-				"If you want to skip this, put the --skip-validation flag or "
+				"If you want to skip this, put the --skip_validation flag or "
 				"`skip_validation` at the start_trial function."
 			)
 			from autorag.validator import Validator  # resolve circular import

--- a/autorag/validator.py
+++ b/autorag/validator.py
@@ -77,7 +77,7 @@ class Validator:
 				corpus_data_path=corpus_path.name,
 				project_dir=temp_project_dir,
 			)
-			evaluator.start_trial(yaml_path)
+			evaluator.start_trial(yaml_path, skip_validation=True)
 			qa_path.close()
 			corpus_path.close()
 			os.unlink(qa_path.name)

--- a/tests/autorag/test_cli.py
+++ b/tests/autorag/test_cli.py
@@ -26,6 +26,8 @@ def test_evaluator_cli():
 				os.path.join(resource_dir, "corpus_data_sample.parquet"),
 				"--project_dir",
 				project_dir,
+				"--skip_validation",
+				"true",
 			]
 		)
 		assert result.returncode == 0


### PR DESCRIPTION
close #820

It will enable auto-validation at every beginning of the optimization

---

This pull request introduces a new `--skip_validation` option to the CLI and updates related components to support this feature. The changes ensure that the evaluation process can optionally bypass validation steps, which can be useful for faster iterations during development or testing.

### New Feature: Skip Validation Option

* [`autorag/cli.py`](diffhunk://#diff-1038233f81b7229ecdf882cfc6ada228d600f3d898339ee0560ec6a9a3af7d43L42-R54): Added a `--skip_validation` option to the `evaluate` function, allowing users to skip the validation step when running the evaluation.
* [`autorag/evaluator.py`](diffhunk://#diff-8ec966a33a0024f88726d8a831e0db177b4bd5d6e8cdcb823e132fd604b82925L101-R116): Updated the `Evaluator` class to handle the `skip_validation` flag in the `start_trial` method, including conditional validation logic.

### Code Enhancements

* [`autorag/evaluator.py`](diffhunk://#diff-8ec966a33a0024f88726d8a831e0db177b4bd5d6e8cdcb823e132fd604b82925R79-R80): Stored `qa_data_path` and `corpus_data_path` as instance variables in the `Evaluator` class for better data management.

### Testing

* [`tests/autorag/test_cli.py`](diffhunk://#diff-8d56a2962fd8d4a36e73d9199d4f993a3382d7ad3f1444824eb2a626adb35253R29-R30): Modified the `test_evaluator_cli` test to include the `--skip_validation` flag, ensuring the new feature is covered in tests.

### Internal Adjustments

* [`autorag/validator.py`](diffhunk://#diff-4729e6a3a29f0d0145655687c4d05c94f426560bc57bc8a751864e4376324fbbL80-R80): Updated the `validate` method to call `start_trial` with `skip_validation=True` to prevent redundant validations during testing.