### PR TITLE
chore: drop mock bypass from openai gpt-5 and improve hybrid retrieval assertion messages

### DIFF
--- a/autorag/nodes/generator/openai_llm.py
+++ b/autorag/nodes/generator/openai_llm.py
@@ -309,12 +309,6 @@ class OpenAILLM(BaseGenerator):
 	async def get_result_gpt_5(self, prompt: Union[str, List[dict]], **kwargs):
 		if not self.llm.startswith("gpt-5"):
 			raise ValueError("get_result_gpt_5 is only for gpt-5 models.")
-		api_key = getattr(self.client, "api_key", None)
-		if isinstance(api_key, str) and api_key.startswith("mock_"):
-			answer = "Why not"
-			tokens = self.tokenizer.encode(answer, allowed_special="all")
-			pseudo_log_probs = [0.5] * len(tokens)
-			return answer, tokens, pseudo_log_probs
 		messages = parse_prompt(prompt)
 		instruction = "\n\n".join(
 			[msg["content"] for msg in messages if msg["role"] == "system"]

--- a/autorag/nodes/hybridretrieval/base.py
+++ b/autorag/nodes/hybridretrieval/base.py
@@ -33,12 +33,28 @@ def hybrid_cast(
 	assert "query" in previous_result.columns, "previous_result must have query column."
 	queries = previous_result["query"].tolist()
 
-	assert "retrieved_contents_semantic" in previous_result.columns
-	assert "retrieved_contents_lexical" in previous_result.columns
-	assert "retrieve_scores_semantic" in previous_result.columns
-	assert "retrieve_scores_lexical" in previous_result.columns
-	assert "retrieved_ids_semantic" in previous_result.columns
-	assert "retrieved_ids_lexical" in previous_result.columns
+	_hybrid_schema_hint = (
+		"The hybrid retrieval node expects the upstream dataframe to expose "
+		"`retrieved_contents_semantic`/`retrieve_scores_semantic`/"
+		"`retrieved_ids_semantic` and the matching `_lexical` columns. "
+		"Retrieval was split into semantic/lexical/hybrid nodes in #1135, so "
+		"parquet files produced before v0.3.17 will not satisfy this schema; "
+		"re-run the retrieval node or run both a semantic and a lexical "
+		"retrieval step before hybrid_cc / hybrid_rrf."
+	)
+	required_columns = [
+		"retrieved_contents_semantic",
+		"retrieved_contents_lexical",
+		"retrieve_scores_semantic",
+		"retrieve_scores_lexical",
+		"retrieved_ids_semantic",
+		"retrieved_ids_lexical",
+	]
+	missing = [col for col in required_columns if col not in previous_result.columns]
+	assert not missing, (
+		f"hybrid_cast: missing required columns {missing} in previous_result "
+		f"(found columns: {list(previous_result.columns)}). {_hybrid_schema_hint}"
+	)
 
 	contents_semantic = previous_result["retrieved_contents_semantic"].tolist()
 	contents_lexical = previous_result["retrieved_contents_lexical"].tolist()

--- a/tests/autorag/nodes/generator/test_openai.py
+++ b/tests/autorag/nodes/generator/test_openai.py
@@ -1,7 +1,9 @@
 import time
+from dataclasses import dataclass
 from unittest.mock import patch
 
 import openai.resources.chat
+import openai.resources.responses
 import pandas as pd
 import pytest
 from pydantic import BaseModel
@@ -21,6 +23,22 @@ from openai.types.chat import (
 	ParsedChatCompletionMessage,
 	ParsedChoice,
 )
+
+
+@dataclass
+class _MockResponsesResult:
+	"""Stand-in for openai.types.responses.Response.
+
+	get_result_gpt_5 only reads `.output_text`, so a tiny dataclass suffices
+	and avoids coupling the test to the full response schema (which varies
+	between SDK versions).
+	"""
+
+	output_text: str
+
+
+async def mock_openai_responses_create(*args, **kwargs) -> _MockResponsesResult:
+	return _MockResponsesResult(output_text="mock gpt-5 answer")
 
 
 @pytest.fixture
@@ -57,6 +75,11 @@ def openai_gpt_5_instance():
 	)
 
 
+@patch.object(
+	openai.resources.responses.AsyncResponses,
+	"create",
+	mock_openai_responses_create,
+)
 def test_openai_llm_gpt_5(openai_gpt_5_instance):
 	answers, tokens, log_probs = openai_gpt_5_instance._pure(
 		prompts,


### PR DESCRIPTION
## Summary
Two small quality cleanups, grouped because both are contained to a single file and have no runtime impact on correct configurations:

1. **Drop the `api_key.startswith("mock_")` bypass from `openai_llm.get_result_gpt_5`** (`autorag/nodes/generator/openai_llm.py`). The block returned a hardcoded `"Why not"` answer plus pseudo tokens whenever the client's API key started with `"mock_"`. This is a test-only behaviour that belongs in the corresponding test module (`unittest.mock.patch`), not in the production code path — a user who happens to use an API key starting with that prefix silently receives the placeholder answer. The existing `beta.chat.completions.parse` ancestors of this method use real mocks in tests, so removing the production bypass does not regress coverage.
2. **Replace the bare `assert` statements in `autorag/nodes/hybridretrieval/base.py::hybrid_cast` with a single actionable message.** PR #1135 split retrieval into `semantic_retrieval`, `lexical_retrieval`, and `hybridretrieval`, introducing new column suffixes (`retrieved_contents_semantic`, `retrieved_contents_lexical`, etc.). Users loading an intermediate parquet produced before v0.3.17, or those running only one retrieval leg, see six `AssertionError`s with no hint about the expected schema. This PR collects the missing columns into one list, reports them all in a single assertion message, and points the user at the correct configuration (run both legs, or re-run the retrieval node) — relates to documentation Issue #1140.

## Reproduction
```python
# 1. Mock bypass fires for any key that starts with 'mock_'
from autorag.nodes.generator.openai_llm import OpenAILLM  # type: ignore
# Before: configuring OpenAILLM with api_key="mock_whatever" silently
# returns "Why not" from gpt-5 generation.
```

```python
# 2. Bare AssertionError — what users see today when loading pre-v0.3.17 results
import pandas as pd
from autorag.nodes.hybridretrieval.base import hybrid_cast
df = pd.DataFrame({"query": ["q"], "retrieved_contents": [["x"]]})
hybrid_cast(df)  # -> AssertionError with no message
```

After this PR the second example raises
`AssertionError: hybrid_cast: missing required columns ['retrieved_contents_semantic', 'retrieved_contents_lexical', ...] in previous_result (found columns: [...]). The hybrid retrieval node expects the upstream dataframe to expose ...`

## Verification
```
ruff check autorag/nodes/generator/openai_llm.py autorag/nodes/hybridretrieval/base.py
ruff format autorag/nodes/generator/openai_llm.py autorag/nodes/hybridretrieval/base.py
python -c "import ast; ast.parse(open('autorag/nodes/generator/openai_llm.py').read()); ast.parse(open('autorag/nodes/hybridretrieval/base.py').read())"
```

## Test plan
- [ ] Tests using `mock_` API keys (if any) are migrated to `unittest.mock.patch` on the OpenAI client.
- [ ] A new unit test for `hybrid_cast` with a pre-v0.3.17 dataframe asserts that the error message lists every missing column and mentions the retrieval split.

## Closes / Relates
- Relates to Issue #1140 (retrieval documentation refresh — this is the code-side complement).

## Risk
- The mock bypass has no documented production use, but a custom test harness relying on the prefix would need to move to a proper mock. Release notes can call this out.
- The assertion message text is new; no behavioural change for correct schemas.
