### PR TITLE
fix: use restricted unpickler for BM25 corpus files to prevent arbitrary code execution (CWE-502)

### DIFF
--- a/autorag/nodes/lexicalretrieval/bm25.py
+++ b/autorag/nodes/lexicalretrieval/bm25.py
@@ -25,6 +25,44 @@ from autorag.utils.util import (
 )
 
 
+class _RestrictedBM25Unpickler(pickle.Unpickler):
+	"""Restricted unpickler that only allows basic Python types.
+
+	BM25 corpus pickle files contain only dicts, lists, strings, and ints.
+	This unpickler refuses to instantiate any other class, preventing
+	arbitrary code execution via crafted pickle payloads (CWE-502).
+	"""
+
+	_SAFE_BUILTINS = frozenset(
+		{
+			"dict",
+			"list",
+			"set",
+			"tuple",
+			"frozenset",
+			"str",
+			"bytes",
+			"int",
+			"float",
+			"bool",
+			"type",
+		}
+	)
+
+	def find_class(self, module: str, name: str):
+		if module == "builtins" and name in self._SAFE_BUILTINS:
+			return super().find_class(module, name)
+		raise pickle.UnpicklingError(
+			f"Restricted unpickler refused to load {module}.{name}. "
+			f"BM25 corpus files should only contain basic Python types."
+		)
+
+
+def _safe_pickle_load(file_obj) -> object:
+	"""Load a pickle file using a restricted unpickler that blocks code execution."""
+	return _RestrictedBM25Unpickler(file_obj).load()
+
+
 def tokenize_ko_kiwi(texts: List[str]) -> List[List[str]]:
 	try:
 		from kiwipiepy import Kiwi, Token
@@ -103,7 +141,7 @@ def load_bm25_corpus(bm25_path: str) -> Dict:
 	if bm25_path is None:
 		return {}
 	with open(bm25_path, "rb") as f:
-		bm25_corpus = pickle.load(f)
+		bm25_corpus = _safe_pickle_load(f)
 	return bm25_corpus
 
 
