### PR TITLE
docs[fix]: modify contents on upstage parser

### DIFF
--- a/docs/source/data_creation/parse/langchain_parse.md
+++ b/docs/source/data_creation/parse/langchain_parse.md
@@ -92,14 +92,14 @@ modules:
 You need to have an API key to use the following document loaders.
 - [Unstructured](https://python.langchain.com/v0.2/docs/integrations/document_loaders/unstructured_file/)
   - `UNSTRUCTURED_API_KEY` should be set in the environment variable.
-- [UpstageLayoutAnalysis](https://python.langchain.com/v0.2/docs/integrations/document_loaders/upstage/)
+- [UpstageDocumentParseLoader](https://python.langchain.com/docs/integrations/providers/upstage/#document-parse)
   - `UPSTAGE_API_KEY` should be set in the environment variable.
 
 #### Example YAML
 
 ```yaml
   - module_type: langchain_parse
-    parse_method: upstagelayoutanalysis
+    parse_method: upstagedocumentparse
 ```
 
 ## Using Parse Method that is not in the Available Parse Method


### PR DESCRIPTION
**description**

I updated the documentation for upstageparser.
`upstagelayoutanalysis` has been deprecated and is now replaced by `upstagedocumentparse`.
```
upstagelayoutanalysis -> upstagedocumentparse
```
![image](https://github.com/user-attachments/assets/88491b4f-3057-48ae-b01b-d37b326e50ec)
![image](https://github.com/user-attachments/assets/fc220dcd-a613-4127-a412-ea7f766b4e6d)

Thank you for your review.

