### PR TITLE
release: AutoRAG v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorag/librarian",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Self-evolving librarian agent on Pi framework with pluggable retrieval methods",
   "license": "MIT",
   "repository": {
@@ -17,7 +17,7 @@
     }
   },
   "bin": {
-    "autorag": "./dist/cli/index.js"
+    "autorag": "dist/cli/index.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Summary

- release AutoRAG 2.1.0 with connector-backed datasource skills and macOS Spotlight search
- add legacy HWP5 body and table extraction
- expose traceable datasource sources and diagnostics
- normalize the npm CLI binary path so global installs expose `autorag` without package correction

## Verification

- 82 test files / 1220 tests passed
- TypeScript typecheck passed
- Biome passed
- production build passed
- packed npm artifact installed successfully and `autorag --help` ran