### PR TITLE
build(deps): bump pi stack to 0.82.1, pi-subagents to 0.37.2, biome to 2.5.6

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,9 +1,9 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.3.5/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true,
+			"preset": "recommended",
 			"style": {
 				"noNonNullAssertion": "off",
 				"useConst": "error",

--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,9 @@
     "": {
       "name": "@autorag/librarian",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.10",
-        "@earendil-works/pi-ai": "^0.80.10",
-        "@earendil-works/pi-coding-agent": "0.80.10",
+        "@earendil-works/pi-agent-core": "^0.82.1",
+        "@earendil-works/pi-ai": "^0.82.1",
+        "@earendil-works/pi-coding-agent": "0.82.1",
         "@opendataloader/pdf": "^2.4.7",
         "@pngwasi/node-tantivy-binding": "^0.3.4",
         "@rhwp/core": "0.7.19",
@@ -16,7 +16,7 @@
         "iconv-lite": "^0.7.2",
         "jszip": "^3.10.1",
         "mailparser": "^3.9.12",
-        "pi-subagents": "0.35.1",
+        "pi-subagents": "0.37.2",
         "slides-grab": "^1.3.1",
         "smol-toml": "1.7.0",
         "tesseract.js": "^7.0.0",
@@ -24,7 +24,7 @@
         "yaml": "^2.8.2",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.3.5",
+        "@biomejs/biome": "2.5.6",
         "@types/mailparser": "^3.4.6",
         "@types/node": "^26.1.2",
         "typescript": "^7.0.2",
@@ -87,31 +87,31 @@
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.3.5", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.5", "@biomejs/cli-darwin-x64": "2.3.5", "@biomejs/cli-linux-arm64": "2.3.5", "@biomejs/cli-linux-arm64-musl": "2.3.5", "@biomejs/cli-linux-x64": "2.3.5", "@biomejs/cli-linux-x64-musl": "2.3.5", "@biomejs/cli-win32-arm64": "2.3.5", "@biomejs/cli-win32-x64": "2.3.5" }, "bin": { "biome": "bin/biome" } }, "sha512-HvLhNlIlBIbAV77VysRIBEwp55oM/QAjQEin74QQX9Xb259/XP/D5AGGnZMOyF1el4zcvlNYYR3AyTMUV3ILhg=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.6", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.6", "@biomejs/cli-darwin-x64": "2.5.6", "@biomejs/cli-linux-arm64": "2.5.6", "@biomejs/cli-linux-arm64-musl": "2.5.6", "@biomejs/cli-linux-x64": "2.5.6", "@biomejs/cli-linux-x64-musl": "2.5.6", "@biomejs/cli-win32-arm64": "2.5.6", "@biomejs/cli-win32-x64": "2.5.6" }, "bin": { "biome": "bin/biome" } }, "sha512-lxVNjv7UF6KfhMJfL9gaUHbWdJdHbsAj6OSmwSYNdhRuG67NxNQ4Xdvh3TUxsSK9sBzJBQhEJj3AopmmNJ5pSA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fLdTur8cJU33HxHUUsii3GLx/TR0BsfQx8FkeqIiW33cGMtUD56fAtrh+2Fx1uhiCsVZlFh6iLKUU3pniZREQw=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zMOLZP4oMrjh6m1zcSj1ud2awUPgTuMVbmQhYYWL7J8HwCnbHHBvTm7VBTRuY7epT5bez76IpKYQ11ZAqHFlnw=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-qpT8XDqeUlzrOW8zb4k3tjhT7rmvVRumhi2657I2aGcY4B+Ft5fNwDdZGACzn8zj7/K1fdWjgwYE3i2mSZ+vOA=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-JAC1VqzvO7Th5ZplU0G2uGfkZbxEe9uDDektPAhF0JLusoz1w+T4okp2bkykI0bbaO2vslKiRfj4gU43JaGreA=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-u/pybjTBPGBHB66ku4pK1gj+Dxgx7/+Z0jAriZISPX1ocTO8aHh8x8e7Kb1rB4Ms0nA/SzjtNOVJ4exVavQBCw=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-6XsYwCFkp5sMxl85ffhgeGpGgs6A7dRYFnkceZ7WVxvycuTnGdD5xa534Z3xfrBQ0JCMK/mujT6ZNPJoghedwg=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-eGUG7+hcLgGnMNl1KHVZUYxahYAhC462jF/wQolqu4qso2MSk32Q+QrpN7eN4jAHAg7FUMIo897muIhK4hXhqg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-eUa3jeeYvfMt19LBeh6E5PUZpxnTC4JqNWo+EDjTtQjAr2xLGnWaxACtVU1DQqmHYbvThlJzLX+ZsYgrqh2qVw=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.5", "", { "os": "linux", "cpu": "x64" }, "sha512-XrIVi9YAW6ye0CGQ+yax0gLfx+BFOtKaNX74n+xHWla6Cl6huUmcKNO7HPx7BiKnJUzrxXY1qYlm7xMvi08X4g=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-Pop9VXCFUhFTMfFefZ39S+u2rOPyNp5iHlxbZRwXGACHLy2r0jjiRgJHmaEKJzL3SyxlVeGShXhvvElvWowonA=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.5", "", { "os": "linux", "cpu": "x64" }, "sha512-awVuycTPpVTH/+WDVnEEYSf6nbCBHf/4wB3lquwT7puhNg8R4XvonWNZzUsfHZrCkjkLhFH/vCZK5jHatD9FEg=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-2Vp13QdKysH3HIWLaYLhUUwbK+jbZonJD1K+Lr0d0RO4wH7mkYd43vJixEDm8cUWrowoRz4UUHF1nm9Ae7ym8A=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-DlBiMlBZZ9eIq4H7RimDSGsYcOtfOIfZOaI5CqsWiSlbTfqbPVfWtCf92wNzx8GNMbu1s7/g3ZZESr6+GwM/SA=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-tDGshcm6BdkZOCGnTDX0Y8/U4IfBSlnUU7T56nNDuPEfed+aHg+u8G36NB43fJVl0Os6+QURXIE1yuD7AaEofA=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.5", "", { "os": "win32", "cpu": "x64" }, "sha512-nUmR8gb6yvrKhtRgzwo/gDimPwnO5a4sCydf8ZS2kHIJhEmSmk+STsusr1LHTuM//wXppBawvSQi2xFXJCdgKQ=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.80.10", "", { "dependencies": { "@earendil-works/pi-ai": "^0.80.10", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-nwnOR3SuLYGRFfyQm8ri4Nj5VGVAvAM9GuqQd3u7BUQj0d6hmD2F8w7OHAAjThE3CuySIdM+v8E22QJG6/RfCg=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.82.1", "", { "dependencies": { "@earendil-works/pi-ai": "^0.82.1", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-Z3kloziJIE2dmrisRckZX8zDca/gIv9/YdFAzeoqpHiLV2wsni6bL4hInNSjVKLbqT+4kqLIkph2JQLKvSepjg=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.10", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.82.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.80.10", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.80.10", "@earendil-works/pi-ai": "^0.80.10", "@earendil-works/pi-tui": "^0.80.10", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.82.1", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.82.1", "@earendil-works/pi-ai": "^0.82.1", "@earendil-works/pi-tui": "^0.82.1", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-zbkAhoIuDPMF3pKuja0ajZabrMWU29FUMV9A/XMXT/XC1yXs5xt6t6t13GogQFsDrDqbFP4DkZQO1w8rWRAzYA=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.80.10", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.82.1", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-9yN8hALfKaxZq7n54EMxqhFCWnMi6LHkraMJ/1YjHiATq75XrI6XDMVppn9EDtiK7Fks8hUe1SDXUTrIvwRWfQ=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
@@ -969,7 +969,7 @@
 
     "peberminta": ["peberminta@0.10.0", "", {}, "sha512-80B2AsU+I4Qdb0ZAPSfe9UwvGzwkM37IKIFEvdS3D/3Ndgv2bsuJ0bfG1+iEYO+l7Gfd4EUJmuRyq7efLgRMzQ=="],
 
