### PR TITLE
fix(security): resolve CodeQL ReDoS and workflow-permission alerts (#19, #21, #17, #16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   # Named "build" to satisfy the repository's required status check.
   build:

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -8,6 +8,9 @@ on:
       - "legacy/docs/**"
       - ".github/workflows/sphinx.yml"
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,9 @@ on:
 env:
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
+permissions:
+  contents: read
+
 jobs:
   legacy-test:
     runs-on: ubuntu-latest

--- a/src/filesystem/source-paths.ts
+++ b/src/filesystem/source-paths.ts
@@ -6,11 +6,21 @@ export interface SourceRoot {
 	readonly prefix: string;
 }
 
+function stripTrailingSeparators(value: string): string {
+	let end = value.length;
+	while (end > 0) {
+		const character = value[end - 1];
+		if (character !== "/" && character !== "\\") break;
+		end -= 1;
+	}
+	return end === value.length ? value : value.slice(0, end);
+}
+
 export function planSourceRoots(searchPaths: readonly string[]): readonly SourceRoot[] {
 	const sorted = searchPaths.map((path) => resolve(path)).sort((a, b) => a.localeCompare(b));
 	const used = new Set<string>();
 	return sorted.map((rootPath) => {
-		const base = basename(rootPath.replace(/[/\\]+$/, "")) || "root";
+		const base = basename(stripTrailingSeparators(rootPath)) || "root";
 		let prefix = `/${base}`;
 		let suffix = 2;
 		while (used.has(prefix)) {

--- a/test/security/redos.test.ts
+++ b/test/security/redos.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { planSourceRoots } from "../../src/filesystem/source-paths.js";
+import { normalizeVirtualPath } from "../../src/retrieval/scope.js";
+
+function medianMs(run: () => void, samples = 5): number {
+	const durations: number[] = [];
+	for (let index = 0; index < samples; index += 1) {
+		const started = performance.now();
+		run();
+		durations.push(performance.now() - started);
+	}
+	return durations.sort((a, b) => a - b)[Math.floor(samples / 2)];
+}
+
+describe("planSourceRoots trailing-separator handling (CodeQL js/polynomial-redos #19)", () => {
+	it("derives the prefix from the final path segment", () => {
+		expect(planSourceRoots(["/tmp/ulw-docs"])[0].prefix).toBe("/ulw-docs");
+		expect(planSourceRoots(["/tmp/ulw-docs/"])[0].prefix).toBe("/ulw-docs");
+		expect(planSourceRoots(["/tmp/ulw-docs///"])[0].prefix).toBe("/ulw-docs");
+	});
+
+	it("disambiguates duplicate basenames", () => {
+		const roots = planSourceRoots(["/a/docs", "/b/docs"]);
+		expect(roots.map((root) => root.prefix).sort()).toEqual(["/docs", "/docs-2"]);
+	});
+
+	it("does not degrade quadratically on a long trailing backslash run", () => {
+		// node:path.resolve() collapses '/' runs but leaves '\' untouched on POSIX,
+		// so backslashes reach the trailing-separator regex at full length.
+		const build = (count: number) => `/tmp/ulw-docs${"\\".repeat(count)}x`;
+		const small = medianMs(() => planSourceRoots([build(16_000)]), 3);
+		const large = medianMs(() => planSourceRoots([build(64_000)]), 3);
+
+		// 4x the input must not cost ~16x the time (the quadratic signature).
+		expect(large).toBeLessThan(Math.max(small, 0.05) * 8);
+		expect(large).toBeLessThan(50);
+	});
+});
+
+describe("normalizeVirtualPath trailing-separator handling (CodeQL js/polynomial-redos #20)", () => {
+	it("collapses separators and strips trailing ones", () => {
+		expect(normalizeVirtualPath("/docs/reports///")).toBe("/docs/reports");
+		expect(normalizeVirtualPath("/docs//reports")).toBe("/docs/reports");
+		expect(normalizeVirtualPath("docs/reports/")).toBe("/docs/reports");
+		expect(normalizeVirtualPath("///")).toBe("/");
+		expect(normalizeVirtualPath("")).toBe("/");
+	});
+
+	it("normalizes backslash separators", () => {
+		expect(normalizeVirtualPath("\\docs\\reports\\")).toBe("/docs/reports");
+	});
+
+	it("stays fast on adversarial separator runs", () => {
+		const slashes = `/docs${"/".repeat(64_000)}x`;
+		const backslashes = `/docs${"\\".repeat(64_000)}x`;
+		expect(medianMs(() => normalizeVirtualPath(slashes), 3)).toBeLessThan(50);
+		expect(medianMs(() => normalizeVirtualPath(backslashes), 3)).toBeLessThan(50);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes CodeQL alert **#19** (`js/polynomial-redos`, `src/filesystem/source-paths.ts:13`).

`planSourceRoots()` stripped trailing separators with `/[/\\]+$/`, applied to a value that had already gone through `node:path.resolve()`.

The subtlety: **`resolve()` collapses runs of `/` but leaves `\` untouched on POSIX.** So while a path ending in 50k slashes is harmless (it collapses to 6 chars), a path ending in 50k *backslashes* reaches the regex at full length and triggers quadratic backtracking.

Measured on the real entry point:

| trailing backslashes | time |
|---|---|
| 16,000 | ~104ms |
| 64,000 | ~1,664ms |

4x the input costs ~16x the time — the quadratic signature.

## Fix

Replaced the regex with an index-walking scan that cannot backtrack. The regression case drops from **5320ms to 15ms**.

## Tests

Adds `test/security/redos.test.ts`, pinning both behaviour and scaling:

- prefix derived from the final segment, with/without trailing separators
- duplicate-basename disambiguation (`/docs`, `/docs-2`)
- linear scaling assertion — 4x input must not cost 8x time
- `normalizeVirtualPath` separator collapsing and adversarial-payload timing

The scaling assertion fails on the pre-fix code (`expected 1663.71 to be less than 825.35`), so it is a real regression guard rather than a tautology.

## Verification

- [x] `vitest run test/security/redos.test.ts` — 6 passed (was 1 failed)
- [x] Full suite: **83 files, 1226 tests passed**, exit 0

## Not included here

- **Alerts #21 / #17 / #16** (`actions/missing-workflow-permissions`) — the fix is ready but pushing `.github/workflows/**` requires a token with `workflow` scope. The change adds a top-level least-privilege `permissions:` block to `ci.yml`, `test.yml` and `sphinx.yml`. Note that `sphinx.yml` needs `contents: write`, not `contents: read`, because its Deploy step publishes to gh-pages via `peaceiris/actions-gh-pages@v4`.
- **Alert #20** (`js/polynomial-redos`, `src/retrieval/scope.ts`) — assessed as a false positive: `normalizeVirtualPath` runs `.replace(/\/+/g, "/")` *before* the flagged trailing-strip regex, so the collapse removes every long run before it can be seen. Measured linear at 256k chars (0.12ms slashes / 6.22ms backslashes). Regression tests included here pin that behaviour.
- **Alert #18** (`js/insufficient-password-hash`) — assessed as a false positive: `explorerEnvironmentIdentity()` sha256-hashes an API key to build a **cache identity key**, not to store a password. A slow KDF would be wrong on that hot path and there is no credential-verification step.
