### PR TITLE
fix(legacy): apply reviewed runtime and metric fixes

### DIFF
--- a/legacy/autorag/evaluation/metric/generation.py
+++ b/legacy/autorag/evaluation/metric/generation.py
@@ -19,6 +19,7 @@ from autorag.evaluation.metric.deepeval_prompt import FaithfulnessTemplate
 from autorag.evaluation.metric.util import (
 	autorag_metric_loop,
 	calculate_cosine_similarity,
+	remove_think_tags as _remove_think_tags,
 )
 from autorag.nodes.generator import OpenAILLM
 from autorag.nodes.generator.base import BaseGenerator
@@ -36,7 +37,11 @@ from autorag.utils.util import (
 
 @convert_inputs_to_list
 def huggingface_evaluate(
-	instance, key: str, metric_inputs: List[MetricInput], **kwargs
+	instance,
+	key: str,
+	metric_inputs: List[MetricInput],
+	remove_think_tags: bool = True,
+	**kwargs,
 ) -> List[float]:
 	"""
 	Compute huggingface evaluate metric.
@@ -49,6 +54,8 @@ def huggingface_evaluate(
 	"""
 
 	def compute_score(gt: List[str], pred: str) -> float:
+		if remove_think_tags:
+			pred = _remove_think_tags(pred)
 		return max(
 			list(
 				map(
@@ -189,6 +196,7 @@ def bleu(
 	max_ngram_order: int = 4,
 	trg_lang: str = "",
 	effective_order: bool = True,
+	remove_think_tags: bool = True,
 	**kwargs,
 ) -> List[float]:
 	"""
@@ -213,14 +221,15 @@ def bleu(
 		**kwargs,
 	)
 
-	result = list(
-		map(
-			lambda x: bleu_instance.sentence_score(
-				x.generated_texts, x.generation_gt
-			).score,
-			metric_inputs,
-		)
-	)
+	def compute_score(metric_input: MetricInput) -> float:
+		prediction = metric_input.generated_texts
+		if remove_think_tags:
+			prediction = _remove_think_tags(prediction)
+		return bleu_instance.sentence_score(
+			prediction, metric_input.generation_gt
+		).score
+
+	result = list(map(compute_score, metric_inputs))
 	return result
 
 
@@ -230,6 +239,7 @@ def meteor(
 	alpha: float = 0.9,
 	beta: float = 3.0,
 	gamma: float = 0.5,
+	remove_think_tags: bool = True,
 ) -> List[float]:
 	"""
 	Compute meteor score for generation.
@@ -250,6 +260,7 @@ def meteor(
 		meteor_instance,
 		"meteor",
 		metric_inputs,
+		remove_think_tags=remove_think_tags,
 		alpha=alpha,
 		beta=beta,
 		gamma=gamma,
@@ -265,6 +276,7 @@ def rouge(
 	use_stemmer: bool = False,
 	split_summaries: bool = False,
 	batch: int = os.cpu_count(),
+	remove_think_tags: bool = True,
 ) -> List[float]:
 	"""
 	Compute rouge score for generation.
@@ -295,6 +307,8 @@ def rouge(
 	)
 
 	async def compute(gt: List[str], pred: str) -> float:
+		if remove_think_tags:
+			pred = _remove_think_tags(pred)
 		return rouge_instance.score_multi(targets=gt, prediction=pred)[
 			rouge_type
 		].fmeasure
@@ -476,8 +490,11 @@ def bert_score(
 	lang: str = "en",
 	batch: int = 128,
 	n_threads: int = os.cpu_count(),
+	remove_think_tags: bool = True,
 ) -> List[float]:
 	generations = [metric_input.generated_texts for metric_input in metric_inputs]
+	if remove_think_tags:
+		generations = [_remove_think_tags(generation) for generation in generations]
 	generation_gt = [metric_input.generation_gt for metric_input in metric_inputs]
 	evaluator = evaluate.load("bertscore")
 

--- a/legacy/autorag/evaluation/metric/util.py
+++ b/legacy/autorag/evaluation/metric/util.py
@@ -1,10 +1,20 @@
 import functools
+import re
 from typing import List
 
 import numpy as np
 
 from autorag.schema.metricinput import MetricInput
 from autorag.utils.util import convert_inputs_to_list
+
+_THINK_TAG_PATTERN = re.compile(
+	r"<think(?:ing)?>[\s\S]*?</think(?:ing)?>\s*", re.IGNORECASE
+)
+
+
+def remove_think_tags(text: str) -> str:
+	"""Remove complete ``<think>`` or ``<thinking>`` reasoning blocks."""
+	return _THINK_TAG_PATTERN.sub("", text)
 
 
 def calculate_cosine_similarity(a, b):

--- a/legacy/autorag/node_line.py
+++ b/legacy/autorag/node_line.py
@@ -50,6 +50,10 @@ def run_node_line(
 			os.path.join(node_line_dir, node.node_type, "summary.csv")
 		)
 		best_node_row = node_summary_df.loc[node_summary_df["is_best"]]
+		if best_node_row.empty:
+			raise ValueError(
+				f"No best module found for node type {node.node_type} in summary file."
+			)
 		summary_lst.append(
 			{
 				"node_type": node.node_type,

--- a/legacy/autorag/nodes/generator/openai_llm.py
+++ b/legacy/autorag/nodes/generator/openai_llm.py
@@ -332,12 +332,6 @@ class OpenAILLM(BaseGenerator):
 	async def get_result_gpt_5(self, prompt: Union[str, List[dict]], **kwargs):
 		if not self.llm.startswith("gpt-5"):
 			raise ValueError("get_result_gpt_5 is only for gpt-5 models.")
-		api_key = getattr(self.client, "api_key", None)
-		if isinstance(api_key, str) and api_key.startswith("mock_"):
-			answer = "Why not"
-			tokens = self.tokenizer.encode(answer, allowed_special="all")
-			pseudo_log_probs = [0.5] * len(tokens)
-			return answer, tokens, pseudo_log_probs
 		messages = parse_prompt(prompt)
 		instruction = "\n\n".join(
 			[msg["content"] for msg in messages if msg["role"] == "system"]

--- a/legacy/autorag/nodes/passagereranker/nvidia.py
+++ b/legacy/autorag/nodes/passagereranker/nvidia.py
@@ -85,6 +85,9 @@ class NvidiaReranker(BasePassageReranker):
 				f"len(queries)={len(queries)}, len(contents_list)={len(contents_list)}, len(ids_list)={len(ids_list)}."
 			)
 
+		if not queries:
+			return [], [], []
+
 		tasks = [
 			nvidia_rerank_pure(
 				self.session,

--- a/legacy/autorag/support.py
+++ b/legacy/autorag/support.py
@@ -131,6 +131,8 @@ def get_support_modules(module_name: str) -> Callable:
 		),
 		"flashrank_reranker": ("autorag.nodes.passagereranker", "FlashRankReranker"),
 		"FlashRankReranker": ("autorag.nodes.passagereranker", "FlashRankReranker"),
+		"nvidia_reranker": ("autorag.nodes.passagereranker", "NvidiaReranker"),
+		"NvidiaReranker": ("autorag.nodes.passagereranker", "NvidiaReranker"),
 		# passage_filter
 		"pass_passage_filter": ("autorag.nodes.passagefilter", "PassPassageFilter"),
 		"similarity_threshold_cutoff": (

--- a/legacy/autorag/utils/util.py
+++ b/legacy/autorag/utils/util.py
@@ -302,7 +302,23 @@ async def process_batch(tasks, batch_size: int = 64) -> List[Any]:
 
 	for i in range(0, len(tasks), batch_size):
 		batch = tasks[i : i + batch_size]
-		batch_results = await asyncio.gather(*batch)
+		batch_results = await asyncio.gather(*batch, return_exceptions=True)
+
+		first_exception = None
+		for offset, item in enumerate(batch_results):
+			if isinstance(item, BaseException):
+				logger.error(
+					"process_batch task %d (batch offset %d) raised %s: %s",
+					i + offset,
+					offset,
+					type(item).__name__,
+					item,
+				)
+				if first_exception is None:
+					first_exception = item
+		if first_exception is not None:
+			raise first_exception
+
 		results.extend(batch_results)
 
 	return results

--- a/legacy/docs/source/evaluate_metrics/generation.md
+++ b/legacy/docs/source/evaluate_metrics/generation.md
@@ -125,3 +125,17 @@ A metric that measures the similarity between two sentences using BERT's Context
 
 Get the Contextual Embedding value of `Answer gt` and `LLM generated result` with BERT, evaluate the similarity with
 Cosine Similarity for each token-pair, and weight each token with IDF.
+
+## Removing reasoning (`<think>`) tags
+
+Reasoning models can include internal reasoning inside `<think>...</think>` or
+`<thinking>...</thinking>` blocks. BLEU, ROUGE, METEOR, and BERTScore remove
+complete reasoning blocks by default so they score the final answer rather than
+the hidden chain of thought.
+
+Set `remove_think_tags: false` on a metric to score the raw output instead:
+
+```yaml
+- metric_name: rouge
+  remove_think_tags: false
+```

--- a/legacy/tests/autorag/evaluate/metric/test_generation_metric.py
+++ b/legacy/tests/autorag/evaluate/metric/test_generation_metric.py
@@ -12,6 +12,7 @@ from autorag.evaluation.metric import (
     bert_score,
     deepeval_faithfulness,
 )
+from autorag.evaluation.metric.util import remove_think_tags
 from autorag.schema.metricinput import MetricInput
 from tests.delete_tests import is_github_action
 from tests.mock import mock_get_text_embedding_batch
@@ -129,6 +130,13 @@ similarity_generation_metric_inputs = [
         generations, generation_gts, retrieval_gt_contents
     )
 ]
+think_similarity_generation_metric_inputs = [
+    MetricInput(
+        generated_texts=f"<think>private reasoning</think>\n{metric_input.generated_texts}",
+        generation_gt=metric_input.generation_gt,
+    )
+    for metric_input in similarity_generation_metric_inputs
+]
 ko_similarity_generation_metric_inputs = [
     MetricInput(generated_texts=gen, generation_gt=gen_gt)
     for gen, gen_gt in zip(ko_generations, ko_generation_gts)
@@ -226,6 +234,38 @@ def test_meteor():
 
 def test_rouge():
     base_test_metrics(rouge, [0.909, 0.35714, 1.0], similarity_generation_metric_inputs)
+
+
+def test_remove_think_tags():
+    assert remove_think_tags("<think>reasoning</think>answer") == "answer"
+    assert remove_think_tags("<Thinking>line 1\nline 2</Thinking>\nanswer") == "answer"
+    assert remove_think_tags("I think this is correct") == "I think this is correct"
+
+
+def test_overlap_metrics_remove_think_tags_by_default():
+    clean_bleu = bleu(similarity_generation_metric_inputs, lowercase=True)
+    clean_rouge = rouge(similarity_generation_metric_inputs)
+    clean_meteor = meteor(
+        similarity_generation_metric_inputs, alpha=0.85, beta=0.2, gamma=0.6
+    )
+
+    assert bleu(think_similarity_generation_metric_inputs, lowercase=True) == pytest.approx(
+        clean_bleu
+    )
+    assert rouge(think_similarity_generation_metric_inputs) == pytest.approx(
+        clean_rouge
+    )
+    assert meteor(
+        think_similarity_generation_metric_inputs, alpha=0.85, beta=0.2, gamma=0.6
+    ) == pytest.approx(clean_meteor)
+
+
+def test_overlap_metrics_can_keep_think_tags():
+    clean_scores = rouge(think_similarity_generation_metric_inputs)
+    raw_scores = rouge(
+        think_similarity_generation_metric_inputs, remove_think_tags=False
+    )
+    assert raw_scores[0] < clean_scores[0]
 
 
 @pytest.mark.skipif(

--- a/legacy/tests/autorag/nodes/generator/test_openai.py
+++ b/legacy/tests/autorag/nodes/generator/test_openai.py
@@ -57,6 +57,15 @@ def openai_gpt_5_instance():
 	)
 
 
+async def mock_openai_responses_create(*args, **kwargs):
+	return SimpleNamespace(output_text="Why not")
+
+
+@patch.object(
+	openai.resources.responses.AsyncResponses,
+	"create",
+	mock_openai_responses_create,
+)
 def test_openai_llm_gpt_5(openai_gpt_5_instance):
 	answers, tokens, log_probs = openai_gpt_5_instance._pure(
 		prompts,
@@ -71,6 +80,11 @@ def test_openai_llm_gpt_5(openai_gpt_5_instance):
 @pytest.mark.parametrize(
 	"model_name",
 	["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4"],
+)
+@patch.object(
+	openai.resources.responses.AsyncResponses,
+	"create",
+	mock_openai_responses_create,
 )
 def test_openai_llm_latest_models(model_name):
 	instance = OpenAILLM(project_dir=".", llm=model_name, api_key="mock_openai_api_key")

--- a/legacy/tests/autorag/nodes/passagereranker/test_nvidia_reranker.py
+++ b/legacy/tests/autorag/nodes/passagereranker/test_nvidia_reranker.py
@@ -4,6 +4,7 @@ from aioresponses import aioresponses
 
 from autorag.nodes.passagereranker import NvidiaReranker
 from autorag.nodes.passagereranker.nvidia import nvidia_rerank_pure
+from autorag.support import get_support_modules
 from autorag.utils.util import get_event_loop
 from tests.autorag.nodes.passagereranker.test_passage_reranker_base import (
 	queries_example,
@@ -116,6 +117,15 @@ def test_nvidia_reranker_batch_one(nvidia_reranker_instance):
             batch=batch,
         )
         base_reranker_test(contents_result, id_result, score_result, top_k)
+
+
+def test_nvidia_reranker_empty_input(nvidia_reranker_instance):
+	assert nvidia_reranker_instance._pure([], [], [], [], top_k=3) == ([], [], [])
+
+
+def test_nvidia_reranker_registration():
+	assert get_support_modules("nvidia_reranker") is NvidiaReranker
+	assert get_support_modules("NvidiaReranker") is NvidiaReranker
 
 
 def test_nvidia_reranker_node():

--- a/legacy/tests/autorag/test_node_line.py
+++ b/legacy/tests/autorag/test_node_line.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from autorag.node_line import run_node_line
+
+
+def test_run_node_line_reports_missing_best_module(tmp_path):
+	node_type = "generator"
+	node_dir = tmp_path / node_type
+	node_dir.mkdir()
+	pd.DataFrame(
+		{
+			"is_best": [False],
+			"filename": ["0.parquet"],
+			"module_name": ["mock"],
+			"module_params": [{}],
+			"execution_time": [0.1],
+		}
+	).to_csv(node_dir / "summary.csv", index=False)
+
+	node = SimpleNamespace(
+		node_type=node_type,
+		run=lambda previous_result, node_line_dir: previous_result,
+	)
+	previous_result = pd.DataFrame({"query": ["test"]})
+
+	with pytest.raises(ValueError, match="No best module found for node type generator"):
+		run_node_line([node], str(tmp_path), previous_result)

--- a/legacy/tests/autorag/utils/test_util.py
+++ b/legacy/tests/autorag/utils/test_util.py
@@ -1,4 +1,5 @@
 import itertools
+import asyncio
 import os
 import pathlib
 import tempfile
@@ -367,6 +368,29 @@ def test_process_batch():
     result = loop.run_until_complete(process_batch(tasks, batch_size=64))
 
     assert result == results
+
+
+def test_process_batch_waits_for_siblings_and_logs_all_failures(caplog):
+    release = asyncio.Event()
+    completed = []
+
+    async def fail(name):
+        await release.wait()
+        raise RuntimeError(name)
+
+    async def complete_sibling():
+        release.set()
+        completed.append("done")
+        return "done"
+
+    tasks = [fail("first"), complete_sibling(), fail("second")]
+    loop = get_event_loop()
+    with pytest.raises(RuntimeError, match="first"):
+        loop.run_until_complete(process_batch(tasks, batch_size=3))
+
+    assert completed == ["done"]
+    assert "first" in caplog.text
+    assert "second" in caplog.text
 
 
 def test_openai_truncate_by_token():


### PR DESCRIPTION
Reviewed replacement for the valid portions of #1236, #1239, #1285, #1238, and #1288.

Included:
- register NVIDIA reranker and handle empty batches
- let process_batch finish siblings, log every exception, then re-raise the first
- report a clear error when a node summary has no best module
- remove production behavior keyed off mock_ API key prefixes and mock Responses API calls in tests instead
- strip complete think/thinking blocks from BLEU, ROUGE, METEOR, and BERTScore by default, with an opt-out

Intentionally excluded from #1236:
- OpenAI changes already superseded by #1338
- the proposed LlamaIndex logprob fix, which still treats List[List[LogProb]] as a flat list
- the chunk embedding remap removal, whose compatibility behavior was not justified

Validation:
- 56 focused non-live tests passed
- ruff and diff checks passed
- manual resolver and metric surfaces passed
- full CI requested