### PR TITLE
ci: separate AutoRAG 2.0 (v*) and legacy (legacy-v*) release triggers safely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # pi-coding-agent's grep tool needs ripgrep; preinstall it so tests
+      # don't depend on its on-demand binary download.
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Verify legacy tag format
+        run: |
+          if ! echo "$GITHUB_REF_NAME" | grep -Eq '^legacy-v[0-9]+\.[0-9]+\.[0-9]+([.-].+)?$'; then
+            echo "::error::Tag '$GITHUB_REF_NAME' is not a valid legacy release tag (expected legacy-vX.Y.Z)."
+            echo "::error::AutoRAG 2.0 npm releases use plain v* tags instead (see .github/workflows/release.yml)."
+            exit 1
+          fi
+
       - name: Export tag
         id: vars
-        run: echo tag=${GITHUB_REF#refs/tags/legacy-} >> $GITHUB_OUTPUT
+        run: echo tag=${GITHUB_REF#refs/tags/legacy-v} >> $GITHUB_OUTPUT
 
       - name: Update project version
         run: |
@@ -65,3 +73,23 @@ jobs:
         working-directory: legacy
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
+
+  github-release:
+    runs-on: ubuntu-latest
+    needs: [publish]
+    permissions:
+      contents: write
+    steps:
+      - name: Create GitHub release (never marked as latest)
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "AutoRAG Legacy ${{ github.ref_name }}"
+          generate_release_notes: true
+          # Keep the repository's "Latest release" pointing at AutoRAG 2.0 (v* tags).
+          make_latest: "false"
+          body: |
+            Legacy Python AutoRAG maintenance release (`legacy/` directory).
+            Install from PyPI: `pip install AutoRAG`
+
+            > This is a maintenance release of the original RAG AutoML tool.
+            > For AutoRAG 2.0 (the librarian agent at the repository root), see the latest `v*` release.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+# AutoRAG 2.0 npm releases only. Tags must be v<version> and match package.json
+# exactly (guard below). Legacy Python releases use legacy-v* tags (publish.yml)
+# and can never trigger this workflow.
 on:
   push:
     tags: ["v*"]
@@ -13,6 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Verify tag matches package.json version
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$GITHUB_REF_NAME" != "v$PKG_VERSION" ]; then
+            echo "::error::Tag '$GITHUB_REF_NAME' does not match package.json version 'v$PKG_VERSION'."
+            echo "::error::AutoRAG 2.0 npm releases require the tag to equal v<package.json version>."
+            echo "::error::If you meant to release the legacy Python AutoRAG, use a 'legacy-v*' tag instead (see .github/workflows/publish.yml)."
+            exit 1
+          fi
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -40,4 +53,6 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          name: "AutoRAG ${{ github.ref_name }}"
           generate_release_notes: true
+          make_latest: "true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,11 @@ jobs:
             exit 1
           fi
 
+      # pi-coding-agent's grep tool needs ripgrep; preinstall it so tests
+      # don't depend on its on-demand binary download.
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest


### PR DESCRIPTION
## Problem

Both release pipelines create GitHub Releases and are triggered by tags, so a legacy Python release and an AutoRAG 2.0 npm release could collide:

- A stray `v*` tag (habit from legacy releases, e.g. `v0.3.23`) would trigger the **npm** workflow and publish the wrong thing.
- A legacy GitHub Release could grab the repo's **"Latest release"** badge away from AutoRAG 2.0.

## Changes

### `release.yml` (AutoRAG 2.0, npm — `v*` tags)
- New guard step: the tag must equal `v<package.json version>` exactly, otherwise the run fails fast with a hint pointing to `legacy-v*` tags. This makes it impossible to accidentally npm-publish from a legacy-style version tag.
- Release is named `AutoRAG vX.Y.Z` and pinned `make_latest: "true"`.

### `publish.yml` (legacy Python, PyPI — `legacy-v*` tags)
- New guard step validating `legacy-vX.Y.Z` tag format.
- Version extraction now strips the full `legacy-v` prefix (previously only `legacy-` was stripped, which would have written `version = "v0.3.23"` into pyproject.toml — an invalid PEP 440 version).
- New `github-release` job so legacy releases also get a GitHub Release, but with `make_latest: "false"` — legacy releases can never take the "Latest" badge from 2.0. Release body clearly labels it as a maintenance release with a pointer to 2.0.

## Result

| Tag | Workflow | Publishes | GitHub Release | Latest badge |
|---|---|---|---|---|
| `v0.1.0` | release.yml | npm `@autorag/librarian` | `AutoRAG v0.1.0` | ✅ yes |
| `legacy-v0.3.23` | publish.yml | PyPI `AutoRAG` | `AutoRAG Legacy legacy-v0.3.23` | ❌ never |
| `v0.3.23` with package.json at 0.1.0 | release.yml | ❌ fails fast with guidance | — | — |
