### PR TITLE
feat: add intfloat/multilingual-e5-large-instruct to embedding model

### DIFF
--- a/autorag/__init__.py
+++ b/autorag/__init__.py
@@ -96,6 +96,9 @@ try:
 	embedding_models["huggingface_bge_m3"] = LazyInit(
 		HuggingFaceEmbedding, model_name="BAAI/bge-m3"
 	)
+	embedding_models["huggingface_multilingual_e5_large"] = LazyInit(
+		HuggingFaceEmbedding, model_name="intfloat/multilingual-e5-large-instruct"
+	)
 except ImportError:
 	logger.info(
 		"You are using API version of AutoRAG."


### PR DESCRIPTION
hello.

I have added intfloat/multilingual-e5-large-instruct to the embedding model list for testing purposes. Additionally, I have created an issue(#1060) to enable the use of other embedding models that are not currently included in the list.

Thank you.