### PR TITLE
Feat/add litellm provider

### DIFF
--- a/autorag/nodes/generator/__init__.py
+++ b/autorag/nodes/generator/__init__.py
@@ -1,3 +1,4 @@
+from .litellm_client import LiteLLMGenerator
 from .llama_index_llm import LlamaIndexLLM
 from .minimax_llm import MiniMaxLLM
 from .openai_llm import OpenAILLM

--- a/autorag/nodes/generator/litellm_client.py
+++ b/autorag/nodes/generator/litellm_client.py
@@ -1,0 +1,180 @@
+import logging
+from typing import Dict, List, Tuple, Union
+
+import pandas as pd
+import tiktoken
+from tiktoken import Encoding
+
+from autorag.nodes.generator.base import BaseGenerator
+from autorag.utils.util import (
+	get_event_loop,
+	process_batch,
+	result_to_dataframe,
+)
+
+logger = logging.getLogger("AutoRAG")
+
+
+class LiteLLMGenerator(BaseGenerator):
+	def __init__(self, project_dir, llm: str, batch: int = 16, *args, **kwargs):
+		"""
+		LiteLLM generator module for AutoRAG.
+
+		Routes to 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock,
+		Vertex AI, Groq, Together, Ollama, etc.) through a single unified
+		interface via litellm.acompletion().
+
+		:param project_dir: The project directory.
+		:param llm: A LiteLLM model string. For example, ``gpt-4o``,
+		    ``anthropic/claude-sonnet-4-20250514``, ``azure/gpt-4o``,
+		    ``bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0``.
+		    See https://docs.litellm.ai/docs/providers for the full list.
+		:param batch: Batch size for API calls. Default is 16.
+		:param api_key: Provider API key. When not set, LiteLLM resolves
+		    credentials from provider-specific env vars (OPENAI_API_KEY,
+		    ANTHROPIC_API_KEY, etc.) based on the model prefix.
+		:param api_base: Custom base URL for self-hosted endpoints or proxies.
+		:param kwargs: Extra parameters forwarded to litellm.acompletion().
+		"""
+		try:
+			import litellm  # noqa: F401
+		except ImportError as err:
+			raise ImportError(
+				"litellm is not installed. Install with: pip install litellm"
+			) from err
+
+		super().__init__(project_dir, llm, *args, **kwargs)
+		assert batch > 0, "batch size must be greater than 0."
+		self.batch = batch
+
+		self.api_key = kwargs.pop("api_key", None)
+		self.api_base = kwargs.pop("api_base", None)
+
+		try:
+			self.tokenizer = tiktoken.encoding_for_model(self.llm)
+		except KeyError:
+			self.tokenizer = tiktoken.get_encoding("o200k_base")
+
+		self.max_token_size = kwargs.pop("max_token_size", 128_000) - 7
+
+	@result_to_dataframe(["generated_texts", "generated_tokens", "generated_log_probs"])
+	def pure(self, previous_result: pd.DataFrame, *args, **kwargs):
+		prompts = self.cast_to_run(previous_result)
+		return self._pure(prompts, **kwargs)
+
+	def _pure(
+		self,
+		prompts: Union[List[str], List[List[dict]]],
+		truncate: bool = True,
+		**kwargs,
+	) -> Tuple[List[str], List[List[int]], List[List[float]]]:
+		if kwargs.get("logprobs") is not None:
+			kwargs.pop("logprobs")
+			logger.warning(
+				"LiteLLM does not guarantee logprobs across all providers. "
+				"This parameter is ignored; pseudo log probs will be returned."
+			)
+		if kwargs.get("n") is not None:
+			kwargs.pop("n")
+			logger.warning("parameter n does not effective. It always set to 1.")
+
+		if truncate:
+			prompts = list(
+				map(
+					lambda prompt: truncate_by_token(
+						prompt, self.tokenizer, self.max_token_size
+					),
+					prompts,
+				)
+			)
+
+		loop = get_event_loop()
+		tasks = [self.get_result(prompt, **kwargs) for prompt in prompts]
+		result = loop.run_until_complete(process_batch(tasks, self.batch))
+		answer_result = list(map(lambda x: x[0], result))
+		token_result = list(map(lambda x: x[1], result))
+		logprob_result = list(map(lambda x: x[2], result))
+		return answer_result, token_result, logprob_result
+
+	async def astream(self, prompt: Union[str, List[Dict]], **kwargs):
+		import litellm
+
+		if kwargs.get("logprobs") is not None:
+			kwargs.pop("logprobs")
+		if kwargs.get("n") is not None:
+			kwargs.pop("n")
+
+		prompt = truncate_by_token(prompt, self.tokenizer, self.max_token_size)
+
+		call_kwargs = {
+			"model": self.llm,
+			"messages": parse_prompt(prompt),
+			"stream": True,
+			"drop_params": True,
+			**kwargs,
+		}
+		if self.api_key:
+			call_kwargs["api_key"] = self.api_key
+		if self.api_base:
+			call_kwargs["api_base"] = self.api_base
+
+		stream = await litellm.acompletion(**call_kwargs)
+		result = ""
+		async for chunk in stream:
+			if chunk.choices[0].delta.content is not None:
+				result += chunk.choices[0].delta.content
+				yield result
+
+	def stream(self, prompt: Union[str, List[Dict]], **kwargs):
+		raise NotImplementedError("stream method is not implemented yet.")
+
+	async def get_result(self, prompt: Union[str, List[dict]], **kwargs):
+		import litellm
+
+		messages = parse_prompt(prompt)
+
+		call_kwargs = {
+			"model": self.llm,
+			"messages": messages,
+			"n": 1,
+			"drop_params": True,
+			**kwargs,
+		}
+		if self.api_key:
+			call_kwargs["api_key"] = self.api_key
+		if self.api_base:
+			call_kwargs["api_base"] = self.api_base
+
+		response = await litellm.acompletion(**call_kwargs)
+		answer = response.choices[0].message.content or ""
+
+		tokens = self.tokenizer.encode(answer, allowed_special="all")
+		pseudo_log_probs = [0.5] * len(tokens)
+		return answer, tokens, pseudo_log_probs
+
+
+def truncate_by_token(
+	prompt: Union[str, List[Dict]], tokenizer: Encoding, max_token_size: int
+):
+	if isinstance(prompt, list):
+		prompt = messages_to_string(prompt)
+	tokens = tokenizer.encode(prompt, allowed_special="all")
+	return tokenizer.decode(tokens[:max_token_size])
+
+
+def messages_to_string(messages: List[Dict[str, str]]) -> str:
+	formatted_parts = [
+		f"<|im_start|>{message['role']}\n{message['content']}<|im_end|>"
+		for message in messages
+	]
+	formatted_parts.append("<|im_start|>assistant")
+	return "\n".join(formatted_parts)
+
+
+def parse_prompt(prompt: Union[str, List[Dict]]) -> List[Dict]:
+	if isinstance(prompt, str):
+		return [{"role": "user", "content": prompt}]
+	elif isinstance(prompt, list):
+		return prompt
+	else:
+		raise ValueError("prompt must be a string or a list of dicts.")

