### PR TITLE
feat: strip <think> reasoning tags from string-overlap metrics

### DIFF
--- a/autorag/evaluation/metric/generation.py
+++ b/autorag/evaluation/metric/generation.py
@@ -19,6 +19,7 @@ from autorag.evaluation.metric.deepeval_prompt import FaithfulnessTemplate
 from autorag.evaluation.metric.util import (
 	autorag_metric_loop,
 	calculate_cosine_similarity,
+	remove_think_tags as _remove_think_tags,
 )
 from autorag.nodes.generator import OpenAILLM
 from autorag.nodes.generator.base import BaseGenerator
@@ -36,7 +37,11 @@ from autorag.utils.util import (
 
 @convert_inputs_to_list
 def huggingface_evaluate(
-	instance, key: str, metric_inputs: List[MetricInput], **kwargs
+	instance,
+	key: str,
+	metric_inputs: List[MetricInput],
+	remove_think_tags: bool = True,
+	**kwargs,
 ) -> List[float]:
 	"""
 	Compute huggingface evaluate metric.
@@ -44,11 +49,16 @@ def huggingface_evaluate(
 	:param instance: The instance of huggingface evaluates metric.
 	:param key: The key to retrieve result score from huggingface evaluate result.
 	:param metric_inputs: A list of MetricInput schema
+	:param remove_think_tags: Whether to strip internal reasoning blocks (e.g.
+		``<think>...</think>``) from the generated text before scoring.
+		Default is True.
 	:param kwargs: The additional arguments for metric function.
 	:return: The list of scores.
 	"""
 
 	def compute_score(gt: List[str], pred: str) -> float:
+		if remove_think_tags:
+			pred = _remove_think_tags(pred)
 		return max(
 			list(
 				map(
@@ -189,6 +199,7 @@ def bleu(
 	max_ngram_order: int = 4,
 	trg_lang: str = "",
 	effective_order: bool = True,
+	remove_think_tags: bool = True,
 	**kwargs,
 ) -> List[float]:
 	"""
@@ -202,6 +213,9 @@ def bleu(
 	:param trg_lang: An optional language code to raise potential tokenizer warnings.
 	:param effective_order: If `True`, stop including n-gram orders for which precision is 0. This should be
 	`True`, if sentence-level BLEU will be computed.
+	:param remove_think_tags: Whether to strip internal reasoning blocks (e.g.
+		``<think>...</think>``) from the generated text before scoring.
+		Default is True.
 	"""
 	bleu_instance = BLEU(
 		tokenize=tokenize,
@@ -213,14 +227,13 @@ def bleu(
 		**kwargs,
 	)
 
-	result = list(
-		map(
-			lambda x: bleu_instance.sentence_score(
-				x.generated_texts, x.generation_gt
-			).score,
-			metric_inputs,
-		)
-	)
+	def compute_score(metric_input: MetricInput) -> float:
+		pred = metric_input.generated_texts
+		if remove_think_tags:
+			pred = _remove_think_tags(pred)
+		return bleu_instance.sentence_score(pred, metric_input.generation_gt).score
+
+	result = list(map(compute_score, metric_inputs))
 	return result
 
 
@@ -230,6 +243,7 @@ def meteor(
 	alpha: float = 0.9,
 	beta: float = 3.0,
 	gamma: float = 0.5,
+	remove_think_tags: bool = True,
 ) -> List[float]:
 	"""
 	Compute meteor score for generation.
@@ -242,6 +256,9 @@ def meteor(
 	    Default is 3.0.
 	:param gamma: Relative weight assigned to fragmentation penalty.
 	    Default is 0.5.
+	:param remove_think_tags: Whether to strip internal reasoning blocks (e.g.
+	    ``<think>...</think>``) from the generated text before scoring.
+	    Default is True.
 	:return: A list of computed metric scores.
 	"""
 	nltk.download("punkt", quiet=True)
@@ -250,6 +267,7 @@ def meteor(
 		meteor_instance,
 		"meteor",
 		metric_inputs,
+		remove_think_tags=remove_think_tags,
 		alpha=alpha,
 		beta=beta,
 		gamma=gamma,
@@ -265,6 +283,7 @@ def rouge(
 	use_stemmer: bool = False,
 	split_summaries: bool = False,
 	batch: int = os.cpu_count(),
+	remove_think_tags: bool = True,
 ) -> List[float]:
 	"""
 	Compute rouge score for generation.
@@ -285,6 +304,9 @@ def rouge(
 	    Default is False.
 	:param batch: The batch size for processing.
 	    Default is your cpu count.
+	:param remove_think_tags: Whether to strip internal reasoning blocks (e.g.
+	    ``<think>...</think>``) from the generated text before scoring.
+	    Default is True.
 	:return: A list of computed metric scores.
 	"""
 	rouge_instance = RougeScorer(
@@ -295,6 +317,8 @@ def rouge(
 	)
 
 	async def compute(gt: List[str], pred: str) -> float:
+		if remove_think_tags:
+			pred = _remove_think_tags(pred)
 		return rouge_instance.score_multi(targets=gt, prediction=pred)[
 			rouge_type
 		].fmeasure
@@ -476,8 +500,23 @@ def bert_score(
 	lang: str = "en",
 	batch: int = 128,
 	n_threads: int = os.cpu_count(),
+	remove_think_tags: bool = True,
 ) -> List[float]:
+	"""
+	Compute BERTScore for generation.
+
+	:param metric_inputs: A list of MetricInput schema (Required Field -> "generation_gt", "generated_texts")
+	:param lang: The language of the text. Default is "en".
+	:param batch: The batch size for processing. Default is 128.
+	:param n_threads: The number of threads to use. Default is your cpu count.
+	:param remove_think_tags: Whether to strip internal reasoning blocks (e.g.
+		``<think>...</think>``) from the generated text before scoring.
+		Default is True.
+	:return: A list of computed metric scores.
+	"""
 	generations = [metric_input.generated_texts for metric_input in metric_inputs]
+	if remove_think_tags:
+		generations = [_remove_think_tags(gen) for gen in generations]
 	generation_gt = [metric_input.generation_gt for metric_input in metric_inputs]
 	evaluator = evaluate.load("bertscore")
 

--- a/autorag/evaluation/metric/util.py
+++ b/autorag/evaluation/metric/util.py
@@ -1,10 +1,31 @@
 import functools
+import re
 from typing import List
 
 import numpy as np
 
 from autorag.schema.metricinput import MetricInput
 from autorag.utils.util import convert_inputs_to_list
+
+# Matches reasoning blocks like <think>...</think> or <thinking>...</thinking>
+# (case-insensitive, spanning newlines) plus any trailing whitespace.
+_THINK_TAG_PATTERN = re.compile(
+	r"<think(?:ing)?>[\s\S]*?</think(?:ing)?>\s*", re.IGNORECASE
+)
+
+
+def remove_think_tags(text: str) -> str:
+	"""
+	Remove internal reasoning blocks (e.g. ``<think>...</think>``) from a model output.
+
+	Reasoning models emit these blocks in the generated text, which pollutes
+	string-overlap metrics such as ROUGE or BLEU. This strips them so the metric
+	scores the actual answer only. Text without such tags is returned unchanged.
+
+	:param text: The generated text to clean.
+	:return: The text with think tags (and their contents) removed.
+	"""
+	return _THINK_TAG_PATTERN.sub("", text)
 
 
 def calculate_cosine_similarity(a, b):

--- a/docs/source/evaluate_metrics/generation.md
+++ b/docs/source/evaluate_metrics/generation.md
@@ -125,3 +125,20 @@ A metric that measures the similarity between two sentences using BERT's Context
 
 Get the Contextual Embedding value of `Answer gt` and `LLM generated result` with BERT, evaluate the similarity with
 Cosine Similarity for each token-pair, and weight each token with IDF.
+
+## ❗Removing reasoning (`<think>`) tags
+
+Reasoning models often include their internal reasoning inside `<think>...</think>` (or
+`<thinking>...</thinking>`) blocks in the generated text. These blocks pollute string-overlap
+metrics such as **Bleu**, **Rouge**, **METEOR**, and **Bert Score**, lowering the score even when
+the actual answer is correct.
+
+By default AutoRAG strips these blocks before scoring. If you want to keep them and score the raw
+output instead, set `remove_think_tags: false` on the metric.
+
+Here is an example YAML file that keeps the reasoning block when computing **Rouge**.
+
+```yaml
+- metric_name: rouge
+  remove_think_tags: false
+```

--- a/tests/autorag/evaluate/metric/test_generation_metric.py
+++ b/tests/autorag/evaluate/metric/test_generation_metric.py
@@ -12,6 +12,7 @@ from autorag.evaluation.metric import (
     bert_score,
     deepeval_faithfulness,
 )
+from autorag.evaluation.metric.util import remove_think_tags
 from autorag.schema.metricinput import MetricInput
 from tests.delete_tests import is_github_action
 from tests.mock import mock_get_text_embedding_batch
@@ -129,6 +130,14 @@ similarity_generation_metric_inputs = [
         generations, generation_gts, retrieval_gt_contents
     )
 ]
+think_generations = [
+    f"<think>\nLet me reason about this step by step before answering.\n</think>\n{gen}"
+    for gen in generations
+]
+think_similarity_generation_metric_inputs = [
+    MetricInput(generated_texts=gen, generation_gt=gen_gt)
+    for gen, gen_gt in zip(think_generations, generation_gts)
+]
 ko_similarity_generation_metric_inputs = [
     MetricInput(generated_texts=gen, generation_gt=gen_gt)
     for gen, gen_gt in zip(ko_generations, ko_generation_gts)
@@ -226,6 +235,62 @@ def test_meteor():
 
 def test_rouge():
     base_test_metrics(rouge, [0.909, 0.35714, 1.0], similarity_generation_metric_inputs)
+
+
+def test_remove_think_tags():
+    assert remove_think_tags("<think>reasoning</think>answer") == "answer"
+    # case-insensitive and the <thinking> variant
+    assert remove_think_tags("<Thinking>reasoning</Thinking>\nanswer") == "answer"
+    # spans multiple lines
+    assert remove_think_tags("<think>line1\nline2</think>\nfinal") == "final"
+    # text without think tags is returned unchanged
+    assert remove_think_tags("just an answer") == "just an answer"
+    # the word "think" outside a tag must not be stripped
+    assert remove_think_tags("I think this is correct") == "I think this is correct"
+
+
+def test_rouge_remove_think_tags():
+    # think tags are stripped by default, so scores match the clean predictions
+    base_test_metrics(
+        rouge, [0.909, 0.35714, 1.0], think_similarity_generation_metric_inputs
+    )
+
+
+def test_rouge_keep_think_tags():
+    # when disabled, the reasoning block pollutes the prediction and lowers scores
+    polluted_scores = rouge(
+        think_similarity_generation_metric_inputs, remove_think_tags=False
+    )
+    clean_scores = rouge(think_similarity_generation_metric_inputs)
+    assert polluted_scores[0] < clean_scores[0]
+
+
+def test_bleu_remove_think_tags():
+    # direct-access path: think tags are stripped by default
+    base_test_metrics(
+        bleu,
+        [51.1507, 23.5783, 100.0],
+        think_similarity_generation_metric_inputs,
+        lowercase=True,
+    )
+    polluted_scores = bleu(
+        think_similarity_generation_metric_inputs,
+        lowercase=True,
+        remove_think_tags=False,
+    )
+    assert polluted_scores[0] < 51.1507
+
+
+def test_meteor_remove_think_tags():
+    # huggingface_evaluate path: think tags are stripped by default
+    base_test_metrics(
+        meteor,
+        [0.454033, 0.2985435, 0.64077828],
+        think_similarity_generation_metric_inputs,
+        alpha=0.85,
+        beta=0.2,
+        gamma=0.6,
+    )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary

Fixes #1133.

Reasoning models emit their internal reasoning inside `<think>...</think>` (or `<thinking>...</thinking>`) blocks. These blocks leak into the generated text and pollute string-overlap generation metrics (BLEU, ROUGE, METEOR, BERTScore), lowering scores even when the actual answer is correct.

This adds a `remove_think_tags: bool = True` option to those metrics. When enabled (the default), the reasoning block is stripped from the prediction before scoring.

## Changes

- **`autorag/evaluation/metric/util.py`** — new shared `remove_think_tags()` helper. Uses `r"<think(?:ing)?>[\s\S]*?</think(?:ing)?>\s*"` (case-insensitive, multiline). It is a no-op on text without think tags.
- **`autorag/evaluation/metric/generation.py`** — `remove_think_tags: bool = True` param on `rouge`, `bleu`, `meteor`, and `bert_score` (via the shared `huggingface_evaluate`). The prediction is cleaned locally so the shared `MetricInput` is never mutated across metrics.
- **`tests/...test_generation_metric.py`** — unit tests for the helper plus integration tests covering both the direct-access path (`rouge`, `bleu`) and the `huggingface_evaluate` path (`meteor`), for both enabled and disabled behavior.
- **`docs/.../generation.md`** — documents the behavior and the opt-out YAML.

## Design notes

- **Default `True`** follows the recommendation in the issue thread. It only changes scores where `<think>` blocks are actually present (no-op otherwise), so existing non-reasoning runs are unaffected.
- The option flows through from YAML config (e.g. `remove_think_tags: false`) since extra metric keys are passed straight to the metric function.

```yaml
- metric_name: rouge
  remove_think_tags: false
```

## Notes

- As documented in CONTRIBUTING, the OpenAI-key tests will fail in GitHub Actions; the new tests added here use only CPU metrics (no API/GPU) and run in CI.
- `bert_score` gained the option too, but no new test was added for it since its tests require a GPU and are already skipped on GitHub Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)