-    "pi-subagents": ["pi-subagents@0.35.1", "", { "dependencies": { "jiti": "2.7.0", "yaml": "2.8.3" }, "peerDependencies": { "@earendil-works/pi-agent-core": "*", "@earendil-works/pi-ai": "*", "@earendil-works/pi-coding-agent": "*", "@earendil-works/pi-tui": "*", "typebox": "*" }, "optionalPeers": ["@earendil-works/pi-agent-core", "@earendil-works/pi-ai", "@earendil-works/pi-coding-agent", "@earendil-works/pi-tui", "typebox"], "bin": { "pi-subagents": "install.mjs" } }, "sha512-nIH6liO541FZ1RoeEu58Ligd59tiNw0/ODPgHh7uvx9Dk4UpWH08F84/l1+hXCzUgC85OCmyVtngWkZjcK94Cg=="],
+    "pi-subagents": ["pi-subagents@0.37.2", "", { "dependencies": { "jiti": "2.7.0", "typebox": "1.1.38", "yaml": "2.8.3" }, "peerDependencies": { "@earendil-works/pi-agent-core": "*", "@earendil-works/pi-ai": ">=0.80.0", "@earendil-works/pi-coding-agent": "*", "@earendil-works/pi-tui": "*" }, "optionalPeers": ["@earendil-works/pi-agent-core", "@earendil-works/pi-ai", "@earendil-works/pi-coding-agent", "@earendil-works/pi-tui"], "bin": { "pi-subagents": "install.mjs" } }, "sha512-pf7DxLBY9pFY3grOFgRfMqoS9QbElWP2ULOCOnmJNrCEvjlA81fiyp0wk1vSaJPJ/rjsP0lA1sAk7S/QD+Olpg=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "node": ">=24.0.0"
   },
   "dependencies": {
-    "@earendil-works/pi-agent-core": "^0.80.10",
-    "@earendil-works/pi-ai": "^0.80.10",
-    "@earendil-works/pi-coding-agent": "0.80.10",
+    "@earendil-works/pi-agent-core": "^0.82.1",
+    "@earendil-works/pi-ai": "^0.82.1",
+    "@earendil-works/pi-coding-agent": "0.82.1",
     "@opendataloader/pdf": "^2.4.7",
     "@pngwasi/node-tantivy-binding": "^0.3.4",
     "@rhwp/core": "0.7.19",
@@ -50,7 +50,7 @@
     "iconv-lite": "^0.7.2",
     "jszip": "^3.10.1",
     "mailparser": "^3.9.12",
-    "pi-subagents": "0.35.1",
+    "pi-subagents": "0.37.2",
     "slides-grab": "^1.3.1",
     "smol-toml": "1.7.0",
     "tesseract.js": "^7.0.0",
@@ -58,7 +58,7 @@
     "yaml": "^2.8.2"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.3.5",
+    "@biomejs/biome": "2.5.6",
     "@types/mailparser": "^3.4.6",
     "@types/node": "^26.1.2",
     "typescript": "^7.0.2",

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -3,6 +3,7 @@ import { watch as fsWatch, realpathSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { Agent, type AgentEvent, type AgentMessage, type AgentTool, type Skill } from "@earendil-works/pi-agent-core";
 import type { Api, Model } from "@earendil-works/pi-ai";
+import { streamSimple } from "@earendil-works/pi-ai/compat";
 import { resolveAutoRAGHome } from "../config/home.ts";
 import { DatasourceAccessContext, type DatasourceAccessContextOptions } from "../datasource/access-context.ts";
 import { mapDatasourceDiagnostics } from "../datasource/diagnostics.ts";
@@ -417,6 +418,7 @@ export class AutoRAGAgent {
 				model: options.model as Model<Api>,
 				tools,
 			},
+			streamFn: streamSimple,
 			convertToLlm: (messages) =>
 				messages.filter((m) => m.role === "user" || m.role === "assistant" || m.role === "toolResult"),
 			transformContext: async (messages) => this.withMemoryContext(messages),

--- a/test/agent/agent-lifecycle.test.ts
+++ b/test/agent/agent-lifecycle.test.ts
@@ -9,7 +9,7 @@ import {
 	fauxAssistantMessage,
 	fauxToolCall,
 } from "@earendil-works/pi-ai";
-import { registerFauxProvider } from "@earendil-works/pi-ai/compat";
+import { registerFauxProvider, streamSimple } from "@earendil-works/pi-ai/compat";
 import { Type } from "typebox";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AutoRAGAgent } from "../../src/agent/agent.ts";
@@ -132,6 +132,7 @@ function fauxSessionFactory(
 				model: options.model,
 				tools: [subagentTool, ...options.tools],
 			},
+			streamFn: streamSimple,
 			convertToLlm: (messages) =>
 				messages.filter(
 					(message) => message.role === "user" || message.role === "assistant" || message.role === "toolResult",

--- a/test/agent/search-documents-live-e2e.test.ts
+++ b/test/agent/search-documents-live-e2e.test.ts
@@ -9,7 +9,7 @@ import {
 	fauxAssistantMessage,
 	fauxToolCall,
 } from "@earendil-works/pi-ai";
-import { registerFauxProvider } from "@earendil-works/pi-ai/compat";
+import { registerFauxProvider, streamSimple } from "@earendil-works/pi-ai/compat";
 import { Type } from "typebox";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AutoRAGAgent } from "../../src/agent/agent.ts";
@@ -146,6 +146,7 @@ function fauxSessionFactory(): NonNullable<ConstructorParameters<typeof AutoRAGA
 				model: options.model,
 				tools: [subagentTool, ...options.tools],
 			},
