### PR TITLE
fix(minsync): make first refresh queryable

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -131,6 +131,7 @@ export interface AutoRAGRefreshOptions {
 
 export interface AutoRAGRefreshResult extends ParsedMirrorSyncResult {
 	readonly bm25?: BM25SyncResult;
+	readonly minsync?: MinSyncSyncResult;
 	readonly datasources?: readonly DatasourceIndexResult[];
 }
 
@@ -1126,7 +1127,7 @@ export class AutoRAGAgent {
 				datasources,
 				lastError: undefined,
 			};
-			return { ...(bm25 ? { ...summary, bm25 } : summary), datasources };
+			return { ...(bm25 ? { ...summary, bm25 } : summary), minsync, datasources };
 		} catch (error) {
 			this.refreshState = {
 				...this.refreshState,

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -129,9 +129,15 @@ export interface AutoRAGRefreshOptions {
 	readonly methods?: readonly RefreshMethod[];
 }
 
+export interface AutoRAGMinSyncRefreshResult {
+	readonly ok: boolean;
+	readonly synced: number;
+	readonly reason?: string;
+}
+
 export interface AutoRAGRefreshResult extends ParsedMirrorSyncResult {
 	readonly bm25?: BM25SyncResult;
-	readonly minsync?: MinSyncSyncResult;
+	readonly minsync?: AutoRAGMinSyncRefreshResult;
 	readonly datasources?: readonly DatasourceIndexResult[];
 }
 
@@ -1127,7 +1133,14 @@ export class AutoRAGAgent {
 				datasources,
 				lastError: undefined,
 			};
-			return { ...(bm25 ? { ...summary, bm25 } : summary), minsync, datasources };
+			const publicMinsync = minsync
+				? {
+						ok: minsync.ok,
+						synced: minsync.synced,
+						...(minsync.reason !== undefined ? { reason: minsync.reason } : {}),
+					}
+				: undefined;
+			return { ...(bm25 ? { ...summary, bm25 } : summary), minsync: publicMinsync, datasources };
 		} catch (error) {
 			this.refreshState = {
 				...this.refreshState,

--- a/src/minsync/client.ts
+++ b/src/minsync/client.ts
@@ -11,7 +11,6 @@ export interface MinSyncClientOptions {
 }
 
 const API_KEY_ENV_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
-const SECRET_PATTERN = /sk-[A-Za-z0-9_-]+/g;
 
 export class MinSyncClient {
 	private readonly binaryPath: string;
@@ -57,7 +56,7 @@ export class MinSyncClient {
 					ok: false,
 					synced: 0,
 					workspacePath: this.workspacePath,
-					reason: sanitizeReason(init.stderr || "init-failed"),
+					reason: "init-failed",
 				};
 			}
 		}
@@ -70,7 +69,7 @@ export class MinSyncClient {
 				ok: false,
 				synced: 0,
 				workspacePath: this.workspacePath,
-				reason: sanitizeReason(check.stderr || "check-failed"),
+				reason: "check-failed",
 			};
 		}
 		const checkFailure = readCheckFailure(check.stdout);
@@ -84,7 +83,7 @@ export class MinSyncClient {
 				ok: false,
 				synced: 0,
 				workspacePath: this.workspacePath,
-				reason: sanitizeReason(result.stderr || "sync-failed"),
+				reason: "sync-failed",
 			};
 		}
 		if (!existsSync(cursorPath)) {
@@ -103,10 +102,6 @@ export class MinSyncClient {
 		if (!result.ok) return [];
 		return parseQueryHits(result.stdout);
 	}
-}
-
-function sanitizeReason(reason: string): string {
-	return reason.trim().replace(SECRET_PATTERN, "[redacted]");
 }
 
 function readSyncedCount(stdout: string): number {

--- a/src/minsync/client.ts
+++ b/src/minsync/client.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
-import { rewriteEmbedderConfig } from "./embedder-config.ts";
+import { join } from "node:path";
+import { minSyncConfigPath, rewriteEmbedderConfig } from "./embedder-config.ts";
 import { spawnProcess } from "./process.ts";
 import type { MinSyncEmbedderConfig, MinSyncQueryHit, MinSyncSyncResult } from "./types.ts";
 
@@ -42,24 +43,37 @@ export class MinSyncClient {
 				};
 			}
 		}
