### PR TITLE
feat: add AG2 multi-agent generator module

### DIFF
--- a/autorag/nodes/generator/__init__.py
+++ b/autorag/nodes/generator/__init__.py
@@ -1,3 +1,4 @@
+from .ag2 import AG2Generator
 from .llama_index_llm import LlamaIndexLLM
 from .minimax_llm import MiniMaxLLM
 from .openai_llm import OpenAILLM

--- a/autorag/nodes/generator/ag2.py
+++ b/autorag/nodes/generator/ag2.py
@@ -1,0 +1,224 @@
+"""AG2 multi-agent generator module for AutoRAG."""
+
+import logging
+import os
+from typing import Dict, List, Tuple, Union
+
+import tiktoken
+
+from autogen import AssistantAgent, LLMConfig, UserProxyAgent
+
+from autorag.nodes.generator.base import BaseGenerator
+from autorag.utils.util import (
+	get_event_loop,
+	process_batch,
+	result_to_dataframe,
+)
+
+logger = logging.getLogger("AutoRAG")
+
+DEFAULT_SYSTEM_MESSAGE = (
+	"You are a precise and helpful assistant. Given the context and "
+	"question below, provide a comprehensive and accurate answer based "
+	"solely on the provided context. If the context doesn't contain "
+	"enough information, say so clearly. Be concise but thorough."
+)
+
+
+class AG2Generator(BaseGenerator):
+	"""
+	AG2 multi-agent generator for AutoRAG.
+
+	Uses AG2's multi-agent conversation framework where a user proxy agent
+	and an assistant agent collaborate to generate answers based on
+	retrieved context.
+
+	It returns pseudo token ids and log probs since AG2 does not support logprobs.
+
+	:param project_dir: The project directory.
+	:param llm: The LLM model name (e.g., "gpt-4o-mini", "gpt-4o").
+		Default is "gpt-4o-mini".
+	:param batch: Batch size for parallel generation. Default is 16.
+	:param api_key: The API key. If not provided, reads from OPENAI_API_KEY env var.
+	:param api_type: The API type for AG2 LLMConfig (e.g., "openai").
+		Default is "openai".
+	:param max_turns: Maximum number of conversation turns for the agent chat.
+		Default is 1.
+	:param system_message: Custom system message for the assistant agent.
+		If not provided, uses a default RAG-optimized prompt.
+	"""
+
+	def __init__(
+		self,
+		project_dir,
+		llm: str = "gpt-4o-mini",
+		batch: int = 16,
+		*args,
+		**kwargs,
+	):
+		super().__init__(project_dir, llm, *args, **kwargs)
+		assert batch > 0, "batch size must be greater than 0."
+		self.batch = batch
+
+		self.api_key = kwargs.pop("api_key", None) or os.environ.get(
+			"OPENAI_API_KEY", ""
+		)
+		self.api_type = kwargs.pop("api_type", "openai")
+		self.max_turns = kwargs.pop("max_turns", 1)
+		self.system_message = (
+			kwargs.pop("system_message", None) or DEFAULT_SYSTEM_MESSAGE
+		)
+
+		try:
+			self.tokenizer = tiktoken.encoding_for_model(self.llm)
+		except KeyError:
+			self.tokenizer = tiktoken.get_encoding("o200k_base")
+
+	@result_to_dataframe(["generated_texts", "generated_tokens", "generated_log_probs"])
+	def pure(self, previous_result, *args, **kwargs):
+		prompts = self.cast_to_run(previous_result)
+		return self._pure(prompts, **kwargs)
+
+	def _pure(
+		self,
+		prompts: Union[List[str], List[List[dict]]],
+		**kwargs,
+	) -> Tuple[List[str], List[List[int]], List[List[float]]]:
+		"""
+		AG2 multi-agent generator module.
+		Uses AG2's multi-agent conversation framework for generating answers.
+		It returns pseudo token ids and log probs.
+
+		:param prompts: A list of prompts.
+		:param kwargs: Optional parameters passed to the AG2 LLMConfig.
+		:return: A tuple of three elements.
+			The first element is a list of generated text.
+			The second element is a list of generated text's pseudo token ids.
+			The third element is a list of generated text's pseudo log probs.
+		"""
+		loop = get_event_loop()
+		tasks = [self._agenerate_single(prompt) for prompt in prompts]
+		result = loop.run_until_complete(process_batch(tasks, self.batch))
+		answer_result = list(map(lambda x: x[0], result))
+		token_result = list(map(lambda x: x[1], result))
+		logprob_result = list(map(lambda x: x[2], result))
+		return answer_result, token_result, logprob_result
+
+	async def _agenerate_single(
+		self, prompt: Union[str, List[Dict]]
+	) -> Tuple[str, List[int], List[float]]:
+		"""Generate a single answer using AG2 agents."""
+		llm_config = LLMConfig(
+			{
+				"model": self.llm,
+				"api_key": self.api_key,
+				"api_type": self.api_type,
+			}
+		)
+
+		assistant = AssistantAgent(
+			name="rag_assistant",
+			system_message=self.system_message,
+			llm_config=llm_config,
+		)
+
+		user_proxy = UserProxyAgent(
+			name="user_proxy",
+			human_input_mode="NEVER",
+			code_execution_config=False,
+			is_termination_msg=lambda x: (
+				x.get("content", "") and "TERMINATE" in x.get("content", "")
+			),
+		)
+
+		message = _format_prompt(prompt)
+
+		try:
+			chat_result = await user_proxy.a_run(
+				assistant, message=message, max_turns=self.max_turns
+			)
+			await chat_result.process()
+
+			answer = _extract_last_assistant_message(assistant, user_proxy)
+			tokens = self.tokenizer.encode(answer, allowed_special="all")
+			pseudo_log_probs = [0.5] * len(tokens)
+			return answer, tokens, pseudo_log_probs
+
+		except Exception as e:
+			logger.warning(f"AG2 generation failed: {e}")
+			empty_tokens = self.tokenizer.encode("", allowed_special="all")
+			return "", empty_tokens, [0.5] * len(empty_tokens)
+
+	async def astream(self, prompt: Union[str, List[Dict]], **kwargs):
+		"""
+		AG2 multi-agent conversations do not support native streaming.
+		This method runs the full generation and yields the complete result.
+		"""
+		llm_config = LLMConfig(
+			{
+				"model": self.llm,
+				"api_key": self.api_key,
+				"api_type": self.api_type,
+			}
+		)
+
+		assistant = AssistantAgent(
+			name="rag_assistant",
+			system_message=self.system_message,
+			llm_config=llm_config,
+		)
+
+		user_proxy = UserProxyAgent(
+			name="user_proxy",
+			human_input_mode="NEVER",
+			code_execution_config=False,
+			is_termination_msg=lambda x: (
+				x.get("content", "") and "TERMINATE" in x.get("content", "")
+			),
+		)
+
+		message = _format_prompt(prompt)
+
+		chat_result = await user_proxy.a_run(
+			assistant, message=message, max_turns=self.max_turns
+		)
+		await chat_result.process()
+
+		answer = _extract_last_assistant_message(assistant, user_proxy)
+		yield answer
+
+	def stream(self, prompt: Union[str, List[Dict]], **kwargs):
+		raise NotImplementedError("stream method is not implemented yet.")
+
+
+def _format_prompt(prompt: Union[str, List[Dict]]) -> str:
+	"""Convert prompt to a single string message for the AG2 user proxy."""
+	if isinstance(prompt, str):
+		return prompt
+	elif isinstance(prompt, list):
+		parts = []
+		for msg in prompt:
+			role = msg.get("role", "")
+			content = msg.get("content", "")
+			if role == "system":
+				parts.append(f"System: {content}")
+			elif role == "user":
+				parts.append(content)
+			else:
+				parts.append(f"{role}: {content}")
+		return "\n\n".join(parts)
+	else:
+		raise ValueError("prompt must be a string or a list of dicts.")
+
+
+def _extract_last_assistant_message(assistant, user_proxy) -> str:
+	"""Extract the last assistant message from the AG2 chat history."""
+	messages = assistant.chat_messages.get(user_proxy, [])
+	for msg in reversed(messages):
+		content = msg.get("content", "")
+		if content:
+			if "TERMINATE" in content:
+				content = content.replace("TERMINATE", "").strip()
+			if content:
+				return content
+	return ""

