### PR TITLE
feat(legacy): add ClapNQ sample dataset

### DIFF
--- a/legacy/sample_dataset/README.md
+++ b/legacy/sample_dataset/README.md
@@ -23,10 +23,11 @@ If you run the script without the `--save_path` argument, the dataset will be sa
 python ./sample_dataset/triviaqa/load_triviaqa_dataset.py
 ```
 
-ClapNQ is downloaded from the public `PrimeQA/clapnq` dataset. Its answerable
-train and development splits are written to `qa_train.parquet` and
-`qa_test.parquet`; unanswerable examples are omitted because they do not have
-a generation ground truth.
+ClapNQ's official retrieval corpus and answerable train/development question
+files are downloaded from the `PrimeQA/clapnq` repository. The corpus includes
+the complete retrieval collection rather than only gold passages. Questions
+without a gold passage are omitted because they cannot produce AutoRAG
+`retrieval_gt` entries.
 
 To create the ClapNQ sample directly:
 

--- a/legacy/sample_dataset/README.md
+++ b/legacy/sample_dataset/README.md
@@ -2,11 +2,11 @@
 
 The sample_dataset folder does not includes a `qa.parquet`, `corpus.parquet` file that is significantly large and cannot be uploaded directly to Git due to size limitations.
 
-To prepare and use datasets available in the sample_dataset folder, specifically `triviaqa`, `hotpotqa`, `msmarco` and `eli5`, you can follow the outlined methods below.
+To prepare and use datasets available in the sample_dataset folder, specifically `triviaqa`, `hotpotqa`, `msmarco`, `eli5` and `clapnq`, you can follow the outlined methods below.
 
 ## Usage
 
- The example provided uses `triviaqa`, but the same approach applies to `msmarco`, `eli5` and `hotpotqa`.
+ The example provided uses `triviaqa`, but the same approach applies to `msmarco`, `eli5`, `hotpotqa` and `clapnq`.
 
 ### 1. Run with a specified save path
 To execute the Python script from the terminal and save the dataset to a specified path, use the command:
@@ -21,5 +21,16 @@ using the `--save_path` argument to specify the dataset's save location.
 If you run the script without the `--save_path` argument, the dataset will be saved to a default location, which is the directory containing the `load_triviaqa_dataset.py` file, essentially `./sample_dataset/triviaqa/`:
 ```bash
 python ./sample_dataset/triviaqa/load_triviaqa_dataset.py
