### PR TITLE
release: v2.0.0 — first npm release of @autorag/librarian

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorag/librarian",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "description": "Self-evolving librarian agent on Pi framework with pluggable retrieval methods",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Bumps package.json to 2.0.0 for the first npm release.

**Why not 0.1.0:** the `v0.1.0` tag (and its GitHub release) already exists from the 2024 legacy Python era, and `release.yml` enforces tag == `v<package.json version>`. `2.0.0` matches AutoRAG 2.0 branding and is clear of every legacy `v0.x` tag.

After merge: tag `v2.0.0` on main → release workflow publishes to npm with provenance and creates the GitHub release (marked Latest).