### PR TITLE
fix(retrieval): normalize physical search scopes

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -43,6 +43,12 @@ import { ParallelRetriever, ResultMerger } from "../retrieval/merger.ts";
 import { BM25Method, type BM25MethodOptions, type BM25SyncResult } from "../retrieval/methods/bm25.ts";
 
 import { RetrievalMethodRegistry } from "../retrieval/registry.ts";
+import {
+	buildRetrievalScopeBindings,
+	normalizeVirtualPath,
+	type RetrievalScopeBinding,
+	resolveRetrievalScope,
+} from "../retrieval/scope.ts";
 import type { CuratedResult, RetrievalDiagnostic, RetrievalOptions, RetrievalResult } from "../retrieval/types.ts";
 import { safeParseExplorerReport } from "../subagents/contracts.ts";
 import { buildDispatchTemplatesPromptSection } from "../subagents/dispatch-templates.ts";
@@ -255,6 +261,9 @@ export class AutoRAGAgent {
 	};
 
 	private readonly searchPaths: string[];
+	private readonly configuredSearchPaths: readonly string[];
+	private retrievalScopeBindings: readonly RetrievalScopeBinding[];
+	private readonly datasourceVirtualScopePrefixes: readonly string[];
 	private readonly allowedExplorerRoots: readonly string[];
 	private readonly workspaceProjectRoot: string;
 	private readonly methodRegistry = new RetrievalMethodRegistry();