--- a/autorag/support.py
+++ b/autorag/support.py
@@ -176,10 +176,12 @@ def get_support_modules(module_name: str) -> Callable:
 		"ChatFstring": ("autorag.nodes.promptmaker", "ChatFstring"),
 		# generator
 		"llama_index_llm": ("autorag.nodes.generator", "LlamaIndexLLM"),
+		"litellm_client": ("autorag.nodes.generator", "LiteLLMGenerator"),
 		"minimax_llm": ("autorag.nodes.generator", "MiniMaxLLM"),
 		"vllm": ("autorag.nodes.generator", "Vllm"),
 		"openai_llm": ("autorag.nodes.generator", "OpenAILLM"),
 		"vllm_api": ("autorag.nodes.generator", "VllmAPI"),
+		"LiteLLMGenerator": ("autorag.nodes.generator", "LiteLLMGenerator"),
 		"LlamaIndexLLM": ("autorag.nodes.generator", "LlamaIndexLLM"),
 		"MiniMaxLLM": ("autorag.nodes.generator", "MiniMaxLLM"),
 		"Vllm": ("autorag.nodes.generator", "Vllm"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "pandas>=2.2.3",
     "tqdm>=4.67.1",
     "tiktoken>=0.9.0",  # for counting token
+    "litellm>=1.55,<1.85",
     "openai>=2.8.0",
     "rank_bm25>=0.2.2",  # for bm25 retrieval
     "pyyaml>=6.0.2",  # for yaml file

--- a/tests/autorag/nodes/generator/test_litellm_client.py
+++ b/tests/autorag/nodes/generator/test_litellm_client.py
@@ -83,50 +83,50 @@ class TestLiteLLMModuleRegistration:
 
 
 class TestLiteLLMGeneratorPure:
-	@patch("autorag.nodes.generator.litellm_client.litellm")
-	def test_pure_string_prompts(self, mock_litellm, litellm_instance):
-		mock_litellm.acompletion = AsyncMock(return_value=_mock_litellm_response())
+	@patch("litellm.acompletion", new_callable=AsyncMock)
+	def test_pure_string_prompts(self, mock_acompletion, litellm_instance):
+		mock_acompletion.return_value = _mock_litellm_response()
 
 		answers, tokens, log_probs = litellm_instance._pure(prompts, temperature=0.5)
 		check_generated_texts(answers)
 		check_generated_tokens(tokens)
 		check_generated_log_probs(log_probs)
 
-	@patch("autorag.nodes.generator.litellm_client.litellm")
-	def test_pure_chat_prompts(self, mock_litellm, litellm_instance):
-		mock_litellm.acompletion = AsyncMock(return_value=_mock_litellm_response())
+	@patch("litellm.acompletion", new_callable=AsyncMock)
+	def test_pure_chat_prompts(self, mock_acompletion, litellm_instance):
+		mock_acompletion.return_value = _mock_litellm_response()
 
 		answers, tokens, log_probs = litellm_instance._pure(chat_prompts)
 		check_generated_texts(answers)
 		check_generated_tokens(tokens)
 		check_generated_log_probs(log_probs)
 
-	@patch("autorag.nodes.generator.litellm_client.litellm")
-	def test_pure_forwards_api_key(self, mock_litellm, litellm_instance_with_key):
-		mock_litellm.acompletion = AsyncMock(return_value=_mock_litellm_response())
+	@patch("litellm.acompletion", new_callable=AsyncMock)
+	def test_pure_forwards_api_key(self, mock_acompletion, litellm_instance_with_key):
+		mock_acompletion.return_value = _mock_litellm_response()
 
 		litellm_instance_with_key._pure(prompts[:1])
 
-		call_kwargs = mock_litellm.acompletion.call_args[1]
+		call_kwargs = mock_acompletion.call_args[1]
 		assert call_kwargs["api_key"] == "sk-test-key"
 		assert call_kwargs["api_base"] == "https://my-proxy.com"
 
-	@patch("autorag.nodes.generator.litellm_client.litellm")
-	def test_pure_sets_drop_params(self, mock_litellm, litellm_instance):
-		mock_litellm.acompletion = AsyncMock(return_value=_mock_litellm_response())
+	@patch("litellm.acompletion", new_callable=AsyncMock)
+	def test_pure_sets_drop_params(self, mock_acompletion, litellm_instance):
+		mock_acompletion.return_value = _mock_litellm_response()
 
 		litellm_instance._pure(prompts[:1])
 
-		call_kwargs = mock_litellm.acompletion.call_args[1]
+		call_kwargs = mock_acompletion.call_args[1]
 		assert call_kwargs["drop_params"] is True
 
-	@patch("autorag.nodes.generator.litellm_client.litellm")
-	def test_pure_omits_api_key_when_none(self, mock_litellm, litellm_instance):
-		mock_litellm.acompletion = AsyncMock(return_value=_mock_litellm_response())
+	@patch("litellm.acompletion", new_callable=AsyncMock)
+	def test_pure_omits_api_key_when_none(self, mock_acompletion, litellm_instance):
+		mock_acompletion.return_value = _mock_litellm_response()
 
 		litellm_instance._pure(prompts[:1])
 
-		call_kwargs = mock_litellm.acompletion.call_args[1]
+		call_kwargs = mock_acompletion.call_args[1]
 		assert "api_key" not in call_kwargs
 
 

--- a/tests/autorag/nodes/generator/test_litellm_client.py
+++ b/tests/autorag/nodes/generator/test_litellm_client.py
@@ -1,0 +1,161 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from autorag.nodes.generator import LiteLLMGenerator
+from autorag.nodes.generator.litellm_client import parse_prompt, truncate_by_token
+from autorag.schema.module import Module
+from autorag.support import get_support_modules
+from tests.autorag.nodes.generator.test_generator_base import (
+	prompts,
+	check_generated_texts,
+	check_generated_tokens,
+	check_generated_log_probs,
+	chat_prompts,
+)
+
+
+def _mock_litellm_response(content="Why not"):
+	mock_message = MagicMock()
+	mock_message.content = content
+
+	mock_choice = MagicMock()
+	mock_choice.message = mock_message
+
+	mock_response = MagicMock()
+	mock_response.choices = [mock_choice]
+	mock_response.model = "gpt-4o-mini"
+	mock_response.usage = MagicMock(prompt_tokens=10, completion_tokens=2)
+
+	return mock_response
+
+
+@pytest.fixture
+def litellm_instance():
+	return LiteLLMGenerator(
+		project_dir=".",
+		llm="gpt-4o-mini",
+	)
+
+
+@pytest.fixture
+def litellm_instance_with_key():
+	return LiteLLMGenerator(
+		project_dir=".",
+		llm="anthropic/claude-sonnet-4-20250514",
+		api_key="sk-test-key",
+		api_base="https://my-proxy.com",
+	)
+
+
+class TestLiteLLMGeneratorInit:
+	def test_init_default(self, litellm_instance):
+		assert litellm_instance.llm == "gpt-4o-mini"
+		assert litellm_instance.batch == 16
+		assert litellm_instance.api_key is None
+		assert litellm_instance.api_base is None
+
+	def test_init_with_credentials(self, litellm_instance_with_key):
+		assert litellm_instance_with_key.llm == "anthropic/claude-sonnet-4-20250514"
+		assert litellm_instance_with_key.api_key == "sk-test-key"
+		assert litellm_instance_with_key.api_base == "https://my-proxy.com"
+
+	def test_init_custom_batch(self):
+		instance = LiteLLMGenerator(project_dir=".", llm="gpt-4o", batch=8)
+		assert instance.batch == 8
+
+	def test_init_invalid_batch(self):
+		with pytest.raises(AssertionError):
+			LiteLLMGenerator(project_dir=".", llm="gpt-4o", batch=0)
+
+
+class TestLiteLLMModuleRegistration:
+	def test_support_module_resolution(self):
+		assert get_support_modules("litellm_client") is LiteLLMGenerator
+		assert get_support_modules("LiteLLMGenerator") is LiteLLMGenerator
+
+	def test_module_from_dict(self):
+		module = Module.from_dict(
+			{"module_type": "litellm_client", "llm": "gpt-4o-mini"}
+		)
+		assert module.module is LiteLLMGenerator
+
+
+class TestLiteLLMGeneratorPure:
+	@patch("autorag.nodes.generator.litellm_client.litellm")
+	def test_pure_string_prompts(self, mock_litellm, litellm_instance):
+		mock_litellm.acompletion = AsyncMock(return_value=_mock_litellm_response())
+
+		answers, tokens, log_probs = litellm_instance._pure(prompts, temperature=0.5)
+		check_generated_texts(answers)
+		check_generated_tokens(tokens)
+		check_generated_log_probs(log_probs)
+
+	@patch("autorag.nodes.generator.litellm_client.litellm")
+	def test_pure_chat_prompts(self, mock_litellm, litellm_instance):
+		mock_litellm.acompletion = AsyncMock(return_value=_mock_litellm_response())
+
+		answers, tokens, log_probs = litellm_instance._pure(chat_prompts)
+		check_generated_texts(answers)
+		check_generated_tokens(tokens)
+		check_generated_log_probs(log_probs)
+
+	@patch("autorag.nodes.generator.litellm_client.litellm")
+	def test_pure_forwards_api_key(self, mock_litellm, litellm_instance_with_key):
+		mock_litellm.acompletion = AsyncMock(return_value=_mock_litellm_response())
+
+		litellm_instance_with_key._pure(prompts[:1])
+
+		call_kwargs = mock_litellm.acompletion.call_args[1]
+		assert call_kwargs["api_key"] == "sk-test-key"
+		assert call_kwargs["api_base"] == "https://my-proxy.com"
+
+	@patch("autorag.nodes.generator.litellm_client.litellm")
+	def test_pure_sets_drop_params(self, mock_litellm, litellm_instance):
+		mock_litellm.acompletion = AsyncMock(return_value=_mock_litellm_response())
+
+		litellm_instance._pure(prompts[:1])
+
+		call_kwargs = mock_litellm.acompletion.call_args[1]
+		assert call_kwargs["drop_params"] is True
+
+	@patch("autorag.nodes.generator.litellm_client.litellm")
+	def test_pure_omits_api_key_when_none(self, mock_litellm, litellm_instance):
+		mock_litellm.acompletion = AsyncMock(return_value=_mock_litellm_response())
+
+		litellm_instance._pure(prompts[:1])
+
+		call_kwargs = mock_litellm.acompletion.call_args[1]
+		assert "api_key" not in call_kwargs
+
+
+class TestLiteLLMGeneratorStream:
+	def test_stream_not_implemented(self, litellm_instance):
+		with pytest.raises(NotImplementedError):
+			litellm_instance.stream("Hello")
+
+
+class TestParsePrompt:
+	def test_string_prompt(self):
+		result = parse_prompt("Hello world")
+		assert result == [{"role": "user", "content": "Hello world"}]
+
+	def test_list_prompt(self):
+		messages = [
+			{"role": "system", "content": "You are helpful."},
+			{"role": "user", "content": "Hello"},
+		]
+		result = parse_prompt(messages)
+		assert result == messages
+
+	def test_invalid_prompt(self):
+		with pytest.raises(ValueError):
+			parse_prompt(123)
+
+
+class TestLiteLLMImportError:
+	def test_raises_import_error_without_litellm(self):
+		with patch.dict("sys.modules", {"litellm": None}):
+			with pytest.raises(ImportError, match="litellm is not installed"):
+				LiteLLMGenerator(project_dir=".", llm="gpt-4o")


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                          
  Adds `LiteLLMGenerator`, a new generator module backed by [LiteLLM](https://github.com/BerriAI/litellm), enabling access to 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex AI, Together, Groq, Ollama, etc.) through a single unified interface.                                                                                                         
   
  Relates to #944 -- LiteLLM is now a first-class generator, not just a proxy workaround.                                                                                                                                                                                                                                                                                 
                                          
  ## Changes                                                                                                                                                                                                                                                                                                                                                              
                                          
  - `autorag/nodes/generator/litellm_client.py` -- new `LiteLLMGenerator` extending `BaseGenerator` (180 lines). Uses `litellm.acompletion()` directly with `drop_params=True` for cross-provider compatibility.                                                                                                                                                          
  - `autorag/nodes/generator/__init__.py` -- import registration
  - `autorag/support.py` -- registered as `litellm_client` and `LiteLLMGenerator`                                                                                                                                                                                                                                                                                         
  - `pyproject.toml` -- added `litellm>=1.55,<1.85`                                                                                                                                                                                                                                                                                                                       
  - `tests/autorag/nodes/generator/test_litellm_client.py` -- 16 unit tests                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                          
  ## Key details                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                          
  - `drop_params=True` by default -- silently drops provider-unsupported kwargs (e.g. `logprobs` on Anthropic, `seed` on Bedrock). Prevents cross-provider evaluation failures.                                                                                                                                                                                           
  - Lazy `import litellm` inside methods -- base install unaffected if litellm is not installed.
  - Flexible auth: accepts `api_key=` param or provider-specific env vars (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.). When `api_key` is not set, LiteLLM resolves credentials from env vars based on the model prefix.                                                                                                                                                 
  - Returns pseudo token IDs and log probs (same approach as MiniMaxLLM) since logprobs support varies across providers.                                                                                                                                                                                                                                                  
  - Prompt truncation via tiktoken, matching the OpenAILLM/MiniMaxLLM pattern.                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                          
  ## Usage                                                                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                          
  YAML config:                            
  ```yaml
  node_lines:
    - node_line_name: post_retrieve_node_line                                                                                                                                                                                                                                                                                                                             
      nodes:                                                                                                                                                                                                                                                                                                                                                              
        - node_type: generator                                                                                                                                                                                                                                                                                                                                            
          modules:                                                                                                                                                                                                                                                                                                                                                        
            - module_type: litellm_client 
              llm: anthropic/claude-sonnet-4-20250514                                                                                                                                                                                                                                                                                                                     
              temperature: 0.5
                                                                                                                                                                                                                                                                                                                                                                          
  Python:                                 
  from autorag.nodes.generator import LiteLLMGenerator                                                                                                                                                                                                                                                                                                                    
                                                      
  generator = LiteLLMGenerator(
      project_dir=".",         
      llm="anthropic/claude-sonnet-4-20250514",  # any LiteLLM model string
      api_key="sk-...",  # or set ANTHROPIC_API_KEY env var                                                                                                                                                                                                                                                                                                               
  )                                                                                                                                                                                                                                                                                                                                                                       
  answers, tokens, log_probs = generator._pure(["What is 2+2?"])                                                                                                                                                                                                                                                                                                          
  ```                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                          
  Unit tests (16/16 pass):                                                                                                                                                                                                                                                                                                                                                
  
  ```                                                                                                                                                                                                                                                                                                                                                                        
  tests/autorag/nodes/generator/test_litellm_client.py::TestLiteLLMGeneratorInit::test_init_default PASSED                                                                                                                                                                                                                                                                
  tests/autorag/nodes/generator/test_litellm_client.py::TestLiteLLMGeneratorInit::test_init_with_credentials PASSED                                                                                                                                                                                                                                                       
  tests/autorag/nodes/generator/test_litellm_client.py::TestLiteLLMGeneratorInit::test_init_custom_batch PASSED
  tests/autorag/nodes/generator/test_litellm_client.py::TestLiteLLMGeneratorInit::test_init_invalid_batch PASSED                                                                                                                                                                                                                                                          
  tests/autorag/nodes/generator/test_litellm_client.py::TestLiteLLMModuleRegistration::test_support_module_resolution PASSED                                                                                                                                                                                                                                              
  tests/autorag/nodes/generator/test_litellm_client.py::TestLiteLLMModuleRegistration::test_module_from_dict PASSED                                                                                                                                                                                                                                                       
  tests/autorag/nodes/generator/test_litellm_client.py::TestLiteLLMGeneratorPure::test_pure_string_prompts PASSED                                                                                                                                                                                                                                                         
  tests/autorag/nodes/generator/test_litellm_client.py::TestLiteLLMGeneratorPure::test_pure_chat_prompts PASSED
  tests/autorag/nodes/generator/test_litellm_client.py::TestLiteLLMGeneratorPure::test_pure_forwards_api_key PASSED                                                                                                                                                                                                                                                       
  tests/autorag/nodes/generator/test_litellm_client.py::TestLiteLLMGeneratorPure::test_pure_sets_drop_params PASSED                                                                                                                                                                                                                                                       
  tests/autorag/nodes/generator/test_litellm_client.py::TestLiteLLMGeneratorPure::test_pure_omits_api_key_when_none PASSED                                                                                                                                                                                                                                                
  tests/autorag/nodes/generator/test_litellm_client.py::TestLiteLLMGeneratorStream::test_stream_not_implemented PASSED                                                                                                                                                                                                                                                    
  tests/autorag/nodes/generator/test_litellm_client.py::TestParsePrompt::test_string_prompt PASSED                                                                                                                                                                                                                                                                        
  tests/autorag/nodes/generator/test_litellm_client.py::TestParsePrompt::test_list_prompt PASSED                                                                                                                                                                                                                                                                          
  tests/autorag/nodes/generator/test_litellm_client.py::TestParsePrompt::test_invalid_prompt PASSED                                                                                                                                                                                                                                                                       
  tests/autorag/nodes/generator/test_litellm_client.py::TestLiteLLMImportError::test_raises_import_error_without_litellm PASSED
  ============================== 16 passed in 4.74s ==============================                                                                                                                                                                                                                                                                                        
```
                                          
  Live E2E against Anthropic Claude Sonnet 4-6 (via Azure):                                                                                                                                                                                                                                                                                                               
  ```                                        
  ============================================================                                                                                                                                                                                                                                                                                                            
  Live E2E: AutoRAG LiteLLMGenerator      
  ============================================================
  Answer: 4
  Tokens: in=20, out=5
                                                                                                                                                                                                                                                                                                                                                                          
  PASSED
  ```