--- a/autorag/support.py
+++ b/autorag/support.py
@@ -177,11 +177,13 @@ def get_support_modules(module_name: str) -> Callable:
 		# generator
 		"llama_index_llm": ("autorag.nodes.generator", "LlamaIndexLLM"),
 		"minimax_llm": ("autorag.nodes.generator", "MiniMaxLLM"),
+		"ag2": ("autorag.nodes.generator", "AG2Generator"),
 		"vllm": ("autorag.nodes.generator", "Vllm"),
 		"openai_llm": ("autorag.nodes.generator", "OpenAILLM"),
 		"vllm_api": ("autorag.nodes.generator", "VllmAPI"),
 		"LlamaIndexLLM": ("autorag.nodes.generator", "LlamaIndexLLM"),
 		"MiniMaxLLM": ("autorag.nodes.generator", "MiniMaxLLM"),
+		"AG2Generator": ("autorag.nodes.generator", "AG2Generator"),
 		"Vllm": ("autorag.nodes.generator", "Vllm"),
 		"OpenAILLM": ("autorag.nodes.generator", "OpenAILLM"),
 		"VllmAPI": ("autorag.nodes.generator", "VllmAPI"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,13 +126,14 @@ dev = [
 ]
 
 [project.optional-dependencies]
+ag2 = ["ag2[openai]>=0.11.4,<1.0"]
 ko = ["kiwipiepy >= 0.18.0", "konlpy>=0.6.0"]
 parse = ["PyMuPDF>=1.26.1", "pdfminer.six>=20250506", "pdfplumber>=0.11.7", "jq>=1.9.1", "unstructured[pdf]>=0.17.2", "PyPDF2==2.12.1", "pdf2image>=1.17.0"]
 ja = ["sudachipy>=0.6.8", "sudachidict_core"]
 gpu = ["torch>=2.7.1", "sentencepiece>=0.2.0", "bert_score>=0.3.13", "peft>=0.15.2", "llmlingua>=0.2.2", "FlagEmbedding>=1.2.11",
     "sentence-transformers>=4.1.0", "transformers>=4.51.3", "llama-index-llms-ollama>=0.6.0", "llama-index-embeddings-huggingface>=0.5.4",
     "llama-index-llms-huggingface>=0.5.0", "onnxruntime>=1.22.0", "vllm>=0.11.0"]
-all = ["AutoRAG[gpu]", "AutoRAG[ko]", "AutoRAG[parse]", "AutoRAG[ja]"]
+all = ["AutoRAG[gpu]", "AutoRAG[ko]", "AutoRAG[parse]", "AutoRAG[ja]", "AutoRAG[ag2]"]
 
 [project.scripts]
 autorag = "autorag.cli:cli"

--- a/sample_config/rag/english/non_gpu/simple_ag2.yaml
+++ b/sample_config/rag/english/non_gpu/simple_ag2.yaml
@@ -1,0 +1,25 @@
+node_lines:
+- node_line_name: retrieve_node_line  # Arbitrary node line name
+  nodes:
+    - node_type: semantic_retrieval
+      strategy:
+        metrics: [retrieval_f1, retrieval_recall, retrieval_precision]
+      top_k: 3
+      modules:
+        - module_type: vectordb
+          vectordb: default
+- node_line_name: post_retrieve_node_line  # Arbitrary node line name
+  nodes:
+    - node_type: prompt_maker
+      strategy:
+        metrics: [bleu, meteor, rouge]
+      modules:
+        - module_type: fstring
+          prompt: "Read the passages and answer the given question. \n Question: {query} \n Passage: {retrieved_contents} \n Answer : "
+    - node_type: generator
+      strategy:
+        metrics: [bleu, rouge]
+      modules:
+        - module_type: ag2
+          llm: gpt-4o-mini
+          max_turns: 1

--- a/tests/autorag/nodes/generator/test_ag2.py
+++ b/tests/autorag/nodes/generator/test_ag2.py
@@ -1,0 +1,367 @@
+"""Tests for AG2 generator module."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from autorag.nodes.generator import AG2Generator
+from autorag.nodes.generator.ag2 import (
+	DEFAULT_SYSTEM_MESSAGE,
+	_extract_last_assistant_message,
+	_format_prompt,
+)
+from autorag.schema.module import Module
+from autorag.support import get_support_modules
+from tests.autorag.nodes.generator.test_generator_base import (
+	check_generated_log_probs,
+	check_generated_texts,
+	check_generated_tokens,
+	chat_prompts,
+	prompts,
+)
+
+
+def _make_mock_ag2(answer="Why not"):
+	"""Create mock AG2 classes that return a fixed answer."""
+	mock_assistant_cls = MagicMock()
+	mock_user_proxy_cls = MagicMock()
+	mock_llm_config_cls = MagicMock()
+
+	mock_assistant = MagicMock()
+	mock_assistant_cls.return_value = mock_assistant
+
+	mock_user_proxy = MagicMock()
+	mock_user_proxy_cls.return_value = mock_user_proxy
+
+	mock_chat_result = MagicMock()
+	mock_chat_result.process = AsyncMock()
+	mock_user_proxy.a_run = AsyncMock(return_value=mock_chat_result)
+
+	mock_assistant.chat_messages = {
+		mock_user_proxy: [
+			{"role": "assistant", "content": f"{answer} TERMINATE"},
+		]
+	}
+
+	return mock_assistant_cls, mock_user_proxy_cls, mock_llm_config_cls
+
+
+@pytest.fixture
+def ag2_instance():
+	return AG2Generator(
+		project_dir=".",
+		llm="gpt-4o-mini",
+		api_key="mock_ag2_api_key",
+	)
+
+
+@pytest.fixture
+def ag2_custom_instance():
+	return AG2Generator(
+		project_dir=".",
+		llm="gpt-4o",
+		batch=8,
+		api_key="mock_ag2_api_key",
+		api_type="openai",
+		max_turns=3,
+		system_message="Custom prompt.",
+	)
+
+
+# --- Unit Tests ---
+
+
+class TestAG2GeneratorInit:
+	"""Test AG2Generator initialization."""
+
+	def test_default_init(self, ag2_instance):
+		assert ag2_instance.llm == "gpt-4o-mini"
+		assert ag2_instance.batch == 16
+		assert ag2_instance.api_type == "openai"
+		assert ag2_instance.max_turns == 1
+		assert ag2_instance.system_message == DEFAULT_SYSTEM_MESSAGE
+
+	def test_custom_init(self, ag2_custom_instance):
+		assert ag2_custom_instance.llm == "gpt-4o"
+		assert ag2_custom_instance.batch == 8
+		assert ag2_custom_instance.max_turns == 3
+		assert ag2_custom_instance.system_message == "Custom prompt."
+
+	def test_init_invalid_batch(self):
+		with pytest.raises(AssertionError):
+			AG2Generator(
+				project_dir=".",
+				llm="gpt-4o-mini",
+				batch=0,
+				api_key="mock_key",
+			)
+
+
+class TestAG2ModuleRegistration:
+	"""Test AG2Generator module registration in support.py."""
+
+	def test_support_module_resolution(self):
+		assert get_support_modules("ag2") is AG2Generator
+		assert get_support_modules("AG2Generator") is AG2Generator
+
+	def test_module_from_dict(self):
+		module = Module.from_dict({"module_type": "ag2", "llm": "gpt-4o-mini"})
+		assert module.module is AG2Generator
+
+
+class TestAG2GeneratorPure:
+	"""Test AG2Generator._pure method."""
+
+	@patch("autorag.nodes.generator.ag2.UserProxyAgent")
+	@patch("autorag.nodes.generator.ag2.AssistantAgent")
+	@patch("autorag.nodes.generator.ag2.LLMConfig")
+	def test_pure_string_prompts(
+		self, mock_llm_config, mock_assistant_cls, mock_user_proxy_cls, ag2_instance
+	):
+		mock_assistant = MagicMock()
+		mock_assistant_cls.return_value = mock_assistant
+		mock_user_proxy = MagicMock()
+		mock_user_proxy_cls.return_value = mock_user_proxy
+
+		mock_chat_result = MagicMock()
+		mock_chat_result.process = AsyncMock()
+		mock_user_proxy.a_run = AsyncMock(return_value=mock_chat_result)
+
+		mock_assistant.chat_messages = {
+			mock_user_proxy: [
+				{"role": "assistant", "content": "Why not TERMINATE"},
+			]
+		}
+
+		answers, tokens, log_probs = ag2_instance._pure(prompts)
+		check_generated_texts(answers)
+		check_generated_tokens(tokens)
+		check_generated_log_probs(log_probs)
+
+	@patch("autorag.nodes.generator.ag2.UserProxyAgent")
+	@patch("autorag.nodes.generator.ag2.AssistantAgent")
+	@patch("autorag.nodes.generator.ag2.LLMConfig")
+	def test_pure_chat_prompts(
+		self, mock_llm_config, mock_assistant_cls, mock_user_proxy_cls, ag2_instance
+	):
+		mock_assistant = MagicMock()
+		mock_assistant_cls.return_value = mock_assistant
+		mock_user_proxy = MagicMock()
+		mock_user_proxy_cls.return_value = mock_user_proxy
+
+		mock_chat_result = MagicMock()
+		mock_chat_result.process = AsyncMock()
+		mock_user_proxy.a_run = AsyncMock(return_value=mock_chat_result)
+
+		mock_assistant.chat_messages = {
+			mock_user_proxy: [
+				{"role": "assistant", "content": "Why not TERMINATE"},
+			]
+		}
+
+		answers, tokens, log_probs = ag2_instance._pure(chat_prompts)
+		check_generated_texts(answers)
+		check_generated_tokens(tokens)
+		check_generated_log_probs(log_probs)
+
+	@patch("autorag.nodes.generator.ag2.UserProxyAgent")
+	@patch("autorag.nodes.generator.ag2.AssistantAgent")
+	@patch("autorag.nodes.generator.ag2.LLMConfig")
+	def test_pure_uses_correct_llm_config(
+		self, mock_llm_config, mock_assistant_cls, mock_user_proxy_cls
+	):
+		mock_assistant = MagicMock()
+		mock_assistant_cls.return_value = mock_assistant
+		mock_user_proxy = MagicMock()
+		mock_user_proxy_cls.return_value = mock_user_proxy
+
+		mock_chat_result = MagicMock()
+		mock_chat_result.process = AsyncMock()
+		mock_user_proxy.a_run = AsyncMock(return_value=mock_chat_result)
+
+		mock_assistant.chat_messages = {
+			mock_user_proxy: [
+				{"role": "assistant", "content": "answer TERMINATE"},
+			]
+		}
+
+		gen = AG2Generator(
+			project_dir=".", llm="gpt-4o", api_key="my-key", api_type="openai"
+		)
+		gen._pure(["test"])
+
+		mock_llm_config.assert_called_with(
+			{
+				"model": "gpt-4o",
+				"api_key": "my-key",
+				"api_type": "openai",
+			}
+		)
+
+	@patch("autorag.nodes.generator.ag2.UserProxyAgent")
+	@patch("autorag.nodes.generator.ag2.AssistantAgent")
+	@patch("autorag.nodes.generator.ag2.LLMConfig")
+	def test_pure_handles_exception(
+		self, mock_llm_config, mock_assistant_cls, mock_user_proxy_cls, ag2_instance
+	):
+		mock_assistant = MagicMock()
+		mock_assistant_cls.return_value = mock_assistant
+		mock_user_proxy = MagicMock()
+		mock_user_proxy_cls.return_value = mock_user_proxy
+
+		mock_user_proxy.a_run = AsyncMock(side_effect=Exception("API error"))
+
+		answers, tokens, log_probs = ag2_instance._pure(["test"])
+		assert len(answers) == 1
+		assert answers[0] == ""
+
+	@patch("autorag.nodes.generator.ag2.UserProxyAgent")
+	@patch("autorag.nodes.generator.ag2.AssistantAgent")
+	@patch("autorag.nodes.generator.ag2.LLMConfig")
+	def test_pure_empty_messages(
+		self, mock_llm_config, mock_assistant_cls, mock_user_proxy_cls, ag2_instance
+	):
+		mock_assistant = MagicMock()
+		mock_assistant_cls.return_value = mock_assistant
+		mock_user_proxy = MagicMock()
+		mock_user_proxy_cls.return_value = mock_user_proxy
+
+		mock_chat_result = MagicMock()
+		mock_chat_result.process = AsyncMock()
+		mock_user_proxy.a_run = AsyncMock(return_value=mock_chat_result)
+
+		mock_assistant.chat_messages = {mock_user_proxy: []}
+
+		answers, _, _ = ag2_instance._pure(["test"])
+		assert answers[0] == ""
+
+
+class TestAG2GeneratorNode:
+	"""Test AG2Generator as a node (run_evaluator)."""
+
+	@patch("autorag.nodes.generator.ag2.UserProxyAgent")
+	@patch("autorag.nodes.generator.ag2.AssistantAgent")
+	@patch("autorag.nodes.generator.ag2.LLMConfig")
+	def test_run_evaluator(
+		self, mock_llm_config, mock_assistant_cls, mock_user_proxy_cls
+	):
+		mock_assistant = MagicMock()
+		mock_assistant_cls.return_value = mock_assistant
+		mock_user_proxy = MagicMock()
+		mock_user_proxy_cls.return_value = mock_user_proxy
+
+		mock_chat_result = MagicMock()
+		mock_chat_result.process = AsyncMock()
+		mock_user_proxy.a_run = AsyncMock(return_value=mock_chat_result)
+
+		mock_assistant.chat_messages = {
+			mock_user_proxy: [
+				{"role": "assistant", "content": "Why not TERMINATE"},
+			]
+		}
+
+		previous_result = pd.DataFrame(
+			{"prompts": prompts, "qid": ["id-1", "id-2", "id-3"]}
+		)
+		result_df = AG2Generator.run_evaluator(
+			project_dir=".",
+			previous_result=previous_result,
+			llm="gpt-4o-mini",
+			api_key="mock_ag2_api_key",
+		)
+		check_generated_texts(result_df["generated_texts"].tolist())
+		check_generated_tokens(result_df["generated_tokens"].tolist())
+		check_generated_log_probs(result_df["generated_log_probs"].tolist())
+
+
+class TestAG2GeneratorStream:
+	"""Test streaming methods."""
+
+	def test_stream_not_implemented(self, ag2_instance):
+		with pytest.raises(NotImplementedError):
+			ag2_instance.stream("Hello")
+
+	@pytest.mark.asyncio()
+	@patch("autorag.nodes.generator.ag2.UserProxyAgent")
+	@patch("autorag.nodes.generator.ag2.AssistantAgent")
+	@patch("autorag.nodes.generator.ag2.LLMConfig")
+	async def test_astream(
+		self, mock_llm_config, mock_assistant_cls, mock_user_proxy_cls, ag2_instance
+	):
+		mock_assistant = MagicMock()
+		mock_assistant_cls.return_value = mock_assistant
+		mock_user_proxy = MagicMock()
+		mock_user_proxy_cls.return_value = mock_user_proxy
+
+		mock_chat_result = MagicMock()
+		mock_chat_result.process = AsyncMock()
+		mock_user_proxy.a_run = AsyncMock(return_value=mock_chat_result)
+
+		mock_assistant.chat_messages = {
+			mock_user_proxy: [
+				{"role": "assistant", "content": "The answer TERMINATE"},
+			]
+		}
+
+		results = []
+		async for partial in ag2_instance.astream("Hello"):
+			results.append(partial)
+
+		assert len(results) == 1
+		assert results[0] == "The answer"
+
+
+class TestFormatPrompt:
+	"""Test the _format_prompt utility function."""
+
+	def test_string_prompt(self):
+		result = _format_prompt("Hello world")
+		assert result == "Hello world"
+
+	def test_list_prompt(self):
+		messages = [
+			{"role": "system", "content": "You are helpful."},
+			{"role": "user", "content": "Hello"},
+		]
+		result = _format_prompt(messages)
+		assert "System: You are helpful." in result
+		assert "Hello" in result
+
+	def test_invalid_prompt(self):
+		with pytest.raises(ValueError):
+			_format_prompt(123)
+
+
+class TestExtractLastAssistantMessage:
+	"""Test the _extract_last_assistant_message utility function."""
+
+	def test_extracts_last_message(self):
+		assistant = MagicMock()
+		user_proxy = MagicMock()
+		assistant.chat_messages = {
+			user_proxy: [
+				{"role": "assistant", "content": "First answer"},
+				{"role": "assistant", "content": "Second answer TERMINATE"},
+			]
+		}
+		result = _extract_last_assistant_message(assistant, user_proxy)
+		assert result == "Second answer"
+
+	def test_empty_messages(self):
+		assistant = MagicMock()
+		user_proxy = MagicMock()
+		assistant.chat_messages = {user_proxy: []}
+		result = _extract_last_assistant_message(assistant, user_proxy)
+		assert result == ""
+
+	def test_only_terminate(self):
+		assistant = MagicMock()
+		user_proxy = MagicMock()
+		assistant.chat_messages = {
+			user_proxy: [
+				{"role": "assistant", "content": "TERMINATE"},
+			]
+		}
+		result = _extract_last_assistant_message(assistant, user_proxy)
+		assert result == ""


### PR DESCRIPTION
## Summary

Add [AG2](https://ag2.ai/) as a new generator module for AutoRAG.

- `autorag/nodes/generator/ag2.py` — `AG2Generator` class inheriting `BaseGenerator`
- Registration in `autorag/support.py` as `"ag2"` module type
- `tests/autorag/nodes/generator/test_ag2.py` — 19 unit tests (mocked)
- `sample_config/rag/english/non_gpu/simple_ag2.yaml` — Sample YAML config
- AG2 added to optional dependencies in `pyproject.toml`

### How it works

The AG2 generator orchestrates a multi-agent conversation (UserProxyAgent + AssistantAgent) to produce answers. AutoRAG can benchmark this against single-LLM generators (OpenAI, vLLM, etc.).

### YAML config usage

```yaml
- node_type: generator
  modules:
    - module_type: ag2
      llm: gpt-4o-mini
      max_turns: 1
```

### New files
- `autorag/nodes/generator/ag2.py`
- `tests/autorag/nodes/generator/test_ag2.py`
- `sample_config/rag/english/non_gpu/simple_ag2.yaml`

### Modified files
- `autorag/nodes/generator/__init__.py`
- `autorag/support.py`
- `pyproject.toml`

## Test plan

- [x] 19 unit tests pass (`pytest tests/autorag/nodes/generator/test_ag2.py -v`)
- [x] Existing generator tests unaffected (test_minimax, test_generator_base)
- [x] E2E test with real OpenAI API (string prompts, chat prompts, batch, run_evaluator, custom system message)
- [x] `ruff check` and `ruff format` pass