@@ -288,11 +297,20 @@ export class AutoRAGAgent {
 			(async (sessionOptions) => (await createMandatorySubagentSession(sessionOptions)).session);
 		const manifests = manifestDir ? loadManifests(manifestDir) : [];
 		this.datasourceSkills = options.datasourceSkills ?? [];
+		this.datasourceVirtualScopePrefixes = this.datasourceSkills.map((skill) =>
+			normalizeVirtualPath(`/${skill.describe().name}`),
+		);
 		this.datasourceAccessOptions = options.datasourceAccess ?? {};
 		this.datasourceAgentSkills = this.buildAuthorizedDatasourceSkills();
 
+		this.configuredSearchPaths = options.searchPaths.map((searchPath) => resolve(searchPath));
 		this.searchPaths = options.searchPaths.map(pinSearchRoot);
 		this.workspaceProjectRoot = options.workspacePath ?? process.cwd();
+		this.retrievalScopeBindings = buildRetrievalScopeBindings(
+			this.workspaceProjectRoot,
+			this.searchPaths,
+			this.configuredSearchPaths,
+		);
 		this.allowedExplorerRoots = [...new Set(this.searchPaths)].sort();
 		this.parserOptions = options.parserOptions;
 
@@ -319,10 +337,16 @@ export class AutoRAGAgent {
 		this.runLogger = new AutoRAGRunLogger(join(dirname(memPath), "logs", "runs.jsonl"));
 
 		const checkMemoryTool = createCheckMemoryTool(this.memory);
-		const searchBM25Tool = createSearchBM25DocumentsTool(() => this.bm25Method);
+		const searchBM25Tool = createSearchBM25DocumentsTool(
+			() => this.bm25Method,
+			(scope) => this.resolveRetrievalScope(scope),
+		);
 		const searchDatasourceTool = createSearchDatasourceDocumentsTool(this);
 
-		const searchMinSyncTool = createSearchMinSyncDocumentsTool(() => this.minSyncMethod);
+		const searchMinSyncTool = createSearchMinSyncDocumentsTool(
+			() => this.minSyncMethod,
+			(scope) => this.resolveRetrievalScope(scope),
+		);
 		const searchAllTool = createSearchAllDocumentsTool(this);
 		const loadDatasourceSkillTool = createLoadDatasourceSkillTool(this);
 		const emitResultsTool = createEmitResultsTool((details) => this.resultCapture?.(details));
@@ -805,6 +829,7 @@ export class AutoRAGAgent {
 			this.lastSessionId = sessionId;
 			return createEmptySearchDocumentsResponse(sessionId, trimmedQuery, this.sessions);
 		}
+		options = this.normalizeRetrievalOptions(options);
 
 		this.activeRun = true;
 		this.activeJikjiPolicy = undefined;
@@ -1076,6 +1101,11 @@ export class AutoRAGAgent {
 			const minsync = wants("minsync") ? await this.syncMinSync() : undefined;
 			const datasources = wants("datasources") ? await this.indexDatasources() : [];
 			const jikji = wants("jikji") ? await this.executeJikjiPrepare() : undefined;
+			this.retrievalScopeBindings = buildRetrievalScopeBindings(
+				this.workspaceProjectRoot,
+				this.searchPaths,
+				this.configuredSearchPaths,
+			);
 			const jikjiDiagnostics = (jikji ?? [])
 				.map((result) => jikjiPrepareDiagnostic(result))
 				.filter((diag): diag is JikjiDiagnostic => diag !== undefined);
@@ -1569,6 +1599,7 @@ export class AutoRAGAgent {
 		query: string,
 		options: RetrievalOptions = {},
 	): Promise<{ results: RetrievalResult[]; diagnostics: RetrievalDiagnostic[] }> {
+		options = this.normalizeRetrievalOptions(options);
 		const methods = this.methodRegistry.list();
 		const { results: byMethod, diagnostics } = await this.retriever.retrieveWithDiagnostics(methods, query, options);
 		const filteredByMethod = this.datasourceFilter.filter(
@@ -1628,6 +1659,24 @@ export class AutoRAGAgent {
 
 	getSystemPrompt(): string {
 		return this.innerAgent.state.systemPrompt;
+	}
+
+	private normalizeRetrievalOptions(options: RetrievalOptions): RetrievalOptions {
+		const scope = this.resolveRetrievalScope(options.scope);
+		if (scope === undefined) {
+			const { scope: _scope, ...rest } = options;
+			return rest;
+		}
+		return { ...options, scope };
+	}
+
+	private resolveRetrievalScope(scope: string | undefined): string | undefined {
+		return resolveRetrievalScope(
+			scope,
+			this.retrievalScopeBindings,
+			process.platform,
+			this.datasourceVirtualScopePrefixes,
+		);
 	}
 }
 

--- a/src/agent/search-bm25-tool.ts
+++ b/src/agent/search-bm25-tool.ts
@@ -22,6 +22,7 @@ export interface SearchBM25DocumentsDetails {
 
 export function createSearchBM25DocumentsTool(
 	getMethod: () => BM25Method | undefined,
+	resolveScope: (scope: string | undefined) => string | undefined = (scope) => scope,
 ): AgentTool<typeof searchBM25Schema, SearchBM25DocumentsDetails> {
 	return {
 		name: SEARCH_BM25_DOCUMENTS_TOOL_NAME,
@@ -50,8 +51,12 @@ export function createSearchBM25DocumentsTool(
 					},
 				};
 			}
+			const scope = resolveScope(params.scope);
 			try {
-				const results = await method.retrieve(params.query, { topK: params.topK, scope: params.scope });
+				const results = await method.retrieve(params.query, {
+					topK: params.topK,
+					scope,
+				});
 				return {
 					content: [{ type: "text", text: formatResults(results, method.getStatus()) }],
 					details: {

--- a/src/agent/search-minsync-tool.ts
+++ b/src/agent/search-minsync-tool.ts
@@ -29,6 +29,7 @@ export interface SearchMinSyncDocumentsDetails {
  */
 export function createSearchMinSyncDocumentsTool(
 	getMethod: () => MinSyncVectorMethod | undefined,
+	resolveScope: (scope: string | undefined) => string | undefined = (scope) => scope,
 ): AgentTool<typeof searchMinSyncSchema, SearchMinSyncDocumentsDetails> {
 	return {
 		name: SEARCH_MINSYNC_DOCUMENTS_TOOL_NAME,
@@ -50,8 +51,12 @@ export function createSearchMinSyncDocumentsTool(
 					details: { method: "search_minsync_documents", resultCount: 0, sources: [], available: true },
 				};
 			}
+			const scope = resolveScope(params.scope);
 			try {
-				const results = await method.retrieve(params.query, { topK: params.topK, scope: params.scope });
+				const results = await method.retrieve(params.query, {
+					topK: params.topK,
+					scope,
+				});
 				return {
 					content: [{ type: "text", text: formatResults(results) }],
 					details: {

--- a/src/retrieval/scope.ts
+++ b/src/retrieval/scope.ts
@@ -1,3 +1,23 @@
+import { realpathSync } from "node:fs";
+import { dirname, posix, resolve, win32 } from "node:path";
+import { planSourceRoots } from "../filesystem/source-paths.ts";
+import { loadMirrorIndex } from "../mirror/index-store.ts";
+
+export interface RetrievalScopeBinding {
+	readonly virtualPrefix: string;
+	readonly physicalRoots: readonly string[];
+}
+
+export class RetrievalScopeError extends Error {
+	readonly code = "invalid-retrieval-scope";
+
+	constructor(virtualPrefixes: readonly string[]) {
+		const guidance = virtualPrefixes.length > 0 ? ` Use a virtual scope under ${virtualPrefixes.join(", ")}.` : "";
+		super(`invalid-retrieval-scope: physical scope is outside the configured search roots.${guidance}`);
+		this.name = "RetrievalScopeError";
+	}
+}
+
 export function normalizeVirtualPath(value: string): string {
 	const normalized = value.replace(/\\/g, "/").replace(/\/+/g, "/").trim();
 	if (normalized.length === 0 || normalized === "/") return "/";
@@ -9,6 +29,79 @@ export function normalizeVirtualPathScope(scope: string | undefined): string | u
 	if (scope === undefined) return undefined;
 	const normalized = normalizeVirtualPath(scope);
 	return normalized === "/" ? undefined : normalized;
+}
+
+export function resolveRetrievalScope(
+	scope: string | undefined,
+	bindings: readonly RetrievalScopeBinding[],
+	platform: NodeJS.Platform = process.platform,
+	passthroughVirtualPrefixes: readonly string[] = [],
+): string | undefined {
+	if (scope === undefined) return undefined;
+	const trimmed = scope.trim();
+	if (trimmed.length === 0) return undefined;
+	const normalizedVirtual = normalizeVirtualPathScope(trimmed);
+	if (
+		normalizedVirtual !== undefined &&
+		(bindings.some((binding) => virtualPathBelongsToRoot(normalizedVirtual, binding.virtualPrefix)) ||
+			passthroughVirtualPrefixes.some((prefix) => virtualPathBelongsToRoot(normalizedVirtual, prefix)))
+	) {
+		return normalizedVirtual;
+	}
+
+	const pathApi = platform === "win32" ? win32 : posix;
+	let bestMatch: { mappedScope: string; specificity: number } | undefined;
+	for (const binding of bindings) {
+		for (const physicalRoot of binding.physicalRoots) {
+			for (const physicalScope of physicalScopeCandidates(trimmed, platform)) {
+				const relativePath = pathApi.relative(pathApi.normalize(physicalRoot), pathApi.normalize(physicalScope));
+				if (!isContainedRelativePath(relativePath, pathApi)) continue;
+				const mappedScope =
+					relativePath.length === 0
+						? normalizeVirtualPath(binding.virtualPrefix)
+						: normalizeVirtualPath(`${binding.virtualPrefix}/${relativePath.split(pathApi.sep).join("/")}`);
+				const specificity = pathApi.normalize(physicalRoot).length;
+				if (bestMatch === undefined || specificity > bestMatch.specificity) {
+					bestMatch = { mappedScope, specificity };
+				} else if (specificity === bestMatch.specificity && mappedScope !== bestMatch.mappedScope) {
+					throw new RetrievalScopeError(bindings.map((candidate) => candidate.virtualPrefix));
+				}
+			}
+		}
+	}
+	if (bestMatch !== undefined) return bestMatch.mappedScope;
+
+	if (isUnambiguouslyPhysicalScope(trimmed, platform)) {
+		throw new RetrievalScopeError(bindings.map((binding) => binding.virtualPrefix));
+	}
+	return normalizedVirtual;
+}
+
+export function buildRetrievalScopeBindings(
+	workspaceRoot: string,
+	searchPaths: readonly string[],
+	configuredSearchPaths: readonly string[] = searchPaths,
+): readonly RetrievalScopeBinding[] {
+	const currentRoots = planSourceRoots(searchPaths);
+	const persistedRoots = persistedScopeRoots(workspaceRoot);
+	const configuredAliases = configuredPathAliases(configuredSearchPaths);
+	const singlePersisted = persistedRoots.size === 1 ? [...persistedRoots.entries()][0] : undefined;
+
+	return currentRoots.map((currentRoot) => {
+		const exactPersisted = [...persistedRoots.entries()].find(([, roots]) =>
+			roots.some((root) => samePhysicalPath(root, currentRoot.rootPath)),
+		);
+		const persisted = exactPersisted ?? (currentRoots.length === 1 ? singlePersisted : undefined);
+		const virtualPrefix = persisted?.[0] ?? currentRoot.prefix;
+		const physicalRoots = new Set<string>([currentRoot.rootPath, ...(persisted?.[1] ?? [])]);
+		for (const alias of configuredAliases) {
+			if (samePhysicalPath(alias.canonical, currentRoot.rootPath)) {
+				physicalRoots.add(alias.configured);
+				physicalRoots.add(alias.canonical);
+			}
+		}
+		return { virtualPrefix, physicalRoots: [...physicalRoots] };
+	});
 }
 
 export function matchesVirtualPathScope(virtualPath: string, scope: string | undefined): boolean {
@@ -34,6 +127,65 @@ export function virtualPathScopeToRegExp(scope: string): RegExp {
 
 function hasGlob(scope: string): boolean {
 	return scope.includes("*");
+}
+
+function virtualPathBelongsToRoot(scope: string, virtualPrefix: string): boolean {
+	const normalizedRoot = normalizeVirtualPath(virtualPrefix);
+	return scope === normalizedRoot || scope.startsWith(`${normalizedRoot}/`);
+}
+
+function isContainedRelativePath(relativePath: string, pathApi: typeof posix | typeof win32): boolean {
+	return (
+		relativePath === "" ||
+		(relativePath !== ".." && !relativePath.startsWith(`..${pathApi.sep}`) && !pathApi.isAbsolute(relativePath))
+	);
+}
+
+function isUnambiguouslyPhysicalScope(scope: string, platform: NodeJS.Platform): boolean {
+	if (platform === "win32") return win32.isAbsolute(scope);
+	return posix.isAbsolute(scope);
+}
+
+function physicalScopeCandidates(scope: string, platform: NodeJS.Platform): readonly string[] {
+	if (platform !== process.platform || hasGlob(scope)) return [scope];
+	try {
+		return [scope, realpathSync(scope)];
+	} catch {
+		return [scope];
+	}
+}
+
+function configuredPathAliases(paths: readonly string[]): readonly { configured: string; canonical: string }[] {
+	return paths.map((path) => {
+		const configured = resolve(path);
+		try {
+			return { configured, canonical: realpathSync(configured) };
+		} catch {
+			return { configured, canonical: configured };
+		}
+	});
+}
+
+function persistedScopeRoots(workspaceRoot: string): ReadonlyMap<string, readonly string[]> {
+	const roots = new Map<string, Set<string>>();
+	for (const entry of Object.values(loadMirrorIndex(workspaceRoot).entries)) {
+		const normalized = normalizeVirtualPath(entry.virtualPath);
+		const segments = normalized.slice(1).split("/");
+		const virtualPrefix = segments[0] ? `/${segments[0]}` : "/";
+		let physicalRoot = entry.sourcePath;
+		for (let index = 1; index < segments.length; index += 1) {
+			physicalRoot = dirname(physicalRoot);
+		}
+		const candidates = roots.get(virtualPrefix) ?? new Set<string>();
+		candidates.add(physicalRoot);
+		roots.set(virtualPrefix, candidates);
+	}
+	return new Map([...roots].map(([prefix, physicalRoots]) => [prefix, [...physicalRoots]]));
+}
+
+function samePhysicalPath(left: string, right: string): boolean {
+	const pathApi = process.platform === "win32" ? win32 : posix;
+	return pathApi.relative(pathApi.normalize(left), pathApi.normalize(right)) === "";
 }
 
 function looksLikeFileScope(scope: string): boolean {

--- a/test/agent/search-minsync-tool.test.ts
+++ b/test/agent/search-minsync-tool.test.ts
@@ -7,6 +7,7 @@ import {
 	SEARCH_MINSYNC_DOCUMENTS_TOOL_NAME,
 } from "../../src/agent/search-minsync-tool.ts";
 import { MinSyncVectorMethod } from "../../src/minsync/method.ts";
+import { RetrievalScopeError } from "../../src/retrieval/scope.ts";
 import type { RetrievalResult } from "../../src/retrieval/types.ts";
 
 let tmpDir: string;
@@ -102,6 +103,44 @@ describe("search_minsync_documents tool", () => {
 		expect(text).toContain("/docs/notes");
 		expect(text).toContain("/docs/guide");
 		expect(text).not.toContain(tmpDir);
+	});
+
+	it("normalizes model-supplied physical scopes before MinSync retrieval", async () => {
+		const seenScopes: Array<string | undefined> = [];
+		const method: StubMethod = {
+			isBinaryMissing: () => false,
+			retrieve(_query, options) {
+				seenScopes.push(options.scope);
+				return Promise.resolve([result("a", "/docs/notes")]);
+			},
+		};
+		const normalizeScope = () => "/docs";
+		const factory = createSearchMinSyncDocumentsTool as unknown as (
+			getMethod: () => MinSyncVectorMethod,
+			resolveScope: typeof normalizeScope,
+		) => ReturnType<typeof createSearchMinSyncDocumentsTool>;
+		const tool = factory(() => method as never, normalizeScope);
+
+		await tool.execute("call-scope", { query: "concept", scope: join(tmpDir, "docs") });
+
+		expect(seenScopes).toEqual(["/docs"]);
+	});
+
+	it("preserves coded scope errors at the MinSync tool boundary", async () => {
+		const method: StubMethod = {
+			isBinaryMissing: () => false,
+			retrieve: () => Promise.resolve([]),
+		};
+		const tool = createSearchMinSyncDocumentsTool(
+			() => method as never,
+			() => {
+				throw new RetrievalScopeError(["/docs"]);
+			},
+		);
+
+		await expect(tool.execute("call-invalid-scope", { query: "concept", scope: "/outside" })).rejects.toMatchObject({
+			code: "invalid-retrieval-scope",
+		});
 	});
 
 	it("reports a path-free unavailable message when retrieval throws", async () => {

--- a/test/integration/retrieval-scope-flow.test.ts
+++ b/test/integration/retrieval-scope-flow.test.ts
@@ -1,0 +1,100 @@
+import { cpSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { AutoRAGAgent } from "../../src/agent/agent.js";
+
+const temporaryRoots: string[] = [];
+
+function temporaryRoot(): string {
+	const root = mkdtempSync(join(tmpdir(), "autorag-scope-"));
+	temporaryRoots.push(root);
+	return root;
+}
+
+afterEach(() => {
+	for (const root of temporaryRoots.splice(0)) {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+describe("AutoRAG retrieval scope flow", () => {
+	it("searches through the configured symlink and canonical physical roots", async () => {
+		const root = temporaryRoot();
+		const source = join(root, "real-docs");
+		const link = join(root, "docs-link");
+		const workspace = join(root, "workspace");
+		mkdirSync(source, { recursive: true });
+		mkdirSync(workspace, { recursive: true });
+		writeFileSync(join(source, "chargebacks.txt"), "Chargeback evidence requires the payment receipt.");
+		symlinkSync(source, link, process.platform === "win32" ? "junction" : "dir");
+
+		const agent = new AutoRAGAgent({
+			searchPaths: [link],
+			workspacePath: workspace,
+			bm25: { forceEngine: "typescript-fallback" },
+			minSync: false,
+		});
+		await agent.refresh();
+
+		const throughLink = await agent.retrieve("chargeback evidence", { scope: link });
+		const throughCanonicalRoot = await agent.retrieve("chargeback evidence", { scope: source });
+		const merged = await agent.searchAllDocuments("chargeback evidence", { scope: link });
+
+		expect(throughLink).toHaveLength(1);
+		expect(throughCanonicalRoot).toHaveLength(1);
+		expect(merged.results).toHaveLength(1);
+		expect(throughLink[0]?.source).toBe("/real-docs/chargebacks.txt");
+	});
+
+	it("keeps the prepared virtual root after a single-root workspace relocation", async () => {
+		const root = temporaryRoot();
+		const prepared = join(root, "organized");
+		const relocated = join(root, "agentdir", "workspace");
+		mkdirSync(prepared, { recursive: true });
+		writeFileSync(join(prepared, "policy.txt"), "The retention policy is seven years.");
+
+		const preparingAgent = new AutoRAGAgent({
+			searchPaths: [prepared],
+			workspacePath: prepared,
+			bm25: { forceEngine: "typescript-fallback" },
+			minSync: false,
+		});
+		await preparingAgent.refresh();
+		cpSync(prepared, relocated, { recursive: true });
+
+		const relocatedAgent = new AutoRAGAgent({
+			searchPaths: [relocated],
+			workspacePath: relocated,
+			bm25: { forceEngine: "typescript-fallback" },
+			minSync: false,
+		});
+		const results = await relocatedAgent.retrieve("retention policy", { scope: relocated });
+
+		expect(results).toHaveLength(1);
+		expect(results[0]?.source).toBe("/organized/policy.txt");
+	});
+
+	it("rejects an unknown physical root before retrieval", async () => {
+		const root = temporaryRoot();
+		const source = join(root, "docs");
+		const workspace = join(root, "workspace");
+		const unknown = join(root, "outside");
+		mkdirSync(source, { recursive: true });
+		mkdirSync(workspace, { recursive: true });
+		mkdirSync(unknown, { recursive: true });
+		writeFileSync(join(source, "policy.txt"), "The retention policy is seven years.");
+
+		const agent = new AutoRAGAgent({
+			searchPaths: [source],
+			workspacePath: workspace,
+			bm25: { forceEngine: "typescript-fallback" },
+			minSync: false,
+		});
+		await agent.refresh();
+
+		await expect(agent.retrieve("retention policy", { scope: unknown })).rejects.toMatchObject({
+			code: "invalid-retrieval-scope",
+		});
+	});
+});

--- a/test/retrieval/bm25.test.ts
+++ b/test/retrieval/bm25.test.ts
@@ -1,12 +1,12 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AutoRAGAgent } from "../../src/agent/agent.ts";
 import { createSearchBM25DocumentsTool } from "../../src/agent/search-bm25-tool.ts";
 import { syncParsedMirrors } from "../../src/mirror/sync.ts";
 import { BM25Method } from "../../src/retrieval/methods/bm25.ts";
-import { matchesVirtualPathScope } from "../../src/retrieval/scope.ts";
+import { matchesVirtualPathScope, RetrievalScopeError } from "../../src/retrieval/scope.ts";
 
 let root: string;
 let docs: string;
@@ -162,5 +162,47 @@ describe("AutoRAG BM25 integration", () => {
 		expect(result.details).toMatchObject({ method: "bm25", resultCount: 1, readiness: "degraded_fallback" });
 		expect(result.details?.sources).toEqual(["/docs/sub/guide.txt"]);
 		expect(result.content[0]?.type).toBe("text");
+	});
+
+	it("normalizes model-supplied physical scopes before BM25 retrieval", async () => {
+		writeFileSync(join(docs, "sub", "guide.txt"), "chargeback scoped process\n");
+		await refreshMirrors();
+		const method = new BM25Method({
+			root,
+			indexPath: join(root, ".autorag", "tool-scope-bm25"),
+			forceEngine: "typescript-fallback",
+		});
+		await method.sync();
+		const normalizeScope = vi.fn(() => "/docs/sub");
+		const factory = createSearchBM25DocumentsTool as unknown as (
+			getMethod: () => BM25Method,
+			resolveScope: typeof normalizeScope,
+		) => ReturnType<typeof createSearchBM25DocumentsTool>;
+		const tool = factory(() => method, normalizeScope);
+
+		const result = await tool.execute("tool-scope", { query: "chargeback", scope: join(docs, "sub") });
+
+		expect(normalizeScope).toHaveBeenCalledWith(join(docs, "sub"));
+		expect(result.details.sources).toEqual(["/docs/sub/guide.txt"]);
+	});
+
+	it("preserves coded scope errors at the BM25 tool boundary", async () => {
+		const method = new BM25Method({
+			root,
+			indexPath: join(root, ".autorag", "tool-error-bm25"),
+			forceEngine: "typescript-fallback",
+		});
+		const tool = createSearchBM25DocumentsTool(
+			() => method,
+			() => {
+				throw new RetrievalScopeError(["/docs"]);
+			},
+		);
+
+		await expect(
+			tool.execute("tool-invalid-scope", { query: "chargeback", scope: "/outside" }),
+		).rejects.toMatchObject({
+			code: "invalid-retrieval-scope",
+		});
 	});
 });

--- a/test/retrieval/scope-resolution.test.ts
+++ b/test/retrieval/scope-resolution.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import * as scopeModule from "../../src/retrieval/scope.js";
+
+interface ScopeBinding {
+	readonly virtualPrefix: string;
+	readonly physicalRoots: readonly string[];
+}
+
+type ScopeResolver = (
+	scope: string | undefined,
+	bindings: readonly ScopeBinding[],
+	platform?: NodeJS.Platform,
+	passthroughVirtualPrefixes?: readonly string[],
+) => string | undefined;
+
+function resolver(): ScopeResolver {
+	const candidate = (scopeModule as Record<string, unknown>).resolveRetrievalScope;
+	expect(candidate).toBeTypeOf("function");
+	return candidate as ScopeResolver;
+}
+
+describe("retrieval scope resolution", () => {
+	it("preserves virtual scopes and maps POSIX physical roots", () => {
+		const resolveScope = resolver();
+		const bindings = [{ virtualPrefix: "/docs", physicalRoots: ["/Users/example/Documents"] }];
+
+		expect(resolveScope("/docs/reports/**", bindings, "darwin")).toBe("/docs/reports/**");
+		expect(resolveScope("/Users/example/Documents/reports/**", bindings, "darwin")).toBe("/docs/reports/**");
+	});
+
+	it("maps Windows drive, case, separator, and UNC aliases consistently", () => {
+		const resolveScope = resolver();
+
+		expect(
+			resolveScope(
+				String.raw`c:\documents\Reports\**`,
+				[{ virtualPrefix: "/docs", physicalRoots: [String.raw`C:\Documents`] }],
+				"win32",
+			),
+		).toBe("/docs/Reports/**");
+		expect(
+			resolveScope(
+				String.raw`\\server\share\Documents\Reports`,
+				[{ virtualPrefix: "/docs", physicalRoots: [String.raw`\\SERVER\SHARE\Documents`] }],
+				"win32",
+			),
+		).toBe("/docs/Reports");
+	});
+
+	it("rejects unknown physical absolute scopes instead of returning zero results", () => {
+		const resolveScope = resolver();
+
+		expect(() =>
+			resolveScope(
+				"/definitely-nonexistent/autorag-private",
+				[{ virtualPrefix: "/docs", physicalRoots: ["/srv/docs"] }],
+				"darwin",
+			),
+		).toThrow("invalid-retrieval-scope");
+	});
+
+	it("preserves declared virtual datasource scopes on POSIX and Windows", () => {
+		const resolveScope = resolver();
+		const bindings = [{ virtualPrefix: "/docs", physicalRoots: ["/srv/docs"] }];
+
+		expect(resolveScope("/datasource/account", bindings, "darwin", ["/datasource"])).toBe("/datasource/account");
+		expect(resolveScope("/datasource/account", bindings, "win32", ["/datasource"])).toBe("/datasource/account");
+	});
+
+	it("selects the most specific physical root regardless of binding order", () => {
+		const resolveScope = resolver();
+		const bindings = [
+			{ virtualPrefix: "/repo", physicalRoots: ["/srv/repo"] },
+			{ virtualPrefix: "/docs", physicalRoots: ["/srv/repo/docs"] },
+		];
+
+		expect(resolveScope("/srv/repo/docs/guide.md", bindings, "darwin")).toBe("/docs/guide.md");
+	});
+});


### PR DESCRIPTION
## Summary

- map configured physical roots, symlinks/junctions, and prepared single-root relocations to stable persisted virtual roots
- share scope normalization across agent prompts, direct retrieval, BM25, MinSync, and merged retrieval
- preserve declared datasource virtual namespaces across POSIX and Windows while rejecting unknown physical absolute scopes with a path-opaque coded error
- select the most specific nested root and preserve coded errors at direct backend tool boundaries

Closes #1368

## TDD evidence

- initial physical/symlink/relocation scope suite: **RED 0/6 → GREEN 6/6**
- backend BM25/MinSync/merged boundary suite: **RED 13/18 → GREEN 18/18**
- reviewer blocker suite: **RED 17/22 → GREEN 22/22**

## Verification

- `bun run typecheck` — PASS
- relevant and adjacent regression suite — **183/183 PASS, 420 assertions**
- `bun run build` — PASS
- Biome changed-file check — PASS
- `git diff --check` — PASS
- five-lane review — unconditional PASS after blocker fixes

## Manual QA

- library surface with a physical symlink scope returned `/real-docs/guide.md` and the expected text
- CLI with an unknown physical scope exited 1 with `invalid-retrieval-scope` and exposed only the virtual root
- full CLI success was blocked after correct retrieval by the pre-existing explorer `retrievedAt` grounding parser; this was kept out of scope

## Full-suite note

A repository-wide `bun test` run was attempted with a 20-minute deadline. It did not complete and surfaced unrelated baseline failures involving Bun `vi.hoisted`, user-scoped explorer discovery, and current CLI/config expectations. No failures were suppressed or modified.