+			streamFn: streamSimple,
 			convertToLlm: (messages) =>
 				messages.filter(
 					(message) => message.role === "user" || message.role === "assistant" || message.role === "toolResult",

--- a/test/agent/search-documents.test.ts
+++ b/test/agent/search-documents.test.ts
@@ -20,7 +20,7 @@ import {
 	fauxAssistantMessage,
 	fauxToolCall,
 } from "@earendil-works/pi-ai";
-import { registerFauxProvider } from "@earendil-works/pi-ai/compat";
+import { registerFauxProvider, streamSimple } from "@earendil-works/pi-ai/compat";
 import { Type } from "typebox";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AutoRAGAgent, type AutoRAGSessionFactory } from "../../src/agent/agent.ts";
@@ -304,6 +304,7 @@ function fauxSessionFactory(
 				model: options.model,
 				tools: [subagentTool, ...options.tools],
 			},
+			streamFn: streamSimple,
 			convertToLlm: (messages) =>
 				messages.filter(
 					(message) => message.role === "user" || message.role === "assistant" || message.role === "toolResult",
@@ -2844,6 +2845,7 @@ describe("AutoRAGAgent searchDocuments", () => {
 					model: options.model,
 					tools: [subagentTool, ...options.tools],
 				},
+				streamFn: streamSimple,
 				convertToLlm: (messages) =>
 					messages.filter(
 						(message) => message.role === "user" || message.role === "assistant" || message.role === "toolResult",

--- a/test/integration/exported-api-manual.test.ts
+++ b/test/integration/exported-api-manual.test.ts
@@ -9,7 +9,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Agent, type AgentTool } from "@earendil-works/pi-agent-core";
 import { type FauxProviderRegistration, fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
-import { registerFauxProvider } from "@earendil-works/pi-ai/compat";
+import { registerFauxProvider, streamSimple } from "@earendil-works/pi-ai/compat";
 import { Type } from "typebox";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AutoRAGAgent, EMIT_AUTORAG_RESULTS_TOOL_NAME } from "../../src/index.ts";
@@ -124,6 +124,7 @@ function fauxSessionFactory(): NonNullable<ConstructorParameters<typeof AutoRAGA
 				model: options.model,
 				tools: [subagentTool, ...options.tools],
 			},
+			streamFn: streamSimple,
 			convertToLlm: (messages) =>
 				messages.filter(
 					(message) => message.role === "user" || message.role === "assistant" || message.role === "toolResult",

--- a/test/integration/exported-api-manual.test.ts
+++ b/test/integration/exported-api-manual.test.ts
@@ -274,34 +274,33 @@ describe("exported API — #22 observable refresh status and watch", () => {
 		expect(blob).not.toContain("indexPath");
 	});
 
-	it(
-		"keeps parsed mirrors current via the root-exported startWatchRefresh and stops cleanly",
-		{ retry: 3, timeout: 30000 },
-		async () => {
-			const agent = new AutoRAGAgent({
-				searchPaths: [docs],
-				memoryPath: join(root, "memory.json"),
-				workspacePath: root,
-			});
-			await agent.refresh(true);
-			const handle = agent.startWatchRefresh({ debounceMs: 30 });
+	it("keeps parsed mirrors current via the root-exported startWatchRefresh and stops cleanly", {
+		retry: 3,
+		timeout: 30000,
+	}, async () => {
+		const agent = new AutoRAGAgent({
+			searchPaths: [docs],
+			memoryPath: join(root, "memory.json"),
+			workspacePath: root,
+		});
+		await agent.refresh(true);
+		const handle = agent.startWatchRefresh({ debounceMs: 30 });
 
-			writeFileSync(join(docs, "watched.txt"), "Watched content about ledgers.\n");
-			const mirror = parsedOutputPath(root, "/docs/watched.txt");
-			const start = Date.now();
-			let updated = false;
-			while (Date.now() - start < 10000) {
-				// The parsed-mirror file appearing is the latching signal that the
-				// watcher re-indexed the new source (the per-refresh `written` counter
-				// resets to 0 on the next no-op refresh, so it is not a stable latch).
-				if (existsSync(mirror)) {
-					updated = true;
-					break;
-				}
-				await new Promise((resolve) => setTimeout(resolve, 40));
+		writeFileSync(join(docs, "watched.txt"), "Watched content about ledgers.\n");
+		const mirror = parsedOutputPath(root, "/docs/watched.txt");
+		const start = Date.now();
+		let updated = false;
+		while (Date.now() - start < 10000) {
+			// The parsed-mirror file appearing is the latching signal that the
+			// watcher re-indexed the new source (the per-refresh `written` counter
+			// resets to 0 on the next no-op refresh, so it is not a stable latch).
+			if (existsSync(mirror)) {
+				updated = true;
+				break;
 			}
-			handle.stop();
-			expect(updated).toBe(true);
-		},
-	);
+			await new Promise((resolve) => setTimeout(resolve, 40));
+		}
+		handle.stop();
+		expect(updated).toBe(true);
+	});
 });

--- a/test/integration/watch-refresh-flow.test.ts
+++ b/test/integration/watch-refresh-flow.test.ts
@@ -33,40 +33,39 @@ async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs = 
 }
 
 describe("AutoRAGAgent watch refresh (real fs)", () => {
-	it(
-		"updates parsed mirrors when a watched source file is created, then stops cleanly",
-		{ retry: 3, timeout: 30000 },
-		async () => {
-			const agent = new AutoRAGAgent({
-				searchPaths: [docs],
-				memoryPath: join(root, "memory.json"),
-				workspacePath: root,
-			});
-			await agent.refresh(true);
+	it("updates parsed mirrors when a watched source file is created, then stops cleanly", {
+		retry: 3,
+		timeout: 30000,
+	}, async () => {
+		const agent = new AutoRAGAgent({
+			searchPaths: [docs],
+			memoryPath: join(root, "memory.json"),
+			workspacePath: root,
+		});
+		await agent.refresh(true);
 
-			handle = agent.startWatchRefresh({ debounceMs: 30 });
+		handle = agent.startWatchRefresh({ debounceMs: 30 });
 
-			// Create a new source file in the watched directory.
-			writeFileSync(join(docs, "new-note.txt"), "Freshly added note about invoices.\n");
-			const mirrorPath = parsedOutputPath(root, "/docs/new-note.txt");
-			const appeared = await waitFor(() => existsSync(mirrorPath));
-			expect(appeared).toBe(true);
+		// Create a new source file in the watched directory.
+		writeFileSync(join(docs, "new-note.txt"), "Freshly added note about invoices.\n");
+		const mirrorPath = parsedOutputPath(root, "/docs/new-note.txt");
+		const appeared = await waitFor(() => existsSync(mirrorPath));
+		expect(appeared).toBe(true);
 
-			// Stop the watcher; further changes must NOT trigger a refresh.
-			handle.stop();
+		// Stop the watcher; further changes must NOT trigger a refresh.
+		handle.stop();
 
-			// An in-flight refresh may still be completing after stop(). Wait for it
-			// to finish before capturing the baseline timestamp.
-			await waitFor(async () => !(await agent.getRefreshStatus()).inFlight, 10000);
-			const finishedAt = (await agent.getRefreshStatus()).lastFinishedAt;
+		// An in-flight refresh may still be completing after stop(). Wait for it
+		// to finish before capturing the baseline timestamp.
+		await waitFor(async () => !(await agent.getRefreshStatus()).inFlight, 10000);
+		const finishedAt = (await agent.getRefreshStatus()).lastFinishedAt;
 
-			writeFileSync(join(docs, "after-stop.txt"), "Should not be indexed by the watcher.\n");
-			await new Promise((resolve) => setTimeout(resolve, 300));
-			const afterStopMirror = parsedOutputPath(root, "/docs/after-stop.txt");
+		writeFileSync(join(docs, "after-stop.txt"), "Should not be indexed by the watcher.\n");
+		await new Promise((resolve) => setTimeout(resolve, 300));
+		const afterStopMirror = parsedOutputPath(root, "/docs/after-stop.txt");
 
-			expect(existsSync(afterStopMirror)).toBe(false);
-			// No refresh ran after stop, so the last-finished timestamp is unchanged.
-			expect((await agent.getRefreshStatus()).lastFinishedAt).toBe(finishedAt);
-		},
-	);
+		expect(existsSync(afterStopMirror)).toBe(false);
+		// No refresh ran after stop, so the last-finished timestamp is unchanged.
+		expect((await agent.getRefreshStatus()).lastFinishedAt).toBe(finishedAt);
+	});
 });

