### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/autorag/nodes/generator/minimax_llm.py
+++ b/autorag/nodes/generator/minimax_llm.py
@@ -22,10 +22,9 @@ THINK_OPEN_TAG = "<think>"
 THINK_CLOSE_TAG = "</think>"
 
 MAX_TOKEN_DICT = {
+	"MiniMax-M3": 524_288,
 	"MiniMax-M2.7": 1_048_576,
 	"MiniMax-M2.7-highspeed": 1_048_576,
-	"MiniMax-M2.5": 1_048_576,
-	"MiniMax-M2.5-highspeed": 204_800,
 }
 
 
@@ -38,7 +37,7 @@ class MiniMaxLLM(BaseGenerator):
 		It returns pseudo token ids and log probs since MiniMax does not support logprobs.
 
 		:param project_dir: The project directory.
-		:param llm: A model name for MiniMax. For example, ``MiniMax-M2.7`` or ``MiniMax-M2.5``.
+		:param llm: A model name for MiniMax. For example, ``MiniMax-M3`` or ``MiniMax-M2.7``.
 		:param batch: Batch size for API calls. Default is 16.
 		:param api_key: MiniMax API key. You can also set this to env variable ``MINIMAX_API_KEY``.
 		:param kwargs: Extra parameters for the MiniMax chat completion API.
@@ -172,7 +171,7 @@ class MiniMaxLLM(BaseGenerator):
 		)
 		answer = response.choices[0].message.content
 
-		# Strip thinking tags if present (MiniMax M2.5+ may include them)
+		# Strip thinking tags if present (MiniMax M2.7+ may include them)
 		if answer and THINK_OPEN_TAG in answer:
 			answer = strip_think_tags(answer)
 

--- a/docs/source/nodes/generator/minimax_llm.md
+++ b/docs/source/nodes/generator/minimax_llm.md
@@ -2,8 +2,8 @@
 myst:
    html_meta:
       title: AutoRAG - MiniMax LLM
-      description: Use MiniMax LLM in AutoRAG. Generate answers using MiniMax M2.7 and M2.5 models.
-      keywords: AutoRAG,RAG,LLM,generator,MiniMax,M2.7,M2.5
+      description: Use MiniMax LLM in AutoRAG. Generate answers using MiniMax M3 and M2.7 models.
+      keywords: AutoRAG,RAG,LLM,generator,MiniMax,M3,M2.7
 ---
 # MiniMax LLM
 
