### PR TITLE
fix: hotfixes for v0.3.22 regressions (openai, nvidia reranker, chunk embedding, llama-index logprobs)

### DIFF
--- a/autorag/data/chunk/base.py
+++ b/autorag/data/chunk/base.py
@@ -77,9 +77,6 @@ def __get_chunk_instance(module_type: str, chunk_method: str, **kwargs):
 			kwargs.update({"sentence_splitter": sentence_splitter_func})
 
 	def get_embedding_model(_embed_model_str: str, _module_type: str):
-		if _embed_model_str == "openai":
-			if _module_type == "langchain_chunk":
-				_embed_model_str = "openai_langchain"
 		return EmbeddingModel.load(_embed_model_str)()
 
 	# Add embed_model to kwargs

--- a/autorag/data/qa/evolve/openai_query_evolve.py
+++ b/autorag/data/qa/evolve/openai_query_evolve.py
@@ -30,12 +30,12 @@ async def query_evolve_openai_base(
 	user_prompt = f"Question: {original_query}\nContext: {context_str}\nOutput: "
 	messages.append(ChatMessage(role=MessageRole.USER, content=user_prompt))
 
-	completion = await client.beta.chat.completions.parse(
+	completion = await client.responses.parse(
 		model=model_name,
-		messages=to_openai_message_dicts(messages),
-		response_format=Response,
+		input=to_openai_message_dicts(messages),
+		text_format=Response,
 	)
-	row["query"] = completion.choices[0].message.parsed.evolved_query
+	row["query"] = completion.output_parsed.evolved_query
 	return row
 
 
@@ -72,10 +72,10 @@ async def compress_ragas(
 	user_prompt = f"Question: {original_query}\nOutput: "
 	messages.append(ChatMessage(role=MessageRole.USER, content=user_prompt))
 
-	completion = await client.beta.chat.completions.parse(
+	completion = await client.responses.parse(
 		model=model_name,
-		messages=to_openai_message_dicts(messages),
-		response_format=Response,
+		input=to_openai_message_dicts(messages),
+		text_format=Response,
 	)
-	row["query"] = completion.choices[0].message.parsed.evolved_query
+	row["query"] = completion.output_parsed.evolved_query
 	return row

--- a/autorag/data/qa/filter/dontknow.py
+++ b/autorag/data/qa/filter/dontknow.py
@@ -77,14 +77,14 @@ async def dontknow_filter_openai(
 	system_prompt: List[ChatMessage] = FILTER_PROMPT["dontknow_filter"][lang]
 	result = []
 	for gen_gt in row["generation_gt"]:
-		completion = await client.beta.chat.completions.parse(
+		completion = await client.responses.parse(
 			model=model_name,
-			messages=to_openai_message_dicts(
+			input=to_openai_message_dicts(
 				system_prompt + [ChatMessage(role=MessageRole.USER, content=gen_gt)]
 			),
-			response_format=Response,
+			text_format=Response,
 		)
-		result.append(completion.choices[0].message.parsed.is_dont_know)
+		result.append(completion.output_parsed.is_dont_know)
 	return not any(result)
 
 

--- a/autorag/data/qa/filter/passage_dependency.py
+++ b/autorag/data/qa/filter/passage_dependency.py
@@ -37,9 +37,9 @@ async def passage_dependency_filter_openai(
 	assert "query" in row.keys(), "query column is not in the row."
 	system_prompt: List[ChatMessage] = FILTER_PROMPT["passage_dependency"][lang]
 	query = row["query"]
-	completion = await client.beta.chat.completions.parse(
+	completion = await client.responses.parse(
 		model=model_name,
-		messages=to_openai_message_dicts(
+		input=to_openai_message_dicts(
 			system_prompt
 			+ [
 				ChatMessage(
@@ -48,9 +48,9 @@ async def passage_dependency_filter_openai(
 				)
 			]
 		),
-		response_format=Response,
+		text_format=Response,
 	)
-	return not completion.choices[0].message.parsed.is_passage_dependent
+	return not completion.output_parsed.is_passage_dependent
 
 
 async def passage_dependency_filter_llama_index(

--- a/autorag/data/qa/generation_gt/openai_gen_gt.py
+++ b/autorag/data/qa/generation_gt/openai_gen_gt.py
@@ -25,16 +25,16 @@ async def make_gen_gt_openai(
 	passage_str = "\n".join(retrieval_gt_contents)
 	user_prompt = f"Text:\n<|text_start|>\n{passage_str}\n<|text_end|>\n\nQuestion:\n{query}\n\nAnswer:"
 
-	completion = await client.beta.chat.completions.parse(
+	completion = await client.responses.parse(
 		model=model_name,
-		messages=[
+		input=[
 			{"role": "system", "content": system_prompt},
 			{"role": "user", "content": user_prompt},
 		],
 		temperature=0.0,
-		response_format=Response,
+		text_format=Response,
 	)
-	response: Response = completion.choices[0].message.parsed
+	response: Response = completion.output_parsed
 	return add_gen_gt(row, response.answer)
 
 

--- a/autorag/data/qa/query/openai_gen_query.py
+++ b/autorag/data/qa/query/openai_gen_query.py
@@ -27,12 +27,12 @@ async def query_gen_openai_base(
 	user_prompt = f"{context_str}\n\nGenerated Question from the Text:\n"
 	messages.append(ChatMessage(role=MessageRole.USER, content=user_prompt))
 
-	completion = await client.beta.chat.completions.parse(
+	completion = await client.responses.parse(
 		model=model_name,
-		messages=to_openai_message_dicts(messages),
-		response_format=Response,
+		input=to_openai_message_dicts(messages),
+		text_format=Response,
 	)
-	row["query"] = completion.choices[0].message.parsed.query
+	row["query"] = completion.output_parsed.query
 	return row
 
 
@@ -86,10 +86,10 @@ async def two_hop_incremental(
 	user_prompt = f"{context_str}\n\nGenerated two-hop Question from two Documents:\n"
 	messages.append(ChatMessage(role=MessageRole.USER, content=user_prompt))
 
-	completion = await client.beta.chat.completions.parse(
+	completion = await client.responses.parse(
 		model=model_name,
-		messages=to_openai_message_dicts(messages),
-		response_format=TwoHopIncrementalResponse,
+		input=to_openai_message_dicts(messages),
+		text_format=TwoHopIncrementalResponse,
 	)
-	row["query"] = completion.choices[0].message.parsed.two_hop_question
+	row["query"] = completion.output_parsed.two_hop_question
 	return row

--- a/autorag/nodes/generator/llama_index_llm.py
+++ b/autorag/nodes/generator/llama_index_llm.py
@@ -125,13 +125,19 @@ class LlamaIndexLLM(BaseGenerator):
 
 		generated_texts = [res.message.content for res in results]
 		# Check is there a logprob available
-		if all(res.logprobs is not None for res in results):
-			retrieved_logprobs = [res.logprobs for res in results]
-			tokenized_ids = [logprob.token for logprob in retrieved_logprobs]
-			logprobs = [logprob.logprob for logprob in retrieved_logprobs]
+		if results and all(res.logprobs is not None for res in results):
+			per_response_logprobs = [res.logprobs for res in results]
+			tokenized_ids = [
+				[entry.token for entry in resp_logprobs]
+				for resp_logprobs in per_response_logprobs
+			]
+			logprobs = [
+				[entry.logprob for entry in resp_logprobs]
+				for resp_logprobs in per_response_logprobs
+			]
 		else:
 			logger.warning(
-				"Logprobs are not available from the LLM. So, returning pesudo logprobs."
+				"Logprobs are not available from the LLM. So, returning pseudo logprobs."
 			)
 			tokenized_ids = self.get_default_tokenized_ids(generated_texts)
 			logprobs = self.get_default_log_probs(tokenized_ids)

--- a/autorag/nodes/generator/openai_llm.py
+++ b/autorag/nodes/generator/openai_llm.py
@@ -84,14 +84,13 @@ class OpenAILLM(BaseGenerator):
 		except KeyError:
 			self.tokenizer = tiktoken.get_encoding("o200k_base")
 
-		self.max_token_size = (
-			MAX_TOKEN_DICT.get(self.llm) - 7
-		)  # because of chat token usage
-		if self.max_token_size is None:
+		max_token_limit = MAX_TOKEN_DICT.get(self.llm)
+		if max_token_limit is None:
 			raise ValueError(
 				f"Model {self.llm} does not supported. "
 				f"Please select the model between {list(MAX_TOKEN_DICT.keys())}"
 			)
+		self.max_token_size = max_token_limit - 7  # because of chat token usage
 
 	@result_to_dataframe(["generated_texts", "generated_tokens", "generated_log_probs"])
 	def pure(self, previous_result: pd.DataFrame, *args, **kwargs):
@@ -278,7 +277,7 @@ class OpenAILLM(BaseGenerator):
 			or self.llm.startswith("o3")
 			or self.llm.startswith("o4")
 		):
-			raise ValueError("get_result_reasoning is only for o1,o3,o4,gpt-5 models.")
+			raise ValueError("get_result_reasoning is only for o1, o3, and o4 models.")
 		# The default temperature for the o1 model is 1. 1 is only supported.
 		# See https://platform.openai.com/docs/guides/reasoning about beta limitation of o1 models.
 		unsupported_params = [

--- a/autorag/nodes/passagereranker/nvidia.py
+++ b/autorag/nodes/passagereranker/nvidia.py
@@ -85,6 +85,9 @@ class NvidiaReranker(BasePassageReranker):
 				f"len(queries)={len(queries)}, len(contents_list)={len(contents_list)}, len(ids_list)={len(ids_list)}."
 			)
 
+		if not queries:
+			return [], [], []
+
 		tasks = [
 			nvidia_rerank_pure(
 				self.session,
@@ -110,6 +113,7 @@ class NvidiaReranker(BasePassageReranker):
 		content_result, id_result, score_result = zip(*results)
 
 		return list(content_result), list(id_result), list(score_result)
+
 
 async def nvidia_rerank_pure(
 	session: aiohttp.ClientSession,
@@ -160,7 +164,7 @@ async def nvidia_rerank_pure(
 			)
 
 		def _score(item):
-			# According to the NVIDIA documentation, the output can be either 
+			# According to the NVIDIA documentation, the output can be either
 			# probability scores or raw logits depending on the configuration.
 			# So we check both fields to support various model settings.
 			if item.get("logit") is not None:
@@ -174,7 +178,7 @@ async def nvidia_rerank_pure(
 		top_rankings = rankings[:top_k]
 
 		reranked_contents = [documents[item["index"]] for item in top_rankings]
-		reranked_ids      = [ids[item["index"]]       for item in top_rankings]
-		reranked_scores   = [_score(item)             for item in top_rankings]
+		reranked_ids = [ids[item["index"]] for item in top_rankings]
+		reranked_scores = [_score(item) for item in top_rankings]
 
 		return reranked_contents, reranked_ids, reranked_scores

--- a/autorag/support.py
+++ b/autorag/support.py
@@ -131,6 +131,8 @@ def get_support_modules(module_name: str) -> Callable:
 		),
 		"flashrank_reranker": ("autorag.nodes.passagereranker", "FlashRankReranker"),
 		"FlashRankReranker": ("autorag.nodes.passagereranker", "FlashRankReranker"),
+		"nvidia_reranker": ("autorag.nodes.passagereranker", "NvidiaReranker"),
+		"NvidiaReranker": ("autorag.nodes.passagereranker", "NvidiaReranker"),
 		# passage_filter
 		"pass_passage_filter": ("autorag.nodes.passagefilter", "PassPassageFilter"),
 		"similarity_threshold_cutoff": (

--- a/tests/autorag/data/qa/evolve/test_openai_query_evolve.py
+++ b/tests/autorag/data/qa/evolve/test_openai_query_evolve.py
@@ -1,88 +1,74 @@
-import time
+from dataclasses import dataclass
+from typing import Any
 from unittest.mock import patch
 
 from openai import AsyncOpenAI
-import openai.resources.chat
+import openai.resources.responses
 from autorag.data.qa.evolve.openai_query_evolve import (
-    conditional_evolve_ragas,
-    Response,
-    reasoning_evolve_ragas,
-    compress_ragas,
+	conditional_evolve_ragas,
+	Response,
+	reasoning_evolve_ragas,
+	compress_ragas,
 )
 from autorag.data.qa.schema import QA
 from tests.autorag.data.qa.evolve.base_test_query_evolve import qa_df
-from openai.types.chat import (
-    ParsedChatCompletion,
-    ParsedChatCompletionMessage,
-    ParsedChoice,
-)
 
 
-async def mock_gen_gt_response(*args, **kwargs) -> ParsedChatCompletion[Response]:
-    return ParsedChatCompletion(
-        id="test_id",
-        choices=[
-            ParsedChoice(
-                finish_reason="stop",
-                index=0,
-                message=ParsedChatCompletionMessage(
-                    parsed=Response(evolved_query="mock answer"),
-                    role="assistant",
-                ),
-            )
-        ],
-        created=int(time.time()),
-        model="gpt-4o-mini-2024-07-18",
-        object="chat.completion",
-    )
+@dataclass
+class _MockParsedResponse:
+	output_parsed: Any
+
+
+async def mock_gen_gt_response(*args, **kwargs) -> _MockParsedResponse:
+	return _MockParsedResponse(output_parsed=Response(evolved_query="mock answer"))
 
 
 client = AsyncOpenAI()
 
 
 @patch.object(
-    openai.resources.chat.completions.AsyncCompletions,
-    "parse",
-    mock_gen_gt_response,
+	openai.resources.responses.AsyncResponses,
+	"parse",
+	mock_gen_gt_response,
 )
 def test_conditional_evolve_ragas():
-    qa = QA(qa_df)
-    new_qa = qa.batch_apply(conditional_evolve_ragas, client=client)
-    assert "query" in new_qa.data.columns
-    assert all(isinstance(query, str) for query in new_qa.data["query"].tolist())
-    assert len(new_qa.data) == len(qa_df)
-    assert all(
-        x != y for x, y in zip(new_qa.data["query"].tolist(), qa_df["query"].tolist())
-    )
+	qa = QA(qa_df)
+	new_qa = qa.batch_apply(conditional_evolve_ragas, client=client)
+	assert "query" in new_qa.data.columns
+	assert all(isinstance(query, str) for query in new_qa.data["query"].tolist())
+	assert len(new_qa.data) == len(qa_df)
+	assert all(
+		x != y for x, y in zip(new_qa.data["query"].tolist(), qa_df["query"].tolist())
+	)
 
 
 @patch.object(
-    openai.resources.chat.completions.AsyncCompletions,
-    "parse",
-    mock_gen_gt_response,
+	openai.resources.responses.AsyncResponses,
+	"parse",
+	mock_gen_gt_response,
 )
 def test_reasoning_evolve_ragas():
-    qa = QA(qa_df)
-    new_qa = qa.batch_apply(reasoning_evolve_ragas, client=client)
-    assert "query" in new_qa.data.columns
-    assert all(isinstance(query, str) for query in new_qa.data["query"].tolist())
-    assert len(new_qa.data) == len(qa_df)
-    assert all(
-        x != y for x, y in zip(new_qa.data["query"].tolist(), qa_df["query"].tolist())
-    )
+	qa = QA(qa_df)
+	new_qa = qa.batch_apply(reasoning_evolve_ragas, client=client)
+	assert "query" in new_qa.data.columns
+	assert all(isinstance(query, str) for query in new_qa.data["query"].tolist())
+	assert len(new_qa.data) == len(qa_df)
+	assert all(
+		x != y for x, y in zip(new_qa.data["query"].tolist(), qa_df["query"].tolist())
+	)
 
 
 @patch.object(
-    openai.resources.chat.completions.AsyncCompletions,
-    "parse",
-    mock_gen_gt_response,
+	openai.resources.responses.AsyncResponses,
+	"parse",
+	mock_gen_gt_response,
 )
 def test_compress_ragas():
-    qa = QA(qa_df)
-    new_qa = qa.batch_apply(compress_ragas, client=client)
-    assert "query" in new_qa.data.columns
-    assert all(isinstance(query, str) for query in new_qa.data["query"].tolist())
-    assert len(new_qa.data) == len(qa_df)
-    assert all(
-        x != y for x, y in zip(new_qa.data["query"].tolist(), qa_df["query"].tolist())
-    )
+	qa = QA(qa_df)
+	new_qa = qa.batch_apply(compress_ragas, client=client)
+	assert "query" in new_qa.data.columns
+	assert all(isinstance(query, str) for query in new_qa.data["query"].tolist())
+	assert len(new_qa.data) == len(qa_df)
+	assert all(
+		x != y for x, y in zip(new_qa.data["query"].tolist(), qa_df["query"].tolist())
+	)

--- a/tests/autorag/data/qa/filter/test_dontknow.py
+++ b/tests/autorag/data/qa/filter/test_dontknow.py
@@ -1,177 +1,166 @@
-import time
+from dataclasses import dataclass
+from typing import Any
 from unittest.mock import patch
 
 import pandas as pd
 from llama_index.core.base.llms.types import ChatResponse, ChatMessage, MessageRole
 from llama_index.llms.openai import OpenAI
 from openai import AsyncOpenAI
-from openai.types.chat import (
-    ParsedChatCompletion,
-    ParsedChoice,
-    ParsedChatCompletionMessage,
-)
-import openai.resources.chat
+import openai.resources.responses
 
 from autorag.data.qa.filter.dontknow import (
-    dontknow_filter_rule_based,
-    dontknow_filter_openai,
-    Response,
-    dontknow_filter_llama_index,
+	dontknow_filter_rule_based,
+	dontknow_filter_openai,
+	Response,
+	dontknow_filter_llama_index,
 )
 from autorag.data.qa.schema import QA
 
 en_qa_df = pd.DataFrame(
-    {
-        "generation_gt": [
-            ["I don't know what to say", "This is a test"],
-            ["This is another test", "I do not know the answer"],
-            ["This is fine", "All good"],
-        ]
-    }
+	{
+		"generation_gt": [
+			["I don't know what to say", "This is a test"],
+			["This is another test", "I do not know the answer"],
+			["This is fine", "All good"],
+		]
+	}
 )
 
 ko_qa_df = pd.DataFrame(
-    {
-        "generation_gt": [
-            ["몰라요", "테스트입니다"],
-            ["모르겠습니다", "이것은 테스트입니다"],
-            ["모르겠어요", "이것은 또 다른 테스트입니다"],
-            ["이것은 괜찮습니다", "모든 것이 좋습니다"],
-        ]
-    }
+	{
+		"generation_gt": [
+			["몰라요", "테스트입니다"],
+			["모르겠습니다", "이것은 테스트입니다"],
+			["모르겠어요", "이것은 또 다른 테스트입니다"],
+			["이것은 괜찮습니다", "모든 것이 좋습니다"],
+		]
+	}
 )
 
 ja_qa_df = pd.DataFrame(
-    {
-        "generation_gt": [
-            ["わかりません", "これはテストです"],
-            ["答えがわかりません", "これは別のテストです"],
-            ["これは大丈夫です", "すべて問題ありません"],
-        ]
-    }
+	{
+		"generation_gt": [
+			["わかりません", "これはテストです"],
+			["答えがわかりません", "これは別のテストです"],
+			["これは大丈夫です", "すべて問題ありません"],
+		]
+	}
 )
 
 dont_know_lang = [
-    "I don't know what to say",
-    "I do not know the answer",
-    "몰라요",
-    "모르겠습니다",
-    "모르겠어요",
-    "わかりません",
-    "答えがわかりません",
+	"I don't know what to say",
+	"I do not know the answer",
+	"몰라요",
+	"모르겠습니다",
+	"모르겠어요",
+	"わかりません",
+	"答えがわかりません",
 ]
 
 # Expected data after filtering
 expected_df_en = pd.DataFrame({"generation_gt": [["This is fine", "All good"]]})
 
 expected_df_ko = pd.DataFrame(
-    {"generation_gt": [["이것은 괜찮습니다", "모든 것이 좋습니다"]]}
+	{"generation_gt": [["이것은 괜찮습니다", "모든 것이 좋습니다"]]}
 )
 expected_df_ja = pd.DataFrame(
-    {"generation_gt": [["これは大丈夫です", "すべて問題ありません"]]}
+	{"generation_gt": [["これは大丈夫です", "すべて問題ありません"]]}
 )
 
 
-async def mock_openai_response(*args, **kwargs) -> ParsedChatCompletion[Response]:
-    user_prompt = kwargs["messages"][1]["content"]
-    return ParsedChatCompletion(
-        id="test_id",
-        choices=[
-            ParsedChoice(
-                finish_reason="stop",
-                index=0,
-                message=ParsedChatCompletionMessage(
-                    parsed=Response(is_dont_know=user_prompt in dont_know_lang),
-                    role="assistant",
-                ),
-            )
-        ],
-        created=int(time.time()),
-        model="gpt-4o-mini-2024-07-18",
-        object="chat.completion",
-    )
+@dataclass
+class _MockParsedResponse:
+	output_parsed: Any
+
+
+async def mock_openai_response(*args, **kwargs) -> _MockParsedResponse:
+	# client.responses.parse is called with input=<list of message dicts>.
+	user_prompt = kwargs["input"][1]["content"]
+	return _MockParsedResponse(
+		output_parsed=Response(is_dont_know=user_prompt in dont_know_lang)
+	)
 
 
 async def mock_llama_index_response(*args, **kwargs) -> ChatResponse:
-    user_prompt = kwargs["messages"][1].content
-    return ChatResponse(
-        message=ChatMessage(
-            role=MessageRole.ASSISTANT, content=str(user_prompt in dont_know_lang)
-        )
-    )
+	user_prompt = kwargs["messages"][1].content
+	return ChatResponse(
+		message=ChatMessage(
+			role=MessageRole.ASSISTANT, content=str(user_prompt in dont_know_lang)
+		)
+	)
 
 
 def test_dontknow_filter_rule_based():
-    # Test for English
-    en_qa = QA(en_qa_df)
-    result_en_qa = en_qa.filter(dontknow_filter_rule_based, lang="en").map(
-        lambda df: df.reset_index(drop=True)
-    )
-    pd.testing.assert_frame_equal(result_en_qa.data, expected_df_en)
+	# Test for English
+	en_qa = QA(en_qa_df)
+	result_en_qa = en_qa.filter(dontknow_filter_rule_based, lang="en").map(
+		lambda df: df.reset_index(drop=True)
+	)
+	pd.testing.assert_frame_equal(result_en_qa.data, expected_df_en)
 
-    # Test for Korean
-    ko_qa = QA(ko_qa_df)
-    result_ko_qa = ko_qa.filter(dontknow_filter_rule_based, lang="ko").map(
-        lambda df: df.reset_index(drop=True)
-    )
-    pd.testing.assert_frame_equal(result_ko_qa.data, expected_df_ko)
-    # Test for Japanese
-    ja_qa = QA(ja_qa_df)
-    result_ja_qa = ja_qa.filter(dontknow_filter_rule_based, lang="ja").map(
-        lambda df: df.reset_index(drop=True)
-    )
-    pd.testing.assert_frame_equal(result_ja_qa.data, expected_df_ja)
+	# Test for Korean
+	ko_qa = QA(ko_qa_df)
+	result_ko_qa = ko_qa.filter(dontknow_filter_rule_based, lang="ko").map(
+		lambda df: df.reset_index(drop=True)
+	)
+	pd.testing.assert_frame_equal(result_ko_qa.data, expected_df_ko)
+	# Test for Japanese
+	ja_qa = QA(ja_qa_df)
+	result_ja_qa = ja_qa.filter(dontknow_filter_rule_based, lang="ja").map(
+		lambda df: df.reset_index(drop=True)
+	)
+	pd.testing.assert_frame_equal(result_ja_qa.data, expected_df_ja)
 
 
 @patch.object(
-    openai.resources.chat.completions.AsyncCompletions,
-    "parse",
-    mock_openai_response,
+	openai.resources.responses.AsyncResponses,
+	"parse",
+	mock_openai_response,
 )
 def test_dontknow_filter_openai():
-    client = AsyncOpenAI()
-    en_qa = QA(en_qa_df)
-    result_en_qa = en_qa.batch_filter(
-        dontknow_filter_openai, client=client, lang="en"
-    ).map(lambda df: df.reset_index(drop=True))
-    pd.testing.assert_frame_equal(result_en_qa.data, expected_df_en)
+	client = AsyncOpenAI()
+	en_qa = QA(en_qa_df)
+	result_en_qa = en_qa.batch_filter(
+		dontknow_filter_openai, client=client, lang="en"
+	).map(lambda df: df.reset_index(drop=True))
+	pd.testing.assert_frame_equal(result_en_qa.data, expected_df_en)
 
-    # Test for Korean
-    ko_qa = QA(ko_qa_df)
-    result_ko_qa = ko_qa.batch_filter(
-        dontknow_filter_openai, client=client, lang="ko"
-    ).map(lambda df: df.reset_index(drop=True))
-    pd.testing.assert_frame_equal(result_ko_qa.data, expected_df_ko)
+	# Test for Korean
+	ko_qa = QA(ko_qa_df)
+	result_ko_qa = ko_qa.batch_filter(
+		dontknow_filter_openai, client=client, lang="ko"
+	).map(lambda df: df.reset_index(drop=True))
+	pd.testing.assert_frame_equal(result_ko_qa.data, expected_df_ko)
 
-    # Test for Japanese
-    ja_qa = QA(ja_qa_df)
-    result_ja_qa = ja_qa.batch_filter(
-        dontknow_filter_openai, client=client, lang="ja"
-    ).map(lambda df: df.reset_index(drop=True))
-    pd.testing.assert_frame_equal(result_ja_qa.data, expected_df_ja)
+	# Test for Japanese
+	ja_qa = QA(ja_qa_df)
+	result_ja_qa = ja_qa.batch_filter(
+		dontknow_filter_openai, client=client, lang="ja"
+	).map(lambda df: df.reset_index(drop=True))
+	pd.testing.assert_frame_equal(result_ja_qa.data, expected_df_ja)
 
 
 @patch.object(
-    OpenAI,
-    "achat",
-    mock_llama_index_response,
+	OpenAI,
+	"achat",
+	mock_llama_index_response,
 )
 def test_dontknow_filter_llama_index():
-    llm = OpenAI()
-    en_qa = QA(en_qa_df)
-    result_en_qa = en_qa.batch_filter(
-        dontknow_filter_llama_index, llm=llm, lang="en"
-    ).map(lambda df: df.reset_index(drop=True))
-    pd.testing.assert_frame_equal(result_en_qa.data, expected_df_en)
+	llm = OpenAI()
+	en_qa = QA(en_qa_df)
+	result_en_qa = en_qa.batch_filter(
+		dontknow_filter_llama_index, llm=llm, lang="en"
+	).map(lambda df: df.reset_index(drop=True))
+	pd.testing.assert_frame_equal(result_en_qa.data, expected_df_en)
 
-    ko_qa = QA(ko_qa_df)
-    result_ko_qa = ko_qa.batch_filter(
-        dontknow_filter_llama_index, llm=llm, lang="ko"
-    ).map(lambda df: df.reset_index(drop=True))
-    pd.testing.assert_frame_equal(result_ko_qa.data, expected_df_ko)
+	ko_qa = QA(ko_qa_df)
+	result_ko_qa = ko_qa.batch_filter(
+		dontknow_filter_llama_index, llm=llm, lang="ko"
+	).map(lambda df: df.reset_index(drop=True))
+	pd.testing.assert_frame_equal(result_ko_qa.data, expected_df_ko)
 
-    ja_qa = QA(ja_qa_df)
-    result_ja_qa = ja_qa.batch_filter(
-        dontknow_filter_llama_index, llm=llm, lang="ja"
-    ).map(lambda df: df.reset_index(drop=True))
-    pd.testing.assert_frame_equal(result_ja_qa.data, expected_df_ja)
+	ja_qa = QA(ja_qa_df)
+	result_ja_qa = ja_qa.batch_filter(
+		dontknow_filter_llama_index, llm=llm, lang="ja"
+	).map(lambda df: df.reset_index(drop=True))
+	pd.testing.assert_frame_equal(result_ja_qa.data, expected_df_ja)

--- a/tests/autorag/data/qa/filter/test_passage_dependency.py
+++ b/tests/autorag/data/qa/filter/test_passage_dependency.py
@@ -1,180 +1,167 @@
-import time
+from dataclasses import dataclass
+from typing import Any
 from unittest.mock import patch
 
 import pandas as pd
 from llama_index.llms.openai import OpenAI
 from openai import AsyncOpenAI
-from openai.types.chat import (
-    ParsedChatCompletion,
-    ParsedChoice,
-    ParsedChatCompletionMessage,
-)
-import openai.resources.chat
+import openai.resources.responses
 
 from llama_index.core.base.llms.types import ChatResponse, ChatMessage, MessageRole
 from autorag.data.qa.filter.passage_dependency import (
-    passage_dependency_filter_openai,
-    passage_dependency_filter_llama_index,
-    Response,
+	passage_dependency_filter_openai,
+	passage_dependency_filter_llama_index,
+	Response,
 )
 from autorag.data.qa.schema import QA
 
 en_qa_df = pd.DataFrame(
-    {
-        "query": [
-            "What is the most significant discovery mentioned in the research paper?",
-            "What was the ruling in the case described in this legal brief?",
-            "What is the passage reranker role in the Advanced RAG system?",
-            "Who is the latest 30 homerun 30 steal record owner in the KBO league?",
-        ]
-    }
+	{
+		"query": [
+			"What is the most significant discovery mentioned in the research paper?",
+			"What was the ruling in the case described in this legal brief?",
+			"What is the passage reranker role in the Advanced RAG system?",
+			"Who is the latest 30 homerun 30 steal record owner in the KBO league?",
+		]
+	}
 )
 
 ko_qa_df = pd.DataFrame(
-    {
-        "query": [
-            "연구 논문에서 언급된 가장 중요한 발견은 무엇입니까?",
-            "이 판결문에 기술된 사건의 판결은 무엇이었습니까?",
-            "Advanced RAG 시스템에서 리랭커 역할은 무엇입니까?",
-            "KBO 리그에서 가장 최근 30홈런 30도루를 기록한 선수는 누구입니까?",
-        ]
-    }
+	{
+		"query": [
+			"연구 논문에서 언급된 가장 중요한 발견은 무엇입니까?",
+			"이 판결문에 기술된 사건의 판결은 무엇이었습니까?",
+			"Advanced RAG 시스템에서 리랭커 역할은 무엇입니까?",
+			"KBO 리그에서 가장 최근 30홈런 30도루를 기록한 선수는 누구입니까?",
+		]
+	}
 )
 
 ja_qa_df = pd.DataFrame(
-    {
-        "query": [
-            "研究論文で言及された最も重要な発見は何ですか？",
-            "この判例に記述された判決は何ですか？",
-            "Advanced RAGシステムにおけるリランカーの役割は何ですか?",
-            "KBOリーグで最新の30本塁打30盗塁の記録保持者は誰ですか?",
-        ]
-    }
+	{
+		"query": [
+			"研究論文で言及された最も重要な発見は何ですか？",
+			"この判例に記述された判決は何ですか？",
+			"Advanced RAGシステムにおけるリランカーの役割は何ですか?",
+			"KBOリーグで最新の30本塁打30盗塁の記録保持者は誰ですか?",
+		]
+	}
 )
 
 expected_df_en = pd.DataFrame(
-    {
-        "query": [
-            "What is the passage reranker role in the Advanced RAG system?",
-            "Who is the latest 30 homerun 30 steal record owner in the KBO league?",
-        ]
-    }
+	{
+		"query": [
+			"What is the passage reranker role in the Advanced RAG system?",
+			"Who is the latest 30 homerun 30 steal record owner in the KBO league?",
+		]
+	}
 )
 
 expected_df_ko = pd.DataFrame(
-    {
-        "query": [
-            "Advanced RAG 시스템에서 리랭커 역할은 무엇입니까?",
-            "KBO 리그에서 가장 최근 30홈런 30도루를 기록한 선수는 누구입니까?",
-        ]
-    }
+	{
+		"query": [
+			"Advanced RAG 시스템에서 리랭커 역할은 무엇입니까?",
+			"KBO 리그에서 가장 최근 30홈런 30도루를 기록한 선수는 누구입니까?",
+		]
+	}
 )
 
 expected_df_ja = pd.DataFrame(
-    {
-        "query": [
-            "Advanced RAGシステムにおけるリランカーの役割は何ですか?",
-            "KBOリーグで最新の30本塁打30盗塁の記録保持者は誰ですか?",
-        ]
-    }
+	{
+		"query": [
+			"Advanced RAGシステムにおけるリランカーの役割は何ですか?",
+			"KBOリーグで最新の30本塁打30盗塁の記録保持者は誰ですか?",
+		]
+	}
 )
 
 
 passage_dependent_response = [
-    "What is the most significant discovery mentioned in the research paper?",
-    "What was the ruling in the case described in this legal brief?",
-    "연구 논문에서 언급된 가장 중요한 발견은 무엇입니까?",
-    "이 판결문에 기술된 사건의 판결은 무엇이었습니까?",
-    "研究論文で言及された最も重要な発見は何ですか？",
-    "この判例に記述された判決は何ですか？",
+	"What is the most significant discovery mentioned in the research paper?",
+	"What was the ruling in the case described in this legal brief?",
+	"연구 논문에서 언급된 가장 중요한 발견은 무엇입니까?",
+	"이 판결문에 기술된 사건의 판결은 무엇이었습니까?",
+	"研究論文で言及された最も重要な発見は何ですか？",
+	"この判例に記述された判決は何ですか？",
 ]
 
 
-async def mock_openai_response(*args, **kwargs) -> ParsedChatCompletion[Response]:
-    user_prompt = kwargs["messages"][1]["content"]
-    return ParsedChatCompletion(
-        id="test_id",
-        choices=[
-            ParsedChoice(
-                finish_reason="stop",
-                index=0,
-                message=ParsedChatCompletionMessage(
-                    parsed=Response(
-                        is_passage_dependent=user_prompt.split("\n")[0]
-                        .split(":")[1]
-                        .strip()
-                        in passage_dependent_response
-                    ),
-                    role="assistant",
-                ),
-            )
-        ],
-        created=int(time.time()),
-        model="gpt-4o-mini-2024-07-18",
-        object="chat.completion",
-    )
+@dataclass
+class _MockParsedResponse:
+	output_parsed: Any
+
+
+async def mock_openai_response(*args, **kwargs) -> _MockParsedResponse:
+	# client.responses.parse is called with input=<list of message dicts>.
+	user_prompt = kwargs["input"][1]["content"]
+	return _MockParsedResponse(
+		output_parsed=Response(
+			is_passage_dependent=user_prompt.split("\n")[0].split(":")[1].strip()
+			in passage_dependent_response
+		)
+	)
 
 
 async def mock_llama_index_response(*args, **kwargs) -> ChatResponse:
-    user_prompt = kwargs["messages"][1].content
-    return ChatResponse(
-        message=ChatMessage(
-            role=MessageRole.ASSISTANT,
-            content=str(
-                user_prompt.split("\n")[0].split(":")[1].strip()
-                in passage_dependent_response
-            ),
-        )
-    )
+	user_prompt = kwargs["messages"][1].content
+	return ChatResponse(
+		message=ChatMessage(
+			role=MessageRole.ASSISTANT,
+			content=str(
+				user_prompt.split("\n")[0].split(":")[1].strip()
+				in passage_dependent_response
+			),
+		)
+	)
 
 
 @patch.object(
-    openai.resources.chat.completions.AsyncCompletions,
-    "parse",
-    mock_openai_response,
+	openai.resources.responses.AsyncResponses,
+	"parse",
+	mock_openai_response,
 )
 def test_passage_dependency_filter_openai():
-    client = AsyncOpenAI()
-    en_qa = QA(en_qa_df)
-    result_en_qa = en_qa.batch_filter(
-        passage_dependency_filter_openai, client=client, lang="en"
-    ).map(lambda df: df.reset_index(drop=True))
-    pd.testing.assert_frame_equal(result_en_qa.data, expected_df_en)
+	client = AsyncOpenAI()
+	en_qa = QA(en_qa_df)
+	result_en_qa = en_qa.batch_filter(
+		passage_dependency_filter_openai, client=client, lang="en"
+	).map(lambda df: df.reset_index(drop=True))
+	pd.testing.assert_frame_equal(result_en_qa.data, expected_df_en)
 
-    ko_qa = QA(ko_qa_df)
-    result_ko_qa = ko_qa.batch_filter(
-        passage_dependency_filter_openai, client=client, lang="ko"
-    ).map(lambda df: df.reset_index(drop=True))
-    pd.testing.assert_frame_equal(result_ko_qa.data, expected_df_ko)
+	ko_qa = QA(ko_qa_df)
+	result_ko_qa = ko_qa.batch_filter(
+		passage_dependency_filter_openai, client=client, lang="ko"
+	).map(lambda df: df.reset_index(drop=True))
+	pd.testing.assert_frame_equal(result_ko_qa.data, expected_df_ko)
 
-    ja_qa = QA(ja_qa_df)
-    result_ja_qa = ja_qa.batch_filter(
-        passage_dependency_filter_openai, client=client, lang="ja"
-    ).map(lambda df: df.reset_index(drop=True))
-    pd.testing.assert_frame_equal(result_ja_qa.data, expected_df_ja)
+	ja_qa = QA(ja_qa_df)
+	result_ja_qa = ja_qa.batch_filter(
+		passage_dependency_filter_openai, client=client, lang="ja"
+	).map(lambda df: df.reset_index(drop=True))
+	pd.testing.assert_frame_equal(result_ja_qa.data, expected_df_ja)
 
 
 @patch.object(
-    OpenAI,
-    "achat",
-    mock_llama_index_response,
+	OpenAI,
+	"achat",
+	mock_llama_index_response,
 )
 def test_passage_dependency_filter_llama_index():
-    llm = OpenAI(temperature=0, model="gpt-4o-mini")
-    en_qa = QA(en_qa_df)
-    result_en_qa = en_qa.batch_filter(
-        passage_dependency_filter_llama_index, llm=llm, lang="en"
-    ).map(lambda df: df.reset_index(drop=True))
-    pd.testing.assert_frame_equal(result_en_qa.data, expected_df_en)
+	llm = OpenAI(temperature=0, model="gpt-4o-mini")
+	en_qa = QA(en_qa_df)
+	result_en_qa = en_qa.batch_filter(
+		passage_dependency_filter_llama_index, llm=llm, lang="en"
+	).map(lambda df: df.reset_index(drop=True))
+	pd.testing.assert_frame_equal(result_en_qa.data, expected_df_en)
 
-    ko_qa = QA(ko_qa_df)
-    result_ko_qa = ko_qa.batch_filter(
-        passage_dependency_filter_llama_index, llm=llm, lang="ko"
-    ).map(lambda df: df.reset_index(drop=True))
-    pd.testing.assert_frame_equal(result_ko_qa.data, expected_df_ko)
+	ko_qa = QA(ko_qa_df)
+	result_ko_qa = ko_qa.batch_filter(
+		passage_dependency_filter_llama_index, llm=llm, lang="ko"
+	).map(lambda df: df.reset_index(drop=True))
+	pd.testing.assert_frame_equal(result_ko_qa.data, expected_df_ko)
 
-    ja_qa = QA(ja_qa_df)
-    result_ja_qa = ja_qa.batch_filter(
-        passage_dependency_filter_llama_index, llm=llm, lang="ja"
-    ).map(lambda df: df.reset_index(drop=True))
-    pd.testing.assert_frame_equal(result_ja_qa.data, expected_df_ja)
+	ja_qa = QA(ja_qa_df)
+	result_ja_qa = ja_qa.batch_filter(
+		passage_dependency_filter_llama_index, llm=llm, lang="ja"
+	).map(lambda df: df.reset_index(drop=True))
+	pd.testing.assert_frame_equal(result_ja_qa.data, expected_df_ja)

--- a/tests/autorag/data/qa/generation_gt/test_openai_gen_gt.py
+++ b/tests/autorag/data/qa/generation_gt/test_openai_gen_gt.py
@@ -1,102 +1,88 @@
-import time
+from dataclasses import dataclass
+from typing import Any
 from unittest.mock import patch
 
-import openai.resources.chat
+import openai.resources.responses
 from openai import AsyncOpenAI
-from openai.types.chat import (
-    ParsedChatCompletion,
-    ParsedChoice,
-    ParsedChatCompletionMessage,
-)
 
 from autorag.data.qa.generation_gt.openai_gen_gt import (
-    make_concise_gen_gt,
-    make_basic_gen_gt,
-    Response,
+	make_concise_gen_gt,
+	make_basic_gen_gt,
+	Response,
 )
 from autorag.data.qa.schema import QA
 from tests.autorag.data.qa.generation_gt.base_test_generation_gt import (
-    qa_df,
-    check_generation_gt,
+	qa_df,
+	check_generation_gt,
 )
 
 client = AsyncOpenAI()
 
 
-async def mock_gen_gt_response(*args, **kwargs) -> ParsedChatCompletion[Response]:
-    return ParsedChatCompletion(
-        id="test_id",
-        choices=[
-            ParsedChoice(
-                finish_reason="stop",
-                index=0,
-                message=ParsedChatCompletionMessage(
-                    parsed=Response(answer="mock answer"),
-                    role="assistant",
-                ),
-            )
-        ],
-        created=int(time.time()),
-        model="gpt-4o-mini-2024-07-18",
-        object="chat.completion",
-    )
+@dataclass
+class _MockParsedResponse:
+	output_parsed: Any
+
+
+async def mock_gen_gt_response(*args, **kwargs) -> _MockParsedResponse:
+	return _MockParsedResponse(output_parsed=Response(answer="mock answer"))
 
 
 @patch.object(
-    openai.resources.chat.completions.AsyncCompletions,
-    "parse",
-    mock_gen_gt_response,
+	openai.resources.responses.AsyncResponses,
+	"parse",
+	mock_gen_gt_response,
 )
 def test_make_concise_gen_gt():
-    qa = QA(qa_df)
-    result_qa = qa.batch_apply(
-        make_concise_gen_gt, client=client, model_name="gpt-4o-mini-2024-07-18"
-    )
-    check_generation_gt(result_qa)
+	qa = QA(qa_df)
+	result_qa = qa.batch_apply(
+		make_concise_gen_gt, client=client, model_name="gpt-4o-mini-2024-07-18"
+	)
+	check_generation_gt(result_qa)
 
 
 @patch.object(
-    openai.resources.chat.completions.AsyncCompletions,
-    "parse",
-    mock_gen_gt_response,
+	openai.resources.responses.AsyncResponses,
+	"parse",
+	mock_gen_gt_response,
 )
 def test_make_basic_gen_gt():
-    qa = QA(qa_df)
-    result_qa = qa.batch_apply(make_basic_gen_gt, client=client)
-    check_generation_gt(result_qa)
+	qa = QA(qa_df)
+	result_qa = qa.batch_apply(make_basic_gen_gt, client=client)
+	check_generation_gt(result_qa)
 
 
 @patch.object(
-    openai.resources.chat.completions.AsyncCompletions,
-    "parse",
-    mock_gen_gt_response,
+	openai.resources.responses.AsyncResponses,
+	"parse",
+	mock_gen_gt_response,
 )
 def test_make_basic_gen_gt_ko():
-    qa = QA(qa_df)
-    result_qa = qa.batch_apply(make_basic_gen_gt, client=client, lang="ko")
-    check_generation_gt(result_qa)
+	qa = QA(qa_df)
+	result_qa = qa.batch_apply(make_basic_gen_gt, client=client, lang="ko")
+	check_generation_gt(result_qa)
 
 
 @patch.object(
-    openai.resources.chat.completions.AsyncCompletions,
-    "parse",
-    mock_gen_gt_response,
+	openai.resources.responses.AsyncResponses,
+	"parse",
+	mock_gen_gt_response,
 )
 def test_make_basic_gen_gt_ja():
-    qa = QA(qa_df)
-    result_qa = qa.batch_apply(make_basic_gen_gt, client=client, lang="ja")
-    check_generation_gt(result_qa)
+	qa = QA(qa_df)
+	result_qa = qa.batch_apply(make_basic_gen_gt, client=client, lang="ja")
+	check_generation_gt(result_qa)
 
 
 @patch.object(
-    openai.resources.chat.completions.AsyncCompletions,
-    "parse",
-    mock_gen_gt_response,
+	openai.resources.responses.AsyncResponses,
+	"parse",
+	mock_gen_gt_response,
 )
 def test_make_multiple_gen_gt():
-    qa = QA(qa_df)
-    result_qa = qa.batch_apply(make_basic_gen_gt, client=client, lang="ko").batch_apply(
-        make_concise_gen_gt, client=client
-    )
-    check_generation_gt(result_qa)
-    assert all(len(x) == 2 for x in result_qa.data["generation_gt"].tolist())
+	qa = QA(qa_df)
+	result_qa = qa.batch_apply(make_basic_gen_gt, client=client, lang="ko").batch_apply(
+		make_concise_gen_gt, client=client
+	)
+	check_generation_gt(result_qa)
+	assert all(len(x) == 2 for x in result_qa.data["generation_gt"].tolist())

--- a/tests/autorag/data/qa/query/test_openai_gen_query.py
+++ b/tests/autorag/data/qa/query/test_openai_gen_query.py
@@ -1,20 +1,16 @@
-import time
+from dataclasses import dataclass
+from typing import Any
 from unittest.mock import patch
 
-import openai.resources.chat
+import openai.resources.responses
 from openai import AsyncOpenAI
-from openai.types.chat import (
-    ParsedChatCompletion,
-    ParsedChatCompletionMessage,
-    ParsedChoice,
-)
 
 from autorag.data.qa.query.openai_gen_query import (
-    Response,
-    factoid_query_gen,
-    concept_completion_query_gen,
-    two_hop_incremental,
-    TwoHopIncrementalResponse,
+	Response,
+	factoid_query_gen,
+	concept_completion_query_gen,
+	two_hop_incremental,
+	TwoHopIncrementalResponse,
 )
 from autorag.data.qa.schema import QA
 from tests.autorag.data.qa.query.base_test_query_gen import qa_df, multi_hop_qa_df
@@ -22,134 +18,118 @@ from tests.autorag.data.qa.query.base_test_query_gen import qa_df, multi_hop_qa_
 client = AsyncOpenAI()
 
 
-async def mock_gen_gt_response(*args, **kwargs) -> ParsedChatCompletion[Response]:
-    return ParsedChatCompletion(
-        id="test_id",
-        choices=[
-            ParsedChoice(
-                finish_reason="stop",
-                index=0,
-                message=ParsedChatCompletionMessage(
-                    parsed=Response(query="mock answer"),
-                    role="assistant",
-                ),
-            )
-        ],
-        created=int(time.time()),
-        model="gpt-4o-mini-2024-07-18",
-        object="chat.completion",
-    )
+@dataclass
+class _MockParsedResponse:
+	"""Minimal stand-in for openai.types.responses.ParsedResponse.
+
+	The production helpers only read `.output_parsed`, so a tiny dataclass
+	is enough for the tests and avoids coupling to the full OpenAI response
+	schema (which changes between SDK versions).
+	"""
+
+	output_parsed: Any
 
 
-async def mock_two_hop_response(*args, **kwargs) -> ParsedChatCompletion[Response]:
-    return ParsedChatCompletion(
-        id="test_id",
-        choices=[
-            ParsedChoice(
-                finish_reason="stop",
-                index=0,
-                message=ParsedChatCompletionMessage(
-                    parsed=TwoHopIncrementalResponse(
-                        answer="mock answer",
-                        one_hop_question="mock one hop question",
-                        two_hop_question="mock two hop question",
-                    ),
-                    role="assistant",
-                ),
-            )
-        ],
-        created=int(time.time()),
-        model="gpt-4o-mini-2024-07-18",
-        object="chat.completion",
-    )
+async def mock_gen_gt_response(*args, **kwargs) -> _MockParsedResponse:
+	return _MockParsedResponse(output_parsed=Response(query="mock answer"))
+
+
+async def mock_two_hop_response(*args, **kwargs) -> _MockParsedResponse:
+	return _MockParsedResponse(
+		output_parsed=TwoHopIncrementalResponse(
+			answer="mock answer",
+			one_hop_question="mock one hop question",
+			two_hop_question="mock two hop question",
+		)
+	)
 
 
 @patch.object(
-    openai.resources.chat.completions.AsyncCompletions,
-    "parse",
-    mock_gen_gt_response,
+	openai.resources.responses.AsyncResponses,
+	"parse",
+	mock_gen_gt_response,
 )
 def test_factoid_query_gen():
-    qa = QA(qa_df)
-    new_qa = qa.batch_apply(factoid_query_gen, client=client)
-    assert "query" in new_qa.data.columns
-    assert all(isinstance(query, str) for query in new_qa.data["query"].tolist())
-    assert len(new_qa.data) == len(qa_df)
+	qa = QA(qa_df)
+	new_qa = qa.batch_apply(factoid_query_gen, client=client)
+	assert "query" in new_qa.data.columns
+	assert all(isinstance(query, str) for query in new_qa.data["query"].tolist())
+	assert len(new_qa.data) == len(qa_df)
 
 
 @patch.object(
-    openai.resources.chat.completions.AsyncCompletions,
-    "parse",
-    mock_gen_gt_response,
+	openai.resources.responses.AsyncResponses,
+	"parse",
+	mock_gen_gt_response,
 )
 def test_factoid_query_gen_ko():
-    qa = QA(qa_df)
-    new_qa = qa.batch_apply(factoid_query_gen, client=client, lang="ko")
-    assert "query" in new_qa.data.columns
-    assert all(isinstance(query, str) for query in new_qa.data["query"].tolist())
-    assert len(new_qa.data) == len(qa_df)
+	qa = QA(qa_df)
+	new_qa = qa.batch_apply(factoid_query_gen, client=client, lang="ko")
+	assert "query" in new_qa.data.columns
+	assert all(isinstance(query, str) for query in new_qa.data["query"].tolist())
+	assert len(new_qa.data) == len(qa_df)
 
 
 @patch.object(
-    openai.resources.chat.completions.AsyncCompletions,
-    "parse",
-    mock_gen_gt_response,
+	openai.resources.responses.AsyncResponses,
+	"parse",
+	mock_gen_gt_response,
 )
 def test_factoid_query_gen_ja():
-    qa = QA(qa_df)
-    new_qa = qa.batch_apply(factoid_query_gen, client=client, lang="ja")
-    assert "query" in new_qa.data.columns
-    assert all(isinstance(query, str) for query in new_qa.data["query"].tolist())
-    assert len(new_qa.data) == len(qa_df)
+	qa = QA(qa_df)
+	new_qa = qa.batch_apply(factoid_query_gen, client=client, lang="ja")
+	assert "query" in new_qa.data.columns
+	assert all(isinstance(query, str) for query in new_qa.data["query"].tolist())
+	assert len(new_qa.data) == len(qa_df)
 
 
 @patch.object(
-    openai.resources.chat.completions.AsyncCompletions,
-    "parse",
-    mock_gen_gt_response,
+	openai.resources.responses.AsyncResponses,
+	"parse",
+	mock_gen_gt_response,
 )
 def test_concept_completion_query_gen_ko():
-    qa = QA(qa_df)
-    new_qa = qa.batch_apply(concept_completion_query_gen, client=client, lang="ko")
-    assert "query" in new_qa.data.columns
-    assert all(isinstance(query, str) for query in new_qa.data["query"].tolist())
-    assert len(new_qa.data) == len(qa_df)
+	qa = QA(qa_df)
+	new_qa = qa.batch_apply(concept_completion_query_gen, client=client, lang="ko")
+	assert "query" in new_qa.data.columns
+	assert all(isinstance(query, str) for query in new_qa.data["query"].tolist())
+	assert len(new_qa.data) == len(qa_df)
 
 
 @patch.object(
-    openai.resources.chat.completions.AsyncCompletions,
-    "parse",
-    mock_gen_gt_response,
+	openai.resources.responses.AsyncResponses,
+	"parse",
+	mock_gen_gt_response,
 )
 def test_concept_completion_query_gen_ja():
-    qa = QA(qa_df)
-    new_qa = qa.batch_apply(concept_completion_query_gen, client=client, lang="ja")
-    assert "query" in new_qa.data.columns
-    assert all(isinstance(query, str) for query in new_qa.data["query"].tolist())
-    assert len(new_qa.data) == len(qa_df)
+	qa = QA(qa_df)
+	new_qa = qa.batch_apply(concept_completion_query_gen, client=client, lang="ja")
+	assert "query" in new_qa.data.columns
+	assert all(isinstance(query, str) for query in new_qa.data["query"].tolist())
+	assert len(new_qa.data) == len(qa_df)
 
 
 @patch.object(
-    openai.resources.chat.completions.AsyncCompletions,
-    "parse",
-    mock_two_hop_response,
+	openai.resources.responses.AsyncResponses,
+	"parse",
+	mock_two_hop_response,
 )
 def test_two_hop_incremental():
-    qa = QA(multi_hop_qa_df)
-    new_qa = qa.batch_apply(two_hop_incremental, client=client)
-    assert "query" in new_qa.data.columns
-    assert all(isinstance(query, str) for query in new_qa.data["query"].tolist())
-    assert len(new_qa.data) == len(multi_hop_qa_df)
+	qa = QA(multi_hop_qa_df)
+	new_qa = qa.batch_apply(two_hop_incremental, client=client)
+	assert "query" in new_qa.data.columns
+	assert all(isinstance(query, str) for query in new_qa.data["query"].tolist())
+	assert len(new_qa.data) == len(multi_hop_qa_df)
 
 
 @patch.object(
-    openai.resources.chat.completions.AsyncCompletions,
-    "parse",
-    mock_two_hop_response,
+	openai.resources.responses.AsyncResponses,
+	"parse",
+	mock_two_hop_response,
 )
 def test_two_hop_incremental_ja():
-    qa = QA(multi_hop_qa_df)
-    new_qa = qa.batch_apply(two_hop_incremental, client=client, lang="ja")
-    assert "query" in new_qa.data.columns
-    assert all(isinstance(query, str) for query in new_qa.data["query"].tolist())
-    assert len(new_qa.data) == len(multi_hop_qa_df)
+	qa = QA(multi_hop_qa_df)
+	new_qa = qa.batch_apply(two_hop_incremental, client=client, lang="ja")
+	assert "query" in new_qa.data.columns
+	assert all(isinstance(query, str) for query in new_qa.data["query"].tolist())
+	assert len(new_qa.data) == len(multi_hop_qa_df)


### PR DESCRIPTION
## Summary
This PR bundles small, independent fixes for regressions that surface on a plain install of the current `main` / v0.3.22. Each commit is isolated and cherry-pickable so maintainers can take whatever subset makes sense.

## What it fixes

### 1. `OpenAILLM.__init__` crashes for any model outside `MAX_TOKEN_DICT` (Critical)
`autorag/nodes/generator/openai_llm.py`

`MAX_TOKEN_DICT.get(self.llm) - 7` is evaluated before the `None` guard, so any model alias missing from the dictionary (e.g. `"gpt-4o-latest"`, a freshly-released alias, or a typo) crashes the constructor with:

```
TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'
```

The downstream `if self.max_token_size is None` raise was dead code for that path.

**Fix**: look up the limit first, raise `ValueError` with the list of supported models if it is missing, subtract `7` only on success. While touching the file, drop `gpt-5` from the `get_result_reasoning` error message (the guard above it only checks `o1`/`o3`/`o4` — `gpt-5` has its own `get_result_gpt_5` branch, so the message was misleading).

### 2. `data/qa/*` still calls the removed `client.beta.chat.completions.parse` (Critical)
PR #1131 migrated `autorag/nodes/generator/openai_llm.py` off the removed beta namespace, but the QA data-creation pipeline kept seven call sites across five files:

- `autorag/data/qa/query/openai_gen_query.py:30, 89`
- `autorag/data/qa/evolve/openai_query_evolve.py:33, 75`
- `autorag/data/qa/generation_gt/openai_gen_gt.py:28`
- `autorag/data/qa/filter/dontknow.py:80`
- `autorag/data/qa/filter/passage_dependency.py:40`

With `openai>=2.8.0` these raise `AttributeError: 'AsyncOpenAI' object has no attribute 'beta'`, so any QA-generation workflow fails on first use.

**Fix**: migrate each site to the same `client.responses.parse(input=..., text_format=...)` / `completion.output_parsed` pattern already used in `openai_llm.py::get_structured_result`. No behavioural change beyond the API surface.

### 3. `data/chunk/base.py` references the removed `openai_langchain` embedding key (High)
`autorag/data/chunk/base.py:79-83`

PR #1211 removed the `"openai_langchain"` entry from `autorag/embedding/base.py::embedding_models` (the LangChain-OpenAI shim was dropped with the LangChain v1 upgrade), but `get_embedding_model` still rewrote `_embed_model_str` to `"openai_langchain"` when chunking via `langchain_chunk`. `EmbeddingModel.load` therefore raised `KeyError` for every `semantic_langchain` chunking config.

**Fix**: drop the rewrite so `"openai"` resolves directly to the OpenAI embedding model that every other chunking path already uses.

### 4. `NvidiaReranker` is not registered in `support.py` (High)
`autorag/support.py`

PR #1199 added the new reranker module and exported it from `autorag.nodes.passagereranker.__init__`, but omitted the `support.py` mapping. YAML pipelines with `module_type: nvidia_reranker` therefore fail with `KeyError: 'Input module or node nvidia_reranker is not supported.'` during dispatch.

**Fix**: add snake_case and PascalCase aliases alongside the other reranker entries.

### 5. `LlamaIndexLLM` logprob branch crashes when logprobs are actually present (High)
`autorag/nodes/generator/llama_index_llm.py`

PR #1153 restored the logprob-available check to `all(res.logprobs is not None for res in results)`, but the extraction still treated `ChatResponse.logprobs` as a scalar:

```python
retrieved_logprobs = [res.logprobs for res in results]
tokenized_ids      = [logprob.token   for logprob in retrieved_logprobs]   # list.token ✗
logprobs           = [logprob.logprob for logprob in retrieved_logprobs]   # list.logprob ✗
```

`llama-index` exposes `ChatResponse.logprobs` as `List[ChatCompletionTokenLogprob]`, so the inner loop walks lists, not logprob records, and fails with `AttributeError: 'list' object has no attribute 'token'` as soon as the model returns real logprobs.

**Fix**: iterate each response's list and produce `List[List[int]]` / `List[List[float]]` matching the pseudo-logprob branch and the `BaseGenerator` contract. The fix also (a) adds an empty-`results` guard so `all([]) == True` no longer routes an empty batch into this branch and (b) corrects the `pesudo` typo in the accompanying warning.

### 6. `NvidiaReranker` crashes on empty input batch (Medium)
`autorag/nodes/passagereranker/nvidia.py`

The pre-existing length-mismatch guard accepts `len(queries) == len(contents_list) == len(ids_list) == 0`, but the next line unpacks `zip(*results)` into three variables:

```
ValueError: not enough values to unpack (expected 3, got 0)
```

Callers that produce an empty filtered batch therefore see a crash instead of three empty lists.

**Fix**: return `[], [], []` early when there are no queries.

## Reproduction
```bash
# 1. OpenAILLM TypeError
python -c "from autorag.nodes.generator.openai_llm import OpenAILLM;  OpenAILLM(project_dir='.', llm='gpt-4o-latest', api_key='sk-test')"

# 2. data/qa beta.chat removal
python - <<'PY'
from openai import AsyncClient
import autorag.data.qa.query.openai_gen_query as m
print('call site still on beta namespace:', 'beta.chat.completions.parse' in open(m.__file__).read())
PY

# 5. LlamaIndex logprob branch
python - <<'PY'
class FL:
    def __init__(s,t,l): s.token=t; s.logprob=l
class FR:
    def __init__(s,lp): s.logprobs=lp
results=[FR([FL('A',-.1),FL('B',-.2)])]
retrieved=[r.logprobs for r in results]
try: [lp.token for lp in retrieved]
except AttributeError as e: print('repro:', e)
PY

# 6. Nvidia zip unpack
python -c "a,b,c = zip(*[])"
```

## Verification
```
ruff check autorag/
ruff format autorag/
python -c "import ast; [ast.parse(open(f).read()) for f in [
    'autorag/nodes/generator/openai_llm.py',
    'autorag/nodes/generator/llama_index_llm.py',
    'autorag/nodes/passagereranker/nvidia.py',
    'autorag/support.py',
    'autorag/data/chunk/base.py',
    'autorag/data/qa/query/openai_gen_query.py',
    'autorag/data/qa/evolve/openai_query_evolve.py',
    'autorag/data/qa/generation_gt/openai_gen_gt.py',
    'autorag/data/qa/filter/dontknow.py',
    'autorag/data/qa/filter/passage_dependency.py',
]]"
```

Full pytest run was not possible in the reviewer's environment without the project's GPU / external-service fixtures, but every fix is either (a) an API-surface migration matching an existing working call site, or (b) a localized guard whose repro is included above.

## Test plan
- [ ] Unit test: `OpenAILLM` with an unknown model name raises `ValueError` (not `TypeError`).
- [ ] Unit tests (with `pytest-mock`) for each `data/qa/*` helper that previously used `beta.chat` — assert they now call `client.responses.parse` and unwrap `output_parsed`.
- [ ] Parametrised test for `LlamaIndexLLM._pure` using a mock that returns real per-token logprobs; assert the returned shape is `List[List[int]]` / `List[List[float]]`.
- [ ] Regression test `NvidiaReranker._pure` with empty inputs returning `([], [], [])`.

## Closes / Relates
- Closes #1235.
- Follows up PR #1131 (generator-only migration), PR #1199 (NvidiaReranker), PR #1211 (LangChain v1 upgrade), PR #1153 (logprob handling), and PR #1150 (`MAX_TOKEN_DICT` rework).

## Risk
- `OpenAILLM.__init__` now raises `ValueError` instead of `TypeError` for unknown models. This is the documented contract of the surrounding error message — the previous behaviour was an accidental crash.
- `data/qa/*` calls now use `client.responses.parse`. The returned parsed object is equivalent to `completion.choices[0].message.parsed`; no caller-visible shape change. The migration mirrors what `openai_llm.py::get_structured_result` already does in production.
- Every commit is independently revertible.