--- a/test/observability/run-log.test.ts
+++ b/test/observability/run-log.test.ts
@@ -10,7 +10,7 @@ import {
 	fauxAssistantMessage,
 	fauxToolCall,
 } from "@earendil-works/pi-ai";
-import { registerFauxProvider } from "@earendil-works/pi-ai/compat";
+import { registerFauxProvider, streamSimple } from "@earendil-works/pi-ai/compat";
 import { Type } from "typebox";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AutoRAGAgent, type AutoRAGSessionFactory } from "../../src/agent/agent.ts";
@@ -188,6 +188,7 @@ function makeSessionFactory(subagentResult?: AgentToolResult<unknown>): AutoRAGS
 				model: options.model,
 				tools: [subagentTool, ...options.tools],
 			},
+			streamFn: streamSimple,
 			convertToLlm: (messages) =>
 				messages.filter((m) => m.role === "user" || m.role === "assistant" || m.role === "toolResult"),
 		});


### PR DESCRIPTION
Supersedes and closes #1375 #1376 #1377 #1378 #1379.

The individual dependabot PRs all fail CI because each bumps one package while the frozen lockfile expects the others. This branch applies all five bumps together and regenerates bun.lock.

Breaking change handled: pi-agent-core 0.82 makes `AgentOptions.streamFn` required. The agent and test harnesses now pass `streamSimple` from `@earendil-works/pi-ai/compat` explicitly, matching the pre-0.81 default (pi-coding-agent does the same via `setDefaultStreamFn(streamSimple)`).

Verified locally: typecheck, build, biome check, and full vitest suite (85 files / 1238 tests) all pass.