+```
+
+ClapNQ is downloaded from the public `PrimeQA/clapnq` dataset. Its answerable
+train and development splits are written to `qa_train.parquet` and
+`qa_test.parquet`; unanswerable examples are omitted because they do not have
+a generation ground truth.
+
+To create the ClapNQ sample directly:
+
+```bash
+python ./sample_dataset/clapnq/load_clapnq_dataset.py --save_path /path/to/save/dataset
 ```
 This behavior allows for a straightforward execution without needing to specify a path, making it convenient for quick tests or when working directly within the target directory.

--- a/legacy/sample_dataset/clapnq/load_clapnq_dataset.py
+++ b/legacy/sample_dataset/clapnq/load_clapnq_dataset.py
@@ -1,4 +1,3 @@
-import hashlib
 import pathlib
 from collections.abc import Iterable
 from typing import Any
@@ -8,61 +7,49 @@ import pandas as pd
 from datasets import load_dataset
 
 
-DATASET_ID = "PrimeQA/clapnq"
-TRAIN_FILE = "clapnq_train_answerable.jsonl"
-TEST_FILE = "clapnq_dev_answerable.jsonl"
+PASSAGES_URL = (
+	"https://huggingface.co/datasets/PrimeQA/clapnq_passages/resolve/main/passages.tsv"
+)
+RETRIEVAL_URL = "https://raw.githubusercontent.com/primeqa/clapnq/main/retrieval"
+TRAIN_QUESTIONS_URL = f"{RETRIEVAL_URL}/train/question_train_answerable.tsv"
+TEST_QUESTIONS_URL = f"{RETRIEVAL_URL}/dev/question_dev_answerable.tsv"
 
 
-def _passage_id(title: str, text: str) -> str:
-	value = f"{title}\n{text}".encode("utf-8")
-	return f"clapnq-{hashlib.sha256(value).hexdigest()[:16]}"
+def _load_tsv(url: str):
+	return load_dataset("csv", data_files={"split": url}, delimiter="\t", split="split")
 
 
 def _records_to_dataframes(
-	records: Iterable[dict[str, Any]],
+	passages: Iterable[dict[str, Any]], questions: Iterable[dict[str, Any]]
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
-	corpus: dict[str, dict[str, Any]] = {}
-	qa_rows: list[dict[str, Any]] = []
-
-	for record in records:
-		passage_ids = []
-		for passage in record["passages"]:
-			title = passage.get("title", "")
-			text = passage["text"].strip()
-			if not text:
-				continue
-			doc_id = _passage_id(title, text)
-			corpus.setdefault(
-				doc_id,
-				{
-					"doc_id": doc_id,
-					"contents": text,
-					"metadata": {"title": title},
-				},
-			)
-			passage_ids.append(doc_id)
-
+	corpus = pd.DataFrame(
+		{
+			"doc_id": passage["id"],
+			"contents": passage["text"],
+			"metadata": {"title": passage.get("title", "")},
+		}
+		for passage in passages
+	)
+	corpus_ids = set(corpus["doc_id"])
+	qa_rows = []
+	for question in questions:
+		doc_id = question.get("doc-id-list")
 		answers = [
-			output["answer"].strip()
-			for output in record.get("output", [])
-			if output.get("answer", "").strip()
+			answer.strip() for answer in (question.get("answers") or "").split("::")
 		]
-		answers = list(dict.fromkeys(answers))
-		if passage_ids and answers:
-			qa_rows.append(
-				{
-					"qid": str(record["id"]),
-					"query": record["input"].strip(),
-					"retrieval_gt": [passage_ids],
-					"generation_gt": answers,
-				}
-			)
+		answers = list(dict.fromkeys(answer for answer in answers if answer))
+		if not doc_id or doc_id not in corpus_ids or not answers:
+			continue
+		qa_rows.append(
+			{
+				"qid": str(question["id"]),
+				"query": question["question"].strip(),
+				"retrieval_gt": [[doc_id]],
+				"generation_gt": answers,
+			}
+		)
 
-	return pd.DataFrame(corpus.values()), pd.DataFrame(qa_rows)
-
-
-def _load_split(filename: str):
-	return load_dataset(DATASET_ID, data_files={"split": filename}, split="split")
+	return corpus, pd.DataFrame(qa_rows)
 
 
 @click.command()
@@ -73,7 +60,7 @@ def _load_split(filename: str):
 	help="Path to save sample ClapNQ dataset.",
 )
 def load_clapnq_dataset(save_path: pathlib.Path):
-	"""Download ClapNQ and write AutoRAG-compatible parquet files."""
+	"""Download the official ClapNQ retrieval corpus and QA splits."""
 	paths = {
 		"corpus": save_path / "corpus.parquet",
 		"train": save_path / "qa_train.parquet",
@@ -83,9 +70,11 @@ def load_clapnq_dataset(save_path: pathlib.Path):
 		raised = next(path for path in paths.values() if path.exists())
 		raise ValueError(f"{raised.name} already exists")
 
-	train_corpus, train_qa = _records_to_dataframes(_load_split(TRAIN_FILE))
-	test_corpus, test_qa = _records_to_dataframes(_load_split(TEST_FILE))
-	corpus = pd.concat([train_corpus, test_corpus]).drop_duplicates("doc_id")
+	passages = _load_tsv(PASSAGES_URL)
+	train_questions = _load_tsv(TRAIN_QUESTIONS_URL)
+	test_questions = _load_tsv(TEST_QUESTIONS_URL)
+	corpus, train_qa = _records_to_dataframes(passages, train_questions)
+	_, test_qa = _records_to_dataframes(passages, test_questions)
 
 	save_path.mkdir(parents=True, exist_ok=True)
 	corpus.to_parquet(paths["corpus"], index=False)

--- a/legacy/sample_dataset/clapnq/load_clapnq_dataset.py
+++ b/legacy/sample_dataset/clapnq/load_clapnq_dataset.py
@@ -1,0 +1,97 @@
+import hashlib
+import pathlib
+from collections.abc import Iterable
+from typing import Any
+
+import click
+import pandas as pd
+from datasets import load_dataset
+
+
+DATASET_ID = "PrimeQA/clapnq"
+TRAIN_FILE = "clapnq_train_answerable.jsonl"
+TEST_FILE = "clapnq_dev_answerable.jsonl"
+
+
+def _passage_id(title: str, text: str) -> str:
+	value = f"{title}\n{text}".encode("utf-8")
+	return f"clapnq-{hashlib.sha256(value).hexdigest()[:16]}"
+
+
+def _records_to_dataframes(
+	records: Iterable[dict[str, Any]],
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+	corpus: dict[str, dict[str, Any]] = {}
+	qa_rows: list[dict[str, Any]] = []
+
+	for record in records:
+		passage_ids = []
+		for passage in record["passages"]:
+			title = passage.get("title", "")
+			text = passage["text"].strip()
+			if not text:
+				continue
+			doc_id = _passage_id(title, text)
+			corpus.setdefault(
+				doc_id,
+				{
+					"doc_id": doc_id,
+					"contents": text,
+					"metadata": {"title": title},
+				},
+			)
+			passage_ids.append(doc_id)
+
+		answers = [
+			output["answer"].strip()
+			for output in record.get("output", [])
+			if output.get("answer", "").strip()
+		]
+		answers = list(dict.fromkeys(answers))
+		if passage_ids and answers:
+			qa_rows.append(
+				{
+					"qid": str(record["id"]),
+					"query": record["input"].strip(),
+					"retrieval_gt": [passage_ids],
+					"generation_gt": answers,
+				}
+			)
+
+	return pd.DataFrame(corpus.values()), pd.DataFrame(qa_rows)
+
+
+def _load_split(filename: str):
+	return load_dataset(DATASET_ID, data_files={"split": filename}, split="split")
+
+
+@click.command()
+@click.option(
+	"--save_path",
+	type=click.Path(file_okay=False, dir_okay=True, path_type=pathlib.Path),
+	default=pathlib.Path(__file__).parent,
+	help="Path to save sample ClapNQ dataset.",
+)
+def load_clapnq_dataset(save_path: pathlib.Path):
+	"""Download ClapNQ and write AutoRAG-compatible parquet files."""
+	paths = {
+		"corpus": save_path / "corpus.parquet",
+		"train": save_path / "qa_train.parquet",
+		"test": save_path / "qa_test.parquet",
+	}
+	if any(path.exists() for path in paths.values()):
+		raised = next(path for path in paths.values() if path.exists())
+		raise ValueError(f"{raised.name} already exists")
+
+	train_corpus, train_qa = _records_to_dataframes(_load_split(TRAIN_FILE))
+	test_corpus, test_qa = _records_to_dataframes(_load_split(TEST_FILE))
+	corpus = pd.concat([train_corpus, test_corpus]).drop_duplicates("doc_id")
+
+	save_path.mkdir(parents=True, exist_ok=True)
+	corpus.to_parquet(paths["corpus"], index=False)
+	train_qa.to_parquet(paths["train"], index=False)
+	test_qa.to_parquet(paths["test"], index=False)
+
+
+if __name__ == "__main__":
+	load_clapnq_dataset()

--- a/legacy/tests/sample_dataset/test_load_clapnq_dataset.py
+++ b/legacy/tests/sample_dataset/test_load_clapnq_dataset.py
@@ -1,0 +1,51 @@
+from sample_dataset.clapnq.load_clapnq_dataset import _records_to_dataframes
+
+
+def test_records_to_dataframes_deduplicates_passages_and_preserves_answers():
+	records = [
+		{
+			"id": 1,
+			"input": "What is the answer?",
+			"passages": [{"title": "Title", "text": " Evidence. "}],
+			"output": [{"answer": "Answer"}, {"answer": "Answer"}],
+		},
+		{
+			"id": 2,
+			"input": "Another question",
+			"passages": [{"title": "Title", "text": "Evidence."}],
+			"output": [{"answer": "Second answer"}],
+		},
+	]
+
+	corpus, qa = _records_to_dataframes(records)
+
+	assert len(corpus) == 1
+	assert corpus.iloc[0]["contents"] == "Evidence."
+	assert qa["retrieval_gt"].tolist() == [
+		[[corpus.iloc[0]["doc_id"]]],
+		[[corpus.iloc[0]["doc_id"]]],
+	]
+	assert qa["generation_gt"].tolist() == [["Answer"], ["Second answer"]]
+
+
+def test_records_to_dataframes_ignores_unanswerable_and_empty_passages():
+	records = [
+		{
+			"id": "unanswerable",
+			"input": "Question",
+			"passages": [{"title": "Title", "text": "Context"}],
+			"output": [{"answer": ""}],
+		},
+		{
+			"id": "empty",
+			"input": "Question",
+			"passages": [{"title": "Title", "text": "  "}],
+			"output": [{"answer": "Answer"}],
+		},
+	]
+
+	corpus, qa = _records_to_dataframes(records)
+
+	assert len(corpus) == 1
+	assert corpus.iloc[0]["contents"] == "Context"
+	assert qa.empty

--- a/legacy/tests/sample_dataset/test_load_clapnq_dataset.py
+++ b/legacy/tests/sample_dataset/test_load_clapnq_dataset.py
@@ -1,51 +1,51 @@
 from sample_dataset.clapnq.load_clapnq_dataset import _records_to_dataframes
 
 
-def test_records_to_dataframes_deduplicates_passages_and_preserves_answers():
-	records = [
+def test_records_to_dataframes_uses_official_passage_ids_and_answers():
+	passages = [
+		{"id": "doc-1", "text": "Evidence.", "title": "Title"},
+		{"id": "doc-2", "text": "Negative context.", "title": "Other"},
+	]
+	questions = [
 		{
 			"id": 1,
-			"input": "What is the answer?",
-			"passages": [{"title": "Title", "text": " Evidence. "}],
-			"output": [{"answer": "Answer"}, {"answer": "Answer"}],
+			"question": "What is the answer?",
+			"doc-id-list": "doc-1",
+			"answers": "Answer::Answer",
 		},
 		{
 			"id": 2,
-			"input": "Another question",
-			"passages": [{"title": "Title", "text": "Evidence."}],
-			"output": [{"answer": "Second answer"}],
+			"question": "Another question",
+			"doc-id-list": "doc-2",
+			"answers": "Second answer",
 		},
 	]
 
-	corpus, qa = _records_to_dataframes(records)
+	corpus, qa = _records_to_dataframes(passages, questions)
 
-	assert len(corpus) == 1
-	assert corpus.iloc[0]["contents"] == "Evidence."
-	assert qa["retrieval_gt"].tolist() == [
-		[[corpus.iloc[0]["doc_id"]]],
-		[[corpus.iloc[0]["doc_id"]]],
-	]
+	assert corpus["doc_id"].tolist() == ["doc-1", "doc-2"]
+	assert qa["retrieval_gt"].tolist() == [[["doc-1"]], [["doc-2"]]]
 	assert qa["generation_gt"].tolist() == [["Answer"], ["Second answer"]]
 
 
-def test_records_to_dataframes_ignores_unanswerable_and_empty_passages():
-	records = [
+def test_records_to_dataframes_ignores_questions_without_gold_passages():
+	passages = [{"id": "doc-1", "text": "Context", "title": "Title"}]
+	questions = [
 		{
-			"id": "unanswerable",
-			"input": "Question",
-			"passages": [{"title": "Title", "text": "Context"}],
-			"output": [{"answer": ""}],
+			"id": "missing-doc",
+			"question": "Question",
+			"doc-id-list": None,
+			"answers": "Answer",
 		},
 		{
-			"id": "empty",
-			"input": "Question",
-			"passages": [{"title": "Title", "text": "  "}],
-			"output": [{"answer": "Answer"}],
+			"id": "unknown-doc",
+			"question": "Question",
+			"doc-id-list": "doc-2",
+			"answers": "Answer",
 		},
 	]
 
-	corpus, qa = _records_to_dataframes(records)
+	corpus, qa = _records_to_dataframes(passages, questions)
 
 	assert len(corpus) == 1
-	assert corpus.iloc[0]["contents"] == "Context"
 	assert qa.empty


### PR DESCRIPTION
## Summary

- Add an AutoRAG-compatible ClapNQ sample loader under `legacy/sample_dataset/clapnq`.
- Use the official complete retrieval corpus from `PrimeQA/clapnq_passages`, rather than only passages embedded in annotated examples.
- Use the official answerable train/development retrieval question TSVs to build `retrieval_gt` from the published passage IDs and preserve distinct reference answers.
- Add focused conversion tests and document usage.

Closes #555

## Validation

- `python -m pytest legacy/tests/sample_dataset/test_load_clapnq_dataset.py -q` — 2 passed.
- `python -m ruff check legacy/sample_dataset/clapnq legacy/tests/sample_dataset` — passed.
- `python -m ruff format --check legacy/sample_dataset/clapnq legacy/tests/sample_dataset` — passed.
- End-to-end loader run against the official corpus and question files — passed: corpus 178,890 rows, train QA 1,954 rows, test QA 300 rows; every QA reference resolves to a corpus `doc_id`, and train/test qids do not overlap.
- Full `python -m pytest legacy/tests -q` was attempted. Collection is blocked in the current environment by missing legacy optional dependencies (`llama_index`, etc.; 117 collection errors). `uv sync --dev` was also attempted, but the lock resolution selected `nvidia-cutlass-dsl-libs-base`, which has no Windows wheel. The current system Python is 3.13, while this project requires Python 3.10–3.12.

Dataset references:
- https://huggingface.co/datasets/PrimeQA/clapnq_passages
- https://github.com/primeqa/clapnq/tree/main/retrieval
- https://arxiv.org/abs/2404.02103