@@ -13,10 +13,11 @@ The `minimax_llm` module integrates [MiniMax](https://www.minimax.io/) models in
 
 | Model | Context Window |
 |-------|---------------|
+| MiniMax-M3 | 524,288 tokens |
 | MiniMax-M2.7 | 1,048,576 tokens |
 | MiniMax-M2.7-highspeed | 1,048,576 tokens |
-| MiniMax-M2.5 | 1,048,576 tokens |
-| MiniMax-M2.5-highspeed | 204,800 tokens |
+
+`MiniMax-M3` is the recommended default; M2.7 variants remain available for compatibility.
 
 ## Features
 
@@ -30,11 +31,11 @@ MiniMax models accept temperature values between 0 and 1. Values above 1.0 are a
 
 ### Think-tag stripping
 
-MiniMax M2.5+ models may include `<think>...</think>` reasoning tags in their output. These are automatically stripped from the generated text.
+MiniMax M2.7+ models may include `<think>...</think>` reasoning tags in their output. These are automatically stripped from the generated text.
 
 ## **Module Parameters**
 
-- **llm**: The MiniMax model name. For example, `MiniMax-M2.7` or `MiniMax-M2.5-highspeed`.
+- **llm**: The MiniMax model name. For example, `MiniMax-M3` or `MiniMax-M2.7-highspeed`.
 - **batch**: The batch size for API calls. Default is 16.
 - **truncate**: Whether to truncate input prompts to the model's max length. Default is True.
 - **api_key**: MiniMax API key. You can also set this to env variable `MINIMAX_API_KEY`.
@@ -45,7 +46,7 @@ MiniMax M2.5+ models may include `<think>...</think>` reasoning tags in their ou
 ```yaml
 modules:
   - module_type: minimax_llm
-    llm: [MiniMax-M2.7, MiniMax-M2.5-highspeed]
+    llm: [MiniMax-M3, MiniMax-M2.7]
     temperature: [0.1, 0.5]
     max_tokens: 512
     api_key: ${MINIMAX_API_KEY}

--- a/sample_config/rag/english/non_gpu/simple_minimax.yaml
+++ b/sample_config/rag/english/non_gpu/simple_minimax.yaml
@@ -21,6 +21,6 @@ node_lines:
         metrics: [bleu, rouge]
       modules:
         - module_type: minimax_llm
-          llm: MiniMax-M2.7
+          llm: MiniMax-M3
           temperature: 0.5
           max_tokens: 512

--- a/tests/autorag/nodes/generator/test_minimax.py
+++ b/tests/autorag/nodes/generator/test_minimax.py
@@ -110,6 +110,15 @@ async def mock_minimax_chat_create_stream(
 
 
 @pytest.fixture
+def minimax_m3_instance():
+	return MiniMaxLLM(
+		project_dir=".",
+		llm="MiniMax-M3",
+		api_key="mock_minimax_api_key",
+	)
+
+
+@pytest.fixture
 def minimax_m27_instance():
 	return MiniMaxLLM(
 		project_dir=".",
@@ -119,10 +128,10 @@ def minimax_m27_instance():
 
 
 @pytest.fixture
-def minimax_m25_highspeed_instance():
+def minimax_m27_highspeed_instance():
 	return MiniMaxLLM(
 		project_dir=".",
-		llm="MiniMax-M2.5-highspeed",
+		llm="MiniMax-M2.7-highspeed",
 		api_key="mock_minimax_api_key",
 	)
 
@@ -142,16 +151,20 @@ def minimax_unknown_model_instance():
 class TestMiniMaxLLMInit:
 	"""Test MiniMaxLLM initialization."""
 
-	def test_init_known_model(self, minimax_m27_instance):
+	def test_init_known_model(self, minimax_m3_instance):
+		assert minimax_m3_instance.llm == "MiniMax-M3"
+		assert minimax_m3_instance.batch == 16
+		assert minimax_m3_instance.max_token_size == MAX_TOKEN_DICT["MiniMax-M3"] - 7
+
+	def test_init_m27_model(self, minimax_m27_instance):
 		assert minimax_m27_instance.llm == "MiniMax-M2.7"
-		assert minimax_m27_instance.batch == 16
 		assert minimax_m27_instance.max_token_size == MAX_TOKEN_DICT["MiniMax-M2.7"] - 7
 
-	def test_init_highspeed_model(self, minimax_m25_highspeed_instance):
-		assert minimax_m25_highspeed_instance.llm == "MiniMax-M2.5-highspeed"
+	def test_init_highspeed_model(self, minimax_m27_highspeed_instance):
+		assert minimax_m27_highspeed_instance.llm == "MiniMax-M2.7-highspeed"
 		assert (
-			minimax_m25_highspeed_instance.max_token_size
-			== MAX_TOKEN_DICT["MiniMax-M2.5-highspeed"] - 7
+			minimax_m27_highspeed_instance.max_token_size
+			== MAX_TOKEN_DICT["MiniMax-M2.7-highspeed"] - 7
 		)
 
 	def test_init_unknown_model_uses_default(self, minimax_unknown_model_instance):
@@ -160,7 +173,7 @@ class TestMiniMaxLLMInit:
 	def test_init_custom_batch(self):
 		instance = MiniMaxLLM(
 			project_dir=".",
-			llm="MiniMax-M2.7",
+			llm="MiniMax-M3",
 			batch=8,
 			api_key="mock_key",
 		)
@@ -169,7 +182,7 @@ class TestMiniMaxLLMInit:
 	def test_init_custom_base_url(self):
 		instance = MiniMaxLLM(
 			project_dir=".",
-			llm="MiniMax-M2.7",
+			llm="MiniMax-M3",
 			api_key="mock_key",
 			base_url="https://custom.api.example.com/v1",
 		)
@@ -179,7 +192,7 @@ class TestMiniMaxLLMInit:
 		with pytest.raises(AssertionError):
 			MiniMaxLLM(
 				project_dir=".",
-				llm="MiniMax-M2.7",
+				llm="MiniMax-M3",
 				batch=0,
 				api_key="mock_key",
 			)
@@ -191,7 +204,7 @@ class TestMiniMaxModuleRegistration:
 		assert get_support_modules("MiniMaxLLM") is MiniMaxLLM
 
 	def test_module_from_dict(self):
-		module = Module.from_dict({"module_type": "minimax_llm", "llm": "MiniMax-M2.7"})
+		module = Module.from_dict({"module_type": "minimax_llm", "llm": "MiniMax-M3"})
 		assert module.module is MiniMaxLLM
 
 
@@ -203,10 +216,8 @@ class TestMiniMaxLLMPure:
 		"create",
 		mock_minimax_chat_create,
 	)
-	def test_pure_string_prompts(self, minimax_m27_instance):
-		answers, tokens, log_probs = minimax_m27_instance._pure(
-			prompts, temperature=0.5
-		)
+	def test_pure_string_prompts(self, minimax_m3_instance):
+		answers, tokens, log_probs = minimax_m3_instance._pure(prompts, temperature=0.5)
 		check_generated_texts(answers)
 		check_generated_tokens(tokens)
 		check_generated_log_probs(log_probs)
@@ -216,13 +227,13 @@ class TestMiniMaxLLMPure:
 		"create",
 		mock_minimax_chat_create,
 	)
-	def test_pure_chat_prompts(self, minimax_m27_instance):
-		answers, tokens, log_probs = minimax_m27_instance._pure(chat_prompts)
+	def test_pure_chat_prompts(self, minimax_m3_instance):
+		answers, tokens, log_probs = minimax_m3_instance._pure(chat_prompts)
 		check_generated_texts(answers)
 		check_generated_tokens(tokens)
 		check_generated_log_probs(log_probs)
 
-	def test_pure_chat_prompts_preserve_roles(self, minimax_m27_instance):
+	def test_pure_chat_prompts_preserve_roles(self, minimax_m3_instance):
 		captured_messages = []
 
 		async def capture_chat_create(self, messages, model, **kwargs):
@@ -234,7 +245,7 @@ class TestMiniMaxLLMPure:
 			"create",
 			capture_chat_create,
 		):
-			minimax_m27_instance._pure(chat_prompts[:1])
+			minimax_m3_instance._pure(chat_prompts[:1])
 
 		assert captured_messages[0] == chat_prompts[0]
 		assert captured_messages[0][0]["role"] == "system"
@@ -245,8 +256,8 @@ class TestMiniMaxLLMPure:
 		"create",
 		mock_minimax_chat_create,
 	)
-	def test_pure_strips_logprobs_param(self, minimax_m27_instance):
-		answers, tokens, log_probs = minimax_m27_instance._pure(
+	def test_pure_strips_logprobs_param(self, minimax_m3_instance):
+		answers, tokens, log_probs = minimax_m3_instance._pure(
 			prompts, logprobs=True, n=3
 		)
 		check_generated_texts(answers)
@@ -256,11 +267,9 @@ class TestMiniMaxLLMPure:
 		"create",
 		mock_minimax_chat_create,
 	)
-	def test_pure_temperature_clamping(self, minimax_m27_instance):
+	def test_pure_temperature_clamping(self, minimax_m3_instance):
 		# Temperature > 1.0 should be clamped
-		answers, tokens, log_probs = minimax_m27_instance._pure(
-			prompts, temperature=1.5
-		)
+		answers, tokens, log_probs = minimax_m3_instance._pure(prompts, temperature=1.5)
 		check_generated_texts(answers)
 
 	@patch.object(
@@ -268,9 +277,9 @@ class TestMiniMaxLLMPure:
 		"create",
 		mock_minimax_chat_create,
 	)
-	def test_pure_temperature_zero(self, minimax_m27_instance):
+	def test_pure_temperature_zero(self, minimax_m3_instance):
 		# Temperature 0 should work fine
-		answers, tokens, log_probs = minimax_m27_instance._pure(prompts, temperature=0)
+		answers, tokens, log_probs = minimax_m3_instance._pure(prompts, temperature=0)
 		check_generated_texts(answers)
 
 
@@ -282,8 +291,8 @@ class TestMiniMaxLLMThinkingStrip:
 		"create",
 		mock_minimax_chat_create_with_think_tags,
 	)
-	def test_strips_think_tags(self, minimax_m27_instance):
-		answers, tokens, log_probs = minimax_m27_instance._pure(prompts[:1])
+	def test_strips_think_tags(self, minimax_m3_instance):
+		answers, tokens, log_probs = minimax_m3_instance._pure(prompts[:1])
 		assert answers[0] == "The answer is 42."
 
 	@patch.object(
@@ -291,8 +300,8 @@ class TestMiniMaxLLMThinkingStrip:
 		"create",
 		mock_minimax_chat_create_simple,
 	)
-	def test_no_think_tags(self, minimax_m27_instance):
-		answers, tokens, log_probs = minimax_m27_instance._pure(prompts[:1])
+	def test_no_think_tags(self, minimax_m3_instance):
+		answers, tokens, log_probs = minimax_m3_instance._pure(prompts[:1])
 		assert answers[0] == "Simple answer."
 
 
@@ -304,12 +313,10 @@ class TestMiniMaxLLMTruncation:
 		"create",
 		mock_minimax_chat_create,
 	)
-	def test_truncate_long_prompt(self, minimax_m25_highspeed_instance):
+	def test_truncate_long_prompt(self, minimax_m3_instance):
 		# Create a very long prompt
 		long_prompt = " ".join([f"word {i} is here" for i in range(100_000)])
-		answers, tokens, log_probs = minimax_m25_highspeed_instance._pure(
-			[long_prompt] * 3
-		)
+		answers, tokens, log_probs = minimax_m3_instance._pure([long_prompt] * 3)
 		check_generated_texts(answers)
 
 	@patch.object(
@@ -317,8 +324,8 @@ class TestMiniMaxLLMTruncation:
 		"create",
 		mock_minimax_chat_create,
 	)
-	def test_no_truncation(self, minimax_m27_instance):
-		answers, _, _ = minimax_m27_instance._pure(prompts, truncate=False)
+	def test_no_truncation(self, minimax_m3_instance):
+		answers, _, _ = minimax_m3_instance._pure(prompts, truncate=False)
 		check_generated_texts(answers)
 
 
@@ -337,7 +344,7 @@ class TestMiniMaxLLMNode:
 		result_df = MiniMaxLLM.run_evaluator(
 			project_dir=".",
 			previous_result=previous_result,
-			llm="MiniMax-M2.7",
+			llm="MiniMax-M3",
 			api_key="mock_minimax_api_key",
 			temperature=0.5,
 		)
@@ -349,9 +356,9 @@ class TestMiniMaxLLMNode:
 class TestMiniMaxLLMStream:
 	"""Test streaming methods."""
 
-	def test_stream_not_implemented(self, minimax_m27_instance):
+	def test_stream_not_implemented(self, minimax_m3_instance):
 		with pytest.raises(NotImplementedError):
-			minimax_m27_instance.stream("Hello")
+			minimax_m3_instance.stream("Hello")
 
 	@pytest.mark.asyncio()
 	@patch.object(
@@ -359,9 +366,9 @@ class TestMiniMaxLLMStream:
 		"create",
 		mock_minimax_chat_create_stream,
 	)
-	async def test_astream_strips_think_tags(self, minimax_m27_instance):
+	async def test_astream_strips_think_tags(self, minimax_m3_instance):
 		results = []
-		async for partial in minimax_m27_instance.astream("Hello"):
+		async for partial in minimax_m3_instance.astream("Hello"):
 			results.append(partial)
 
 		assert results[-1] == "Visible answer"
@@ -432,16 +439,22 @@ class TestMaxTokenDict:
 	"""Test MAX_TOKEN_DICT constants."""
 
 	def test_known_models(self):
+		assert "MiniMax-M3" in MAX_TOKEN_DICT
 		assert "MiniMax-M2.7" in MAX_TOKEN_DICT
 		assert "MiniMax-M2.7-highspeed" in MAX_TOKEN_DICT
-		assert "MiniMax-M2.5" in MAX_TOKEN_DICT
-		assert "MiniMax-M2.5-highspeed" in MAX_TOKEN_DICT
+
+	def test_legacy_models_removed(self):
+		assert "MiniMax-M2.5" not in MAX_TOKEN_DICT
+		assert "MiniMax-M2.5-highspeed" not in MAX_TOKEN_DICT
+
+	def test_m3_context(self):
+		assert MAX_TOKEN_DICT["MiniMax-M3"] == 524_288
 
 	def test_m27_context(self):
 		assert MAX_TOKEN_DICT["MiniMax-M2.7"] == 1_048_576
 
-	def test_m25_highspeed_context(self):
-		assert MAX_TOKEN_DICT["MiniMax-M2.5-highspeed"] == 204_800
+	def test_m27_highspeed_context(self):
+		assert MAX_TOKEN_DICT["MiniMax-M2.7-highspeed"] == 1_048_576
 
 
 class TestMiniMaxAPIBase:
@@ -465,7 +478,7 @@ class TestMiniMaxLLMIntegration:
 		"""Test with real API - requires MINIMAX_API_KEY env var."""
 		instance = MiniMaxLLM(
 			project_dir=".",
-			llm="MiniMax-M2.7",
+			llm="MiniMax-M3",
 		)
 		answers, tokens, log_probs = instance._pure(
 			["What is 2 + 2?"], temperature=0.1, max_tokens=50
@@ -481,7 +494,7 @@ class TestMiniMaxLLMIntegration:
 
 		instance = MiniMaxLLM(
 			project_dir=".",
-			llm="MiniMax-M2.7",
+			llm="MiniMax-M3",
 		)
 		result = []
 		async for i, s in a.enumerate(
@@ -493,11 +506,11 @@ class TestMiniMaxLLMIntegration:
 				assert len(result[i]) >= len(result[i - 1])
 		assert len(result) > 0
 
-	def test_real_m25_highspeed(self):
-		"""Test M2.5-highspeed model."""
+	def test_real_m27_highspeed(self):
+		"""Test M2.7-highspeed model."""
 		instance = MiniMaxLLM(
 			project_dir=".",
-			llm="MiniMax-M2.5-highspeed",
+			llm="MiniMax-M2.7-highspeed",
 		)
 		answers, tokens, log_probs = instance._pure(
 			["Tell me a joke."], temperature=0.5, max_tokens=100


### PR DESCRIPTION
## Summary
Upgrade the `minimax_llm` generator module to use MiniMax-M3 as the new default model.

## Changes
- Add `MiniMax-M3` (524,288 token context) to `MAX_TOKEN_DICT`, set as the new default
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as available alternatives
- Remove deprecated `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` entries
- Update `simple_minimax.yaml` sample config to use M3
- Update `minimax_llm.md` docs to reflect the new model list
- Update unit tests to cover M3, M2.7, and M2.7-highspeed paths and assert legacy models are removed

## Why
`MiniMax-M3` is MiniMax's new flagship model with a 512K context window and 128K max output, and it is the recommended default for new integrations. M2.7 (and the high-speed variant) are kept available so users with existing configs continue to work.

## Testing
- `pytest tests/autorag/nodes/generator/test_minimax.py` passes (35 unit tests, 3 integration tests skipped without `MINIMAX_API_KEY`)
- `ruff check` and `ruff format` clean