### PR TITLE
fix: change default similarity_metric for milvus

### DIFF
--- a/autorag/vectordb/milvus.py
+++ b/autorag/vectordb/milvus.py
@@ -24,7 +24,7 @@ class Milvus(BaseVectorStore):
 		embedding_model: str,
 		collection_name: str,
 		embedding_batch: int = 100,
-		similarity_metric: str = "cosine",
+		similarity_metric: str = "l2",
 		uri: str = "http://localhost:19530",
 		db_name: str = "",
 		token: str = "",


### PR DESCRIPTION
**description**
Milvus not supported `similarity_metric:cosine` and only L2 and IP are supported. Therefore, I updated the default similarity_metric.

**log**
```bash
[11/25/24 14:28:57] INFO     [evaluator.py:127] >>                                                                                                                  evaluator.py:127
                                             _        _____            _____                                                                                                        
                                  /\        | |      |  __ \     /\   / ____|                                                                                                       
                                 /  \  _   _| |_ ___ | |__) |   /  \ | |  __                                                                                                        
                                / /\ \| | | | __/ _ \|  _  /   / /\ \| | |_ |                                                                                                       
                               / ____ \ |_| | || (_) | | \ \  / ____ \ |__| |                                                                                                       
                              /_/    \_\__,_|\__\___/|_|  \_\/_/    \_\_____|                                                                                                       
                                                                                                                                                                                    
                                                                                                                                                                                    
                    INFO     [evaluator.py:128] >> Start Validation input data and config YAML file first. If you want to skip this, put the --skip_validation flag evaluator.py:128
                             or `skip_validation` at the start_trial function.                                                                                                      
                    WARNING  [validator.py:50] >> Minimal Requested sample size (5) is larger than available records (1). Sampling will be limited to 1 records.     validator.py:50
[11/25/24 14:28:58] INFO     [evaluator.py:228] >> Embedding BM25 corpus...                                                                                         evaluator.py:228
[11/25/24 14:29:10] INFO     [evaluator.py:248] >> BM25 corpus embedding complete.                                                                                  evaluator.py:248
                    INFO     [_client.py:1039] >> HTTP Request: POST https://api.openai.com/v1/embeddings "HTTP/1.1 200 OK"                                          _client.py:1039
[11/25/24 14:29:11] ERROR    [decorators.py:147] >> RPC error: [create_index], <MilvusException: (code=0, message=metric type not found or not supported,          decorators.py:147
                             supported: [L2 IP])>, <Time:{'RPC start': '2024-11-25 14:29:11.011688', 'RPC error': '2024-11-25 14:29:11.017874'}>  
``` 