@@ -335,7 +373,7 @@ def bm25_ingest(
 	# Load the BM25 corpus if it exists and get the passage ids
 	if os.path.exists(corpus_path) and os.path.getsize(corpus_path) > 0:
 		with open(corpus_path, "rb") as r:
-			corpus = pickle.load(r)
+			corpus = _safe_pickle_load(r)
 			bm25_corpus = pd.DataFrame.from_dict(corpus)
 		duplicated_passage_rows = bm25_corpus[bm25_corpus["passage_id"].isin(ids)]
 		new_passage = corpus_data[


### PR DESCRIPTION
## Vulnerability Summary

**CWE-502: Deserialization of Untrusted Data**
**Severity: Medium**

### Data Flow

Two calls to bare `pickle.load()` in `autorag/nodes/lexicalretrieval/bm25.py` deserialize `.pkl` files from the project directory without any validation or integrity checking:

1. **Line 106** (`load_bm25_corpus`): `pickle.load(f)` — called by `BM25.__init__()` during evaluation and API serving.
2. **Line 338** (`bm25_ingest`): `pickle.load(r)` — called by `Evaluator.start_trial()` and tests.

The call chain is:
- `BM25.__init__()` → `load_bm25_corpus()` → `pickle.load()` (L106)
- `Evaluator.start_trial()` → `bm25_ingest()` → `pickle.load()` (L338)
- `ApiRunner.from_trial_folder()` → `BM25.__init__()` → `load_bm25_corpus()` → `pickle.load()` (L106)

The `.pkl` files reside at `project_dir/resources/bm25_*.pkl`, where `project_dir` is user-specified via CLI.

### Exploit Scenario

An attacker shares a crafted AutoRAG project directory (e.g., via zip, git repo, HuggingFace dataset, or shared filesystem) containing a malicious `bm25_porter_stemmer.pkl`. When the victim loads this directory — e.g., via `autorag run_api --trial_dir /shared/project/0` or `ApiRunner.from_trial_folder()` — the poisoned pickle file is deserialized, achieving **arbitrary code execution** with the privileges of the user running AutoRAG.

```python
# Example: a malicious pickle payload using __reduce__ to invoke os.system
import pickle, os

class Exploit:
    def __reduce__(self):
        return (os.system, ("echo pwned > /tmp/proof",))

with open("resources/bm25_porter_stemmer.pkl", "wb") as f:
    pickle.dump(Exploit(), f)
```

### Preconditions

1. Victim must load a project directory controlled or tampered with by an attacker.
2. This requires: shared filesystem, downloaded project, CI/CD shared artifacts, or social engineering.
3. The `.pkl` files are not downloaded from the network automatically — they must be pre-placed in the project directory.

---

## Fix Description and Rationale

This PR introduces a `_RestrictedBM25Unpickler` class that overrides `pickle.Unpickler.find_class()` to allow only basic Python built-in types (`dict`, `list`, `set`, `tuple`, `frozenset`, `str`, `bytes`, `int`, `float`, `bool`, `type`). Both `pickle.load()` call sites are replaced with `_safe_pickle_load()`, which uses this restricted unpickler.

**Why this approach:**
- [Python docs explicitly warn](https://docs.python.org/3/library/pickle.html) against using `pickle.load()` on untrusted data and recommend restricted unpicklers as the mitigation.
- BM25 corpus pickle files contain only dicts, lists, strings, and ints — no complex objects are needed.
- This is the standard, well-established pattern (used by PyTorch, MLflow, etc.) for hardening pickle deserialization.
- The change is minimal (1 file, 40 lines added, 2 lines changed) and does not alter any functional behavior for legitimate pickle files.

### Diff Summary

```
 autorag/nodes/lexicalretrieval/bm25.py | 42 ++++++++++++++++++++++++++++++--
 1 file changed, 40 insertions(+), 2 deletions(-)
```

---

## Test Results Summary

- The fix is a drop-in replacement: `_safe_pickle_load()` produces identical results to `pickle.load()` for all legitimate BM25 corpus files (dicts of basic Python types).
- Malicious pickle payloads (e.g., `os.system`, `subprocess.Popen`, `eval`) are correctly rejected with `pickle.UnpicklingError`.
- No existing tests are broken by this change.

---

## Disprove Analysis

We systematically attempted to disprove this finding:

| Check | Result |
|---|---|
| **Authentication** | No auth on `bm25.py` or the API server (`deploy/api.py`). API binds to `0.0.0.0`, can be exposed via ngrok. **No mitigating auth.** |
| **Network isolation** | Server defaults to `0.0.0.0:8000` with `remote=True` ngrok option. No CORS restrictions. **Not localhost-only.** |
| **Deployment hardening** | No Dockerfile, docker-compose, k8s manifests. Runs directly via CLI. Documented on HuggingFace Spaces. **No reverse proxy or service mesh.** |
| **Input validation** | No checksums, signatures, or format validation before `pickle.load()`. **No existing protection.** |
| **Prior reports** | No prior security issues or CVEs for this repo. **No prior fix.** |
| **Security policy** | No `SECURITY.md` found. |

### Mitigations Found

**None.** The only implicit mitigation is that `.pkl` files are normally self-generated locally by `pickle.dump()` from trusted DataFrame data. However, `from_trial_folder()` allows loading pre-existing project directories, and project directory structures are documented for sharing/reuse.

### Verdict: LIKELY_VALID | Confidence: Medium

The vulnerability is technically real and the fix follows Python security best practices. While exploitation requires specific preconditions (attacker-controlled project directory), the defense-in-depth principle makes this worth fixing. The restricted unpickler adds negligible complexity and correctly blocks the attack vector.

### Similar Vulnerabilities (Prior Art)

Pickle deserialization (CWE-502) is well-documented in the ML ecosystem with similar findings in MLflow, Hugging Face Transformers, NumPy, and many ML tools.

---

*Found via automated security audit. Happy to address any feedback.*
