### PR TITLE
fix: Poetry shell failed due to incorrect pyproject.toml format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,25 +28,9 @@ dynamic = ["version", "dependencies"]
 
 [tool.poetry]
 name = "AutoRAG"
-version = "v0.1.0"
+version = "0.0.2" #base version
 description = "Automatically Evaluate RAG pipelines with your own data. Find optimal structure for new RAG product."
 authors = ["Marker-Inc <vkehfdl1@gmail.com>"]
-readme = "README.md"
-license = "MIT"
-homepage = "https://github.com/Marker-Inc-Korea/AutoRAG"
-keywords = ["RAG", "AutoRAG", "autorag", "rag-evaluation", "evaluation", "rag-auto", "AutoML", "AutoML-RAG"]
-classifiers = [
-  "Intended Audience :: Developers",
-  "Intended Audience :: Information Technology",
-  "Intended Audience :: Science/Research",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
-  "Topic :: Scientific/Engineering :: Artificial Intelligence",
-  "Topic :: Software Development :: Libraries",
-  "Topic :: Software Development :: Libraries :: Python Modules",
-]
-
 
 [tool.setuptools.dynamic]
 version = { file = ["autorag/VERSION"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dynamic = ["version", "dependencies"]
 
 [tool.poetry]
 name = "AutoRAG"
-version = "0.0.2" #base version
+version = "0.0.2" #initial version
 description = "Automatically Evaluate RAG pipelines with your own data. Find optimal structure for new RAG product."
 authors = ["Marker-Inc <vkehfdl1@gmail.com>"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,28 @@ classifiers = [
 urls = { Homepage = "https://github.com/Marker-Inc-Korea/AutoRAG" }
 dynamic = ["version", "dependencies"]
 
+[tool.poetry]
+name = "AutoRAG"
+version = "v0.1.0"
+description = "Automatically Evaluate RAG pipelines with your own data. Find optimal structure for new RAG product."
+authors = ["Marker-Inc <vkehfdl1@gmail.com>"]
+readme = "README.md"
+license = "MIT"
+homepage = "https://github.com/Marker-Inc-Korea/AutoRAG"
+keywords = ["RAG", "AutoRAG", "autorag", "rag-evaluation", "evaluation", "rag-auto", "AutoML", "AutoML-RAG"]
+classifiers = [
+  "Intended Audience :: Developers",
+  "Intended Audience :: Information Technology",
+  "Intended Audience :: Science/Research",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  "Topic :: Software Development :: Libraries",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+
 [tool.setuptools.dynamic]
 version = { file = ["autorag/VERSION"] }
 dependencies = { file = ["requirements.txt"] }


### PR DESCRIPTION
## Problem
The `poetry shell` command was not working due to missing or incorrect configuration in the `pyproject.toml` file. Users encountered the following error:
## Solution
- Added the `[tool.poetry]` section to the `pyproject.toml` file with the necessary configuration to enable the `poetry shell` command to work correctly.
- Configured essential fields such as `name`, `version`, and `dependencies` to meet Poetry's requirements.

## Changes Made
- Updated `pyproject.toml`:
  - Added `[tool.poetry]` section.
  - Included required fields (`name`, `version`, etc.).
  - Verified the dependencies were correctly defined.

## Testing
- Ran the `poetry shell` command to ensure a virtual environment is correctly activated without errors.