-		const initArgs = ["init", "--format", "json"];
-		if (this.embedder?.id) {
-			initArgs.push("--embedder", this.embedder.id);
-		}
 		const spawnOpts = this.embedder?.timeoutMs !== undefined ? { timeoutMs: this.embedder.timeoutMs } : {};
-		const init = await spawnProcess(this.binaryPath, initArgs, this.workspacePath, spawnOpts);
-		if (!init.ok) {
-			return {
-				ok: false,
-				synced: 0,
-				workspacePath: this.workspacePath,
-				reason: sanitizeReason(init.stderr || "init-failed"),
-			};
+		const initialized = existsSync(minSyncConfigPath(this.workspacePath));
+		if (!initialized) {
+			const initArgs = ["init", "--format", "json"];
+			if (this.embedder?.id) {
+				initArgs.push("--embedder", this.embedder.id);
+			}
+			const init = await spawnProcess(this.binaryPath, initArgs, this.workspacePath, spawnOpts);
+			if (!init.ok) {
+				return {
+					ok: false,
+					synced: 0,
+					workspacePath: this.workspacePath,
+					reason: sanitizeReason(init.stderr || "init-failed"),
+				};
+			}
 		}
 		if (this.embedder) {
 			rewriteEmbedderConfig(this.workspacePath, this.embedder);
 		}
-		const result = await spawnProcess(this.binaryPath, ["sync", "--format", "json"], this.workspacePath, spawnOpts);
+		const check = await spawnProcess(this.binaryPath, ["check", "--format", "json"], this.workspacePath, spawnOpts);
+		if (!check.ok) {
+			return {
+				ok: false,
+				synced: 0,
+				workspacePath: this.workspacePath,
+				reason: sanitizeReason(check.stderr || "check-failed"),
+			};
+		}
+		const syncArgs = initialized ? ["sync", "--format", "json"] : ["sync", "--full", "--format", "json"];
+		const result = await spawnProcess(this.binaryPath, syncArgs, this.workspacePath, spawnOpts);
 		if (!result.ok) {
 			return {
 				ok: false,
@@ -67,6 +81,9 @@ export class MinSyncClient {
 				workspacePath: this.workspacePath,
 				reason: sanitizeReason(result.stderr || "sync-failed"),
 			};
+		}
+		if (!existsSync(join(this.workspacePath, ".minsync", "cursor.json"))) {
+			return { ok: false, synced: 0, workspacePath: this.workspacePath, reason: "not-ready: missing cursor" };
 		}
 		return { ok: true, synced: readSyncedCount(result.stdout), workspacePath: this.workspacePath };
 	}
@@ -84,7 +101,7 @@ export class MinSyncClient {
 }
 
 function sanitizeReason(reason: string): string {
-	return reason.replace(SECRET_PATTERN, "[redacted]");
+	return reason.trim().replace(SECRET_PATTERN, "[redacted]");
 }
 
 function readSyncedCount(stdout: string): number {

--- a/src/minsync/client.ts
+++ b/src/minsync/client.ts
@@ -45,6 +45,7 @@ export class MinSyncClient {
 		}
 		const spawnOpts = this.embedder?.timeoutMs !== undefined ? { timeoutMs: this.embedder.timeoutMs } : {};
 		const initialized = existsSync(minSyncConfigPath(this.workspacePath));
+		const cursorPath = join(this.workspacePath, ".minsync", "cursor.json");
 		if (!initialized) {
 			const initArgs = ["init", "--format", "json"];
 			if (this.embedder?.id) {
@@ -72,7 +73,11 @@ export class MinSyncClient {
 				reason: sanitizeReason(check.stderr || "check-failed"),
 			};
 		}
-		const syncArgs = initialized ? ["sync", "--format", "json"] : ["sync", "--full", "--format", "json"];
+		const checkFailure = readCheckFailure(check.stdout);
+		if (checkFailure) {
+			return { ok: false, synced: 0, workspacePath: this.workspacePath, reason: checkFailure };
+		}
+		const syncArgs = existsSync(cursorPath) ? ["sync", "--format", "json"] : ["sync", "--full", "--format", "json"];
 		const result = await spawnProcess(this.binaryPath, syncArgs, this.workspacePath, spawnOpts);
 		if (!result.ok) {
 			return {
@@ -82,7 +87,7 @@ export class MinSyncClient {
 				reason: sanitizeReason(result.stderr || "sync-failed"),
 			};
 		}
-		if (!existsSync(join(this.workspacePath, ".minsync", "cursor.json"))) {
+		if (!existsSync(cursorPath)) {
 			return { ok: false, synced: 0, workspacePath: this.workspacePath, reason: "not-ready: missing cursor" };
 		}
 		return { ok: true, synced: readSyncedCount(result.stdout), workspacePath: this.workspacePath };
@@ -112,6 +117,15 @@ function readSyncedCount(stdout: string): number {
 		if (typeof count === "number" && Number.isFinite(count)) return count;
 	}
 	return 0;
+}
+
+function readCheckFailure(stdout: string): string | undefined {
+	const parsed = parseJson(stdout);
+	if (!isRecord(parsed)) return "check-failed: invalid response";
+	if (parsed.embedder_ok !== true) return "check-failed: embedder unavailable";
+	if (parsed.vectorstore_ok !== true) return "check-failed: vector store unavailable";
+	if (parsed.all_passed === false) return "check-failed: preflight unhealthy";
+	return undefined;
 }
 
 function parseQueryHits(stdout: string): readonly MinSyncQueryHit[] {

--- a/test/integration/minsync-first-sync.test.ts
+++ b/test/integration/minsync-first-sync.test.ts
@@ -26,7 +26,14 @@ afterEach(() => {
 	rmSync(root, { recursive: true, force: true });
 });
 
-function writeFaithfulMinSync(options: { readonly checkFails?: boolean } = {}): void {
+function writeFaithfulMinSync(
+	options: {
+		readonly checkFails?: boolean;
+		readonly checkUnhealthyJson?: boolean;
+		readonly checkUnhealthyOnce?: boolean;
+		readonly fullSyncCreatesCursor?: boolean;
+	} = {},
+): void {
 	writeFileSync(
 		minsyncBinary,
 		`#!/usr/bin/env node
@@ -37,6 +44,7 @@ const args = process.argv.slice(2);
 const cwd = process.cwd();
 const config = join(cwd, ".minsync", "config.toml");
 const cursor = join(cwd, ".minsync", "cursor.json");
+const unhealthyOnceMarker = join(cwd, ".minsync", "check-failed-once");
 const log = ${JSON.stringify(commandLog)};
 appendFileSync(log, JSON.stringify(args) + "\\n");
 
@@ -56,14 +64,25 @@ if (args[0] === "check") {
     console.error("embedder unavailable");
     process.exit(1);
   }
-  console.log(JSON.stringify({ vectorstore_ok: true, embedder_ok: true }));
+  if (${options.checkUnhealthyOnce === true ? "true" : "false"} && !existsSync(unhealthyOnceMarker)) {
+    writeFileSync(unhealthyOnceMarker, "failed");
+    console.log(JSON.stringify({ all_passed: false, vectorstore_ok: true, embedder_ok: false }));
+    process.exit(0);
+  }
+  if (${options.checkUnhealthyJson === true ? "true" : "false"}) {
+    console.log(JSON.stringify({ all_passed: false, vectorstore_ok: true, embedder_ok: false }));
+    process.exit(0);
+  }
+  console.log(JSON.stringify({ all_passed: true, vectorstore_ok: true, embedder_ok: true }));
   process.exit(0);
 }
 
 if (args[0] === "sync") {
   if (args.includes("--full")) {
-    mkdirSync(dirname(cursor), { recursive: true });
-    writeFileSync(cursor, JSON.stringify({ ready: true }));
+    if (${options.fullSyncCreatesCursor === false ? "false" : "true"}) {
+      mkdirSync(dirname(cursor), { recursive: true });
+      writeFileSync(cursor, JSON.stringify({ ready: true }));
+    }
     console.log(JSON.stringify({ files_processed: 1, embedded_texts: 1 }));
     process.exit(0);
   }
@@ -139,6 +158,7 @@ describe("AutoRAGAgent MinSync first-sync contract (#1366)", () => {
 		const secondRefresh = await agent.refresh(false);
 
 		expect(firstRefresh.minsync).toMatchObject({ ok: true, synced: 1 });
+		expect(firstRefresh.minsync).not.toHaveProperty("workspacePath");
 		expect(secondRefresh.minsync).toMatchObject({ ok: true, synced: 0 });
 		expect(existsSync(join(minsyncWorkspace, ".minsync", "cursor.json"))).toBe(true);
 		expect(hits.map((hit) => hit.source)).toEqual(["/docs/handbook.txt"]);
@@ -152,8 +172,23 @@ describe("AutoRAGAgent MinSync first-sync contract (#1366)", () => {
 		]);
 	});
 
-	it("reports exit-zero incremental sync without a cursor as unready", async () => {
+	it("recovers a config-only workspace with a full sync", async () => {
 		writeFaithfulMinSync();
+		mkdirSync(join(minsyncWorkspace, ".minsync"), { recursive: true });
+		writeFileSync(join(minsyncWorkspace, ".minsync", "config.toml"), '[embedder]\nid = "openai"\n');
+		const agent = createAgent();
+
+		const refresh = await agent.refresh(false);
+
+		expect(refresh.minsync).toMatchObject({ ok: true, synced: 1 });
+		expect(loggedCommands()).toEqual([
+			["check", "--format", "json"],
+			["sync", "--full", "--format", "json"],
+		]);
+	});
+
+	it("reports exit-zero full sync without a cursor as unready", async () => {
+		writeFaithfulMinSync({ fullSyncCreatesCursor: false });
 		mkdirSync(join(minsyncWorkspace, ".minsync"), { recursive: true });
 		writeFileSync(join(minsyncWorkspace, ".minsync", "config.toml"), '[embedder]\nid = "openai"\n');
 		const agent = createAgent();
@@ -164,7 +199,7 @@ describe("AutoRAGAgent MinSync first-sync contract (#1366)", () => {
 		expect(refresh.minsync?.reason).toContain("not-ready");
 		expect(loggedCommands()).toEqual([
 			["check", "--format", "json"],
-			["sync", "--format", "json"],
+			["sync", "--full", "--format", "json"],
 		]);
 		expect((await agent.getRefreshStatus()).components.minsync).toBe("degraded");
 	});
@@ -181,5 +216,39 @@ describe("AutoRAGAgent MinSync first-sync contract (#1366)", () => {
 			["check", "--format", "json"],
 		]);
 		expect((await agent.getRefreshStatus()).components.minsync).toBe("degraded");
+	});
+
+	it("rejects exit-zero unhealthy preflight JSON before sync", async () => {
+		writeFaithfulMinSync({ checkUnhealthyJson: true });
+		const agent = createAgent();
+
+		const refresh = await agent.refresh(true);
+
+		expect(refresh.minsync).toMatchObject({
+			ok: false,
+			synced: 0,
+			reason: "check-failed: embedder unavailable",
+		});
+		expect(loggedCommands()).toEqual([
+			["init", "--format", "json"],
+			["check", "--format", "json"],
+		]);
+	});
+
+	it("retries a transient preflight failure with a full sync", async () => {
+		writeFaithfulMinSync({ checkUnhealthyOnce: true });
+		const agent = createAgent();
+
+		const first = await agent.refresh(true);
+		const second = await agent.refresh(false);
+
+		expect(first.minsync).toMatchObject({ ok: false, synced: 0 });
+		expect(second.minsync).toMatchObject({ ok: true, synced: 1 });
+		expect(loggedCommands()).toEqual([
+			["init", "--format", "json"],
+			["check", "--format", "json"],
+			["check", "--format", "json"],
+			["sync", "--full", "--format", "json"],
+		]);
 	});
 });

--- a/test/integration/minsync-first-sync.test.ts
+++ b/test/integration/minsync-first-sync.test.ts
@@ -29,6 +29,7 @@ afterEach(() => {
 function writeFaithfulMinSync(
 	options: {
 		readonly checkFails?: boolean;
+		readonly checkFailureReason?: string;
 		readonly checkUnhealthyJson?: boolean;
 		readonly checkUnhealthyOnce?: boolean;
 		readonly fullSyncCreatesCursor?: boolean;
@@ -61,7 +62,7 @@ if (args[0] === "init") {
 
 if (args[0] === "check") {
   if (${options.checkFails === true ? "true" : "false"}) {
-    console.error("embedder unavailable");
+    console.error(${JSON.stringify(options.checkFailureReason ?? "embedder unavailable")});
     process.exit(1);
   }
   if (${options.checkUnhealthyOnce === true ? "true" : "false"} && !existsSync(unhealthyOnceMarker)) {
@@ -205,12 +206,14 @@ describe("AutoRAGAgent MinSync first-sync contract (#1366)", () => {
 	});
 
 	it("surfaces embedder preflight failure without claiming readiness", async () => {
-		writeFaithfulMinSync({ checkFails: true });
+		const privateFailure = `cannot open ${join(minsyncWorkspace, ".minsync", "config.toml")}`;
+		writeFaithfulMinSync({ checkFails: true, checkFailureReason: privateFailure });
 		const agent = createAgent();
 
 		const refresh = await agent.refresh(true);
 
-		expect(refresh.minsync).toMatchObject({ ok: false, synced: 0, reason: "embedder unavailable" });
+		expect(refresh.minsync).toMatchObject({ ok: false, synced: 0, reason: "check-failed" });
+		expect(JSON.stringify(refresh.minsync)).not.toContain(root);
 		expect(loggedCommands()).toEqual([
 			["init", "--format", "json"],
 			["check", "--format", "json"],

--- a/test/integration/minsync-first-sync.test.ts
+++ b/test/integration/minsync-first-sync.test.ts
@@ -1,0 +1,185 @@
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AutoRAGAgent } from "../../src/agent/agent.ts";
+import { MinSyncClient } from "../../src/minsync/client.ts";
+
+let root: string;
+let docs: string;
+let minsyncBinary: string;
+let minsyncWorkspace: string;
+let commandLog: string;
+
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), "autorag-minsync-first-sync-"));
+	docs = join(root, "docs");
+	minsyncBinary = join(root, "fake-minsync.mjs");
+	minsyncWorkspace = join(root, ".autorag", "minsync");
+	commandLog = join(root, "minsync-commands.jsonl");
+	mkdirSync(docs, { recursive: true });
+	mkdirSync(minsyncWorkspace, { recursive: true });
+	writeFileSync(join(docs, "handbook.txt"), "Refund decisions require manager review.\n");
+});
+
+afterEach(() => {
+	rmSync(root, { recursive: true, force: true });
+});
+
+function writeFaithfulMinSync(options: { readonly checkFails?: boolean } = {}): void {
+	writeFileSync(
+		minsyncBinary,
+		`#!/usr/bin/env node
+import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const args = process.argv.slice(2);
+const cwd = process.cwd();
+const config = join(cwd, ".minsync", "config.toml");
+const cursor = join(cwd, ".minsync", "cursor.json");
+const log = ${JSON.stringify(commandLog)};
+appendFileSync(log, JSON.stringify(args) + "\\n");
+
+if (args[0] === "init") {
+  if (existsSync(config)) {
+    console.error("AlreadyInitialized");
+    process.exit(1);
+  }
+  mkdirSync(dirname(config), { recursive: true });
+  writeFileSync(config, "[embedder]\\nid = \\"openai\\"\\n");
+  console.log(JSON.stringify({ initialized: true, baseline_files: 1 }));
+  process.exit(0);
+}
+
+if (args[0] === "check") {
+  if (${options.checkFails === true ? "true" : "false"}) {
+    console.error("embedder unavailable");
+    process.exit(1);
+  }
+  console.log(JSON.stringify({ vectorstore_ok: true, embedder_ok: true }));
+  process.exit(0);
+}
+
+if (args[0] === "sync") {
+  if (args.includes("--full")) {
+    mkdirSync(dirname(cursor), { recursive: true });
+    writeFileSync(cursor, JSON.stringify({ ready: true }));
+    console.log(JSON.stringify({ files_processed: 1, embedded_texts: 1 }));
+    process.exit(0);
+  }
+  if (existsSync(cursor)) {
+    console.log(JSON.stringify({ files_processed: 0, embedded_texts: 0, already_up_to_date: true }));
+    process.exit(0);
+  }
+  console.log(JSON.stringify({ files_processed: 0, embedded_texts: 0, already_up_to_date: true }));
+  process.exit(0);
+}
+
+if (args[0] === "query") {
+  if (!existsSync(cursor)) {
+    console.error("never synced");
+    process.exit(1);
+  }
+  console.log(JSON.stringify({
+    results: [{
+      path: ${JSON.stringify(join(root, ".autorag", "parsed", "files", "docs", "handbook.txt.md"))},
+      score: 0.91,
+      text: "Refund decisions require manager review."
+    }]
+  }));
+  process.exit(0);
+}
+
+process.exit(2);
+`,
+	);
+	chmodSync(minsyncBinary, 0o755);
+}
+
+function createAgent(): AutoRAGAgent {
+	return new AutoRAGAgent({
+		searchPaths: [docs],
+		memoryPath: join(root, "memory.json"),
+		workspacePath: root,
+		bm25: false,
+		minSync: { binaryPath: minsyncBinary, workspacePath: minsyncWorkspace },
+	});
+}
+
+function loggedCommands(): string[][] {
+	return readFileSync(commandLog, "utf8")
+		.trim()
+		.split("\n")
+		.filter(Boolean)
+		.map((line) => JSON.parse(line) as string[]);
+}
+
+describe("AutoRAGAgent MinSync first-sync contract (#1366)", () => {
+	it("uses full sync and creates a cursor for a fresh MinSync client workspace", async () => {
+		writeFaithfulMinSync();
+		const client = new MinSyncClient({ binaryPath: minsyncBinary, workspacePath: minsyncWorkspace });
+
+		const result = await client.sync();
+
+		expect(result).toMatchObject({ ok: true, synced: 1 });
+		expect(existsSync(join(minsyncWorkspace, ".minsync", "cursor.json"))).toBe(true);
+		expect(loggedCommands()).toEqual([
+			["init", "--format", "json"],
+			["check", "--format", "json"],
+			["sync", "--full", "--format", "json"],
+		]);
+	});
+
+	it("full-syncs a fresh workspace, queries immediately, then refreshes incrementally", async () => {
+		writeFaithfulMinSync();
+		const agent = createAgent();
+
+		const firstRefresh = await agent.refresh(true);
+		const hits = await agent.retrieve("refund approval", { topK: 1 });
+		const secondRefresh = await agent.refresh(false);
+
+		expect(firstRefresh.minsync).toMatchObject({ ok: true, synced: 1 });
+		expect(secondRefresh.minsync).toMatchObject({ ok: true, synced: 0 });
+		expect(existsSync(join(minsyncWorkspace, ".minsync", "cursor.json"))).toBe(true);
+		expect(hits.map((hit) => hit.source)).toEqual(["/docs/handbook.txt"]);
+		expect(loggedCommands()).toEqual([
+			["init", "--format", "json"],
+			["check", "--format", "json"],
+			["sync", "--full", "--format", "json"],
+			["query", "--format", "json", "-k", "1", "refund approval"],
+			["check", "--format", "json"],
+			["sync", "--format", "json"],
+		]);
+	});
+
+	it("reports exit-zero incremental sync without a cursor as unready", async () => {
+		writeFaithfulMinSync();
+		mkdirSync(join(minsyncWorkspace, ".minsync"), { recursive: true });
+		writeFileSync(join(minsyncWorkspace, ".minsync", "config.toml"), '[embedder]\nid = "openai"\n');
+		const agent = createAgent();
+
+		const refresh = await agent.refresh(false);
+
+		expect(refresh.minsync).toMatchObject({ ok: false, synced: 0 });
+		expect(refresh.minsync?.reason).toContain("not-ready");
+		expect(loggedCommands()).toEqual([
+			["check", "--format", "json"],
+			["sync", "--format", "json"],
+		]);
+		expect((await agent.getRefreshStatus()).components.minsync).toBe("degraded");
+	});
+
+	it("surfaces embedder preflight failure without claiming readiness", async () => {
+		writeFaithfulMinSync({ checkFails: true });
+		const agent = createAgent();
+
+		const refresh = await agent.refresh(true);
+
+		expect(refresh.minsync).toMatchObject({ ok: false, synced: 0, reason: "embedder unavailable" });
+		expect(loggedCommands()).toEqual([
+			["init", "--format", "json"],
+			["check", "--format", "json"],
+		]);
+		expect((await agent.getRefreshStatus()).components.minsync).toBe("degraded");
+	});
+});

--- a/test/integration/minsync-flow.test.ts
+++ b/test/integration/minsync-flow.test.ts
@@ -26,14 +26,27 @@ function writeFakeMinSync(): void {
 	writeFileSync(
 		minsyncBinary,
 		`#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 const args = process.argv.slice(2);
+const cursor = join(process.cwd(), ".minsync", "cursor.json");
 
 if (args[0] === "init") {
+  const config = join(process.cwd(), ".minsync", "config.toml");
+  mkdirSync(dirname(config), { recursive: true });
+  writeFileSync(config, "[embedder]\\nid = \\"openai\\"\\n");
   console.log(JSON.stringify({ initialized: true }));
   process.exit(0);
 }
 
+if (args[0] === "check") {
+  console.log(JSON.stringify({ vectorstore_ok: true, embedder_ok: true }));
+  process.exit(0);
+}
+
 if (args[0] === "sync") {
+  mkdirSync(dirname(cursor), { recursive: true });
+  writeFileSync(cursor, JSON.stringify({ ready: true }));
   console.log(JSON.stringify({ synced: 1 }));
   process.exit(0);
 }
@@ -61,14 +74,27 @@ function writeFakeScopedMinSync(): void {
 	writeFileSync(
 		minsyncBinary,
 		`#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 const args = process.argv.slice(2);
+const cursor = join(process.cwd(), ".minsync", "cursor.json");
 
 if (args[0] === "init") {
+  const config = join(process.cwd(), ".minsync", "config.toml");
+  mkdirSync(dirname(config), { recursive: true });
+  writeFileSync(config, "[embedder]\\nid = \\"openai\\"\\n");
   console.log(JSON.stringify({ initialized: true }));
   process.exit(0);
 }
 
+if (args[0] === "check") {
+  console.log(JSON.stringify({ vectorstore_ok: true, embedder_ok: true }));
+  process.exit(0);
+}
+
 if (args[0] === "sync") {
+  mkdirSync(dirname(cursor), { recursive: true });
+  writeFileSync(cursor, JSON.stringify({ ready: true }));
   console.log(JSON.stringify({ synced: 2 }));
   process.exit(0);
 }

--- a/test/minsync/minsync.test.ts
+++ b/test/minsync/minsync.test.ts
@@ -404,8 +404,8 @@ describe("MinSyncVectorMethod embedder plumbing", () => {
 		}
 	});
 
-	it("strips sk- patterns from reason strings", async () => {
-		// Fake binary that emits a secret-looking string on stderr for init
+	it("projects init stderr to a fixed path-opaque reason", async () => {
+		// Fake binary that emits a secret-looking string on stderr for init.
 		writeFileSync(
 			minsyncBinary,
 			`#!/usr/bin/env node
@@ -428,7 +428,7 @@ process.exit(2);
 
 		expect(result.ok).toBe(false);
 		expect(result.reason).not.toContain("sk-abc123def456");
-		expect(result.reason).toContain("[redacted]");
+		expect(result.reason).toBe("init-failed");
 	});
 
 	it("rewrites allowlisted embedder fields into .minsync/config.toml after init", async () => {

--- a/test/minsync/minsync.test.ts
+++ b/test/minsync/minsync.test.ts
@@ -56,17 +56,29 @@ function writeFakeMinSync(queryJson: string): void {
 	writeFileSync(
 		minsyncBinary,
 		`#!/usr/bin/env node
-import { appendFileSync } from "node:fs";
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 
 const args = process.argv.slice(2);
+const config = join(process.cwd(), ".minsync", "config.toml");
+const cursor = join(process.cwd(), ".minsync", "cursor.json");
 appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({ args, cwd: process.cwd() }) + "\\n");
 
 if (args[0] === "init") {
+  mkdirSync(dirname(config), { recursive: true });
+  writeFileSync(config, "[embedder]\\nid = \\"openai\\"\\n");
   console.log(JSON.stringify({ initialized: true }));
   process.exit(0);
 }
 
+if (args[0] === "check") {
+  console.log(JSON.stringify({ vectorstore_ok: true, embedder_ok: true }));
+  process.exit(0);
+}
+
 if (args[0] === "sync") {
+  mkdirSync(dirname(cursor), { recursive: true });
+  writeFileSync(cursor, JSON.stringify({ ready: true }));
   console.log(JSON.stringify({ files_processed: 1, files_processed_paths: ["files/docs/policy.txt.md"] }));
   process.exit(0);
 }
@@ -115,7 +127,10 @@ describe("MinSyncVectorMethod", () => {
 		// Then
 		expect(result).toMatchObject({ synced: 1 });
 		expect(loggedCalls()).toContainEqual(JSON.stringify({ args: ["init", "--format", "json"], cwd: minSyncCwd() }));
-		expect(loggedCalls()).toContainEqual(JSON.stringify({ args: ["sync", "--format", "json"], cwd: minSyncCwd() }));
+		expect(loggedCalls()).toContainEqual(JSON.stringify({ args: ["check", "--format", "json"], cwd: minSyncCwd() }));
+		expect(loggedCalls()).toContainEqual(
+			JSON.stringify({ args: ["sync", "--full", "--format", "json"], cwd: minSyncCwd() }),
+		);
 	});
 
 	it("returns vector results resolved from parsed mirror paths back to virtual paths", async () => {


### PR DESCRIPTION
## Summary
- initialize MinSync only for a new workspace
- run preflight check and first `sync --full`
- require cursor readiness and expose MinSync refresh status

## Evidence
- RED: faithful first-sync fixture returned `ok:true, synced:0` with no cursor
- GREEN: `bun run test -- test/integration/minsync-first-sync.test.ts test/integration/minsync-flow.test.ts test/minsync/minsync.test.ts` (25 passed)
- Manual QA: live `AutoRAGAgent.refresh()` driver observed init -> check -> full sync -> query -> check -> incremental sync with `pass:true`
- Biome 2.5.6: 5 changed files clean
- `git diff --check`: clean

## Known baseline blocker
`bun run typecheck` and `bun run build` fail at pre-existing `src/subagents/runtime.ts:969:62 TS2554`; reproduced unchanged on `origin/main@02767281`.

Closes #1366