### PR TITLE
Add support for openai_like embedding model in semantic splitter llama_index module

### DIFF
--- a/autorag/autorag/embedding/base.py
+++ b/autorag/autorag/embedding/base.py
@@ -9,6 +9,7 @@ from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.embeddings.openai import OpenAIEmbeddingModelType
 from llama_index.embeddings.ollama import OllamaEmbedding
 from langchain_openai.embeddings import OpenAIEmbeddings
+from llama_index.embeddings.openai_like import OpenAILikeEmbedding
 
 from autorag import LazyInit
 
@@ -37,6 +38,8 @@ embedding_models = {
 	# langchain
 	"openai_langchain": LazyInit(OpenAIEmbeddings),
 	"ollama": LazyInit(OllamaEmbedding),
+	# openai like
+	"openai_like": LazyInit(OpenAILikeEmbedding),
 }
 
 try:
@@ -122,6 +125,7 @@ class EmbeddingModel:
 			"mock": MockEmbeddingRandom,
 			"huggingface": _get_huggingface_class(),
 			"ollama": OllamaEmbedding,
+			"openai_like": OpenAILikeEmbedding,
 		}
 
 		embedding_class = embedding_map.get(model_type)

--- a/docs/source/local_model.md
+++ b/docs/source/local_model.md
@@ -163,6 +163,7 @@ We support the following embedding model types:
 - huggingface
 - mock
 - ollama
+- openai_like
 
 You can configure the embedding model option directly in the YAML file `vectordb` section.
 If you want to know how to configure vectordb in AutoRAG,


### PR DESCRIPTION
This PR adds support for using openai_like embedding models within the semantic_llama_index chunking method via the YAML config. Specifically:
	•	Imported OpenAILikeEmbedding from llama_index.embeddings.openai_like.
	•	Registered openai_like in both embedding_models and embedding_map.
	•	Verified integration by successfully running a YAML configuration that uses openai_like with the multilingual-e5-small model hosted on Hugging Face Spaces.

This enhancement enables users to plug in OpenAI-compatible embedding APIs easily without relying on OpenAI’s native endpoints, allowing greater flexibility and local/self-hosted deployment options.

Example YAML Config:
modules:
  - module_type: llama_index_chunk
    chunk_method: semantic_llama_index
    chunk_size: 64
    chunk_overlap: 16
    add_file_name: en
    embed_model: 
    - type: openai_like
      model_name: multilingual-e5-small
      api_base: https://lamhieu-lightweight-embeddings.hf.space/v1/
      api_key: none