### PR TITLE
Fix: added table_html variable initialization

### DIFF
--- a/autorag/data/parse/clova.py
+++ b/autorag/data/parse/clova.py
@@ -79,6 +79,7 @@ async def clova_ocr_pure(
 	table_detection: bool = False,
 ) -> Tuple[str, str, int]:
 	session = aiohttp.ClientSession()
+	table_html = ""
 	headers = {"X-OCR-SECRET": api_key, "Content-Type": "application/json"}
 
 	# Convert image data to base64


### PR DESCRIPTION
While performing table hybrid parse with naver ocr, there was error: 

```python
 UnboundLocalError: local variable 'table_html' referenced before assignment         
```

To fix this error, I added table_html variable initialization to solve this error. After that, code works as expected. 
                              