### PR TITLE
[WIP] feat: Visual QA data creation PoC (#1162)

### DIFF
--- a/autorag/data/qa/query/openai_vlm_gen_query.py
+++ b/autorag/data/qa/query/openai_vlm_gen_query.py
@@ -1,0 +1,75 @@
+import base64
+import itertools
+from typing import Dict, List
+
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from openai import AsyncClient
+from pydantic import BaseModel
+
+from autorag.data.qa.query.prompt import QUERY_GEN_PROMPT
+
+
+class Response(BaseModel):
+	query: str
+
+
+def encode_image(image_path: str) -> str:
+	with open(image_path, "rb") as image_file:
+		return base64.b64encode(image_file.read()).decode("utf-8")
+
+
+# Single hop Visual QA generation OpenAI
+async def query_gen_vlm_openai_base(
+	row: Dict,
+	client: AsyncClient,
+	messages: List[ChatMessage],
+	model_name: str = "gpt-4o-2024-08-06",
+):
+	context = list(itertools.chain.from_iterable(row.get("retrieval_gt_contents", [])))
+	context_str = "Text:\n" + "\n".join(
+		[f"{i + 1}. {c}" for i, c in enumerate(context)]
+	)
+	user_prompt = f"{context_str}\n\nGenerated Question from the Text and Image:\n"
+
+	openai_messages = []
+	for msg in messages:
+		if msg.role == MessageRole.SYSTEM:
+			openai_messages.append({"role": "system", "content": msg.content})
+
+	user_content = [{"type": "text", "text": user_prompt}]
+
+	if row.get("image_path"):
+		base64_image = encode_image(row["image_path"])
+		user_content.append(
+			{
+				"type": "image_url",
+				"image_url": {"url": f"data:image/jpeg;base64,{base64_image}"},
+			}
+		)
+
+	openai_messages.append({"role": "user", "content": user_content})
+
+	completion = await client.beta.chat.completions.parse(
+		model=model_name,
+		messages=openai_messages,
+		response_format=Response,
+	)
+	row["query"] = completion.choices[0].message.parsed.query
+	return row
+
+
+async def vlm_factoid_query_gen(
+	row: Dict,
+	client: AsyncClient,
+	model_name: str = "gpt-4o-2024-08-06",
+	lang: str = "en",
+) -> Dict:
+	"""
+	Create a visual factoid question using a vision-language model.
+	The input row has to include an image_path.
+
+	:return: The visual factoid question using openai vision model
+	"""
+	return await query_gen_vlm_openai_base(
+		row, client, QUERY_GEN_PROMPT["factoid_single_hop"][lang], model_name
+	)

--- a/autorag/data/qa/query/openai_vlm_gen_query.py
+++ b/autorag/data/qa/query/openai_vlm_gen_query.py
@@ -6,6 +6,9 @@ from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from openai import AsyncClient
 from pydantic import BaseModel
 
+import mimetypes
+import aiofiles
+
 from autorag.data.qa.query.prompt import QUERY_GEN_PROMPT
 
 
@@ -13,9 +16,10 @@ class Response(BaseModel):
 	query: str
 
 
-def encode_image(image_path: str) -> str:
-	with open(image_path, "rb") as image_file:
-		return base64.b64encode(image_file.read()).decode("utf-8")
+async def encode_image_async(image_path: str) -> str:
+	async with aiofiles.open(image_path, "rb") as image_file:
+		data = await image_file.read()
+		return base64.b64encode(data).decode("utf-8")
 
 
 # Single hop Visual QA generation OpenAI
@@ -39,11 +43,14 @@ async def query_gen_vlm_openai_base(
 	user_content = [{"type": "text", "text": user_prompt}]
 
 	if row.get("image_path"):
-		base64_image = encode_image(row["image_path"])
+		mime_type, _ = mimetypes.guess_type(row["image_path"])
+		mime_type = mime_type or "image/jpeg"
+
+		base64_image = await encode_image_async(row["image_path"])
 		user_content.append(
 			{
 				"type": "image_url",
-				"image_url": {"url": f"data:image/jpeg;base64,{base64_image}"},
+				"image_url": {"url": f"data:{mime_type};base64,{base64_image}"},
 			}
 		)
 

--- a/autorag/data/qa/schema.py
+++ b/autorag/data/qa/schema.py
@@ -186,9 +186,12 @@ class QA:
 			raise ValueError("save_path must be ended with .parquet")
 		if not corpus_save_path.endswith(".parquet"):
 			raise ValueError("save_path must be ended with .parquet")
-		save_df = self.data[
-			["qid", "query", "retrieval_gt", "generation_gt"]
-		].reset_index(drop=True)
+
+		columns_to_save = ["qid", "query", "retrieval_gt", "generation_gt"]
+		if "image_path" in self.data.columns:
+			columns_to_save.append("image_path")
+
+		save_df = self.data[columns_to_save].reset_index(drop=True)
 		save_df.to_parquet(qa_save_path)
 		self.linked_corpus.to_parquet(corpus_save_path)
 


### PR DESCRIPTION
Relates to #1162 

Hey @vkehfdl1, since the issue didn't have a description, I threw together a quick draft PR as a PoC to make sure we're aligned on the architecture for visual QA creation before I build out the whole pipeline.

Here's the approach I'm taking:
* **Data layer (`schema.py`):** Updated `QA.to_parquet` to persist an `image_path` column. Assuming it's better to pass local paths through the pipeline rather than storing raw base64 in the DataFrames to avoid memory bloat.
* **Generator (`openai_vlm_gen_query.py`):** Stubbed out a VLM query generator. It dynamically converts the local `image_path` to base64 at the API boundary right before sending it to OpenAI.

_Quick note on the model: I defaulted to `gpt-4o-2024-08-06` to match the existing text modules and keep tests passing. Given OpenAI's transition to `gpt-5.2` this month, let me know if you'd rather bump the default specifically for these vision nodes._

Still left on the to-do list before this is ready for review:
* Update `parse/base.py` for multimodal file ingestion
* Add the VLM `generation_gt` module
* Add tests and mock the new API calls

Let me know if this data flow and file structure work for you, and I'll finish up the rest of the implementation.