### PR TITLE
fix(subagents): keep model runtime refresh offline when persisting credentials

### DIFF
--- a/src/subagents/runtime.ts
+++ b/src/subagents/runtime.ts
@@ -966,7 +966,7 @@ export async function createMandatorySubagentSession(
 			}
 		}
 		for (const [provider, credential] of parentProviderCredentials) {
-			await modelRuntime.setRuntimeApiKey(provider, credential);
+			await modelRuntime.setRuntimeApiKey(provider, credential, { allowNetwork: false });
 		}
 		ensurePiSettingsFile(agentDir);
 		const settingsManager = SettingsManager.create(options.cwd, agentDir);


### PR DESCRIPTION
Follow-up to #1380. pi-coding-agent 0.82 changed `ModelRuntime.setRuntimeApiKey` to default its post-write refresh to the runtime's network-enabled flag rather than the create-time `allowModelNetwork: false` option. Session creation then fetched remote model catalogs from pi.dev without an abort signal, and concurrent session creation (the runtime test suite, parallel explorers) hung indefinitely on those requests — this is what turned main CI red after the 0.82 bump (#1380 merge, run 30524878481).

Reproduced locally: 4 concurrent processes creating 8 sessions each — 3 of 4 hung forever on 0.82, all complete with this fix; the previously failing `test/subagents/runtime.test.ts` + `test/cli/commands.health.test.ts` combination passes 3/3, and the full suite passes (85 files / 1238 tests).

Fix: pass `{ allowNetwork: false }` explicitly to `setRuntimeApiKey`, restoring the pre-0.82 offline behavior for credential persistence.