### PR TITLE
fix(embedding): prevent unhandled Exception in vllm teardown when torch is missing(#1156)

### DIFF
--- a/autorag/embedding/vllm.py
+++ b/autorag/embedding/vllm.py
@@ -102,8 +102,12 @@ class VllmEmbedding(MultiModalEmbedding):
 
 	@atexit.register
 	def close():
-		import torch
-		import gc
+		try:
+			import torch
+			import gc
+		except ImportError:
+			# If torch is not installed, there is no CUDA memory to clean.
+			return
 
 		if torch.cuda.is_available():
 			gc.collect()


### PR DESCRIPTION
**Resolves:** Closes #1156

**What this PR does:**
While looking into the `autorag run web` issue reported in #1156 (which happens because the command was deprecated in favor of `run_web`), I noticed it exposed a secondary bug: the app crashes with an unhandled exception on exit if you don't have PyTorch installed.

In `autorag/embedding/vllm.py`, the `atexit` teardown hook was hard-importing `torch`. For users running the API version of AutoRAG without local GPU dependencies, this causes a `ModuleNotFoundError` during the shutdown routine.

I’ve wrapped the teardown imports in a `try/except ImportError` block. Now, if `torch` isn't found, the app realizes there's no CUDA memory to clean and just exits gracefully.