### PR TITLE
feat(retrieval): reinforce repeated document hits

### DIFF
--- a/src/retrieval/merger.ts
+++ b/src/retrieval/merger.ts
@@ -65,12 +65,16 @@ export class ResultMerger {
 
 function aggregateBySource(results: readonly MethodResult[]): RetrievalResult[] {
 	const bySource = new Map<string, { readonly order: number; readonly hits: [MethodResult, ...MethodResult[]] }>();
+	const seenEvidence = new Set<string>();
 	for (const hit of results) {
+		const evidenceKey = `${hit.method}\0${hit.result.source}\0${hit.result.id}`;
+		if (seenEvidence.has(evidenceKey)) continue;
+		seenEvidence.add(evidenceKey);
 		const group = bySource.get(hit.result.source);
 		if (group) group.hits.push(hit);
 		else bySource.set(hit.result.source, { order: bySource.size, hits: [hit] });
 	}
-	return Array.from(bySource.values())
+	const aggregated = Array.from(bySource.values())
 		.map(({ order, hits }) => {
 			const ranked = hits
 				.map((hit, index) => ({ ...hit, index }))
@@ -97,8 +101,15 @@ function aggregateBySource(results: readonly MethodResult[]): RetrievalResult[] 
 				},
 			};
 		})
-		.sort((a, b) => b.result.score - a.result.score || a.order - b.order)
-		.map(({ result }) => result);
+		.sort((a, b) => b.result.score - a.result.score || a.order - b.order);
+	const scores = aggregated.map(({ result }) => result.score);
+	const min = Math.min(...scores);
+	const max = Math.max(...scores);
+	const range = max - min;
+	return aggregated.map(({ result }) => ({
+		...result,
+		score: range > 0 ? (result.score - min) / range : 1,
+	}));
 }
 
 export class ParallelRetriever {

--- a/src/retrieval/merger.ts
+++ b/src/retrieval/merger.ts
@@ -9,6 +9,7 @@ import type {
 
 export interface MergeOptions {
 	topK: number;
+	/** Retained for API compatibility; exact-source aggregation is always enabled. */
 	dedup: boolean;
 }
 
@@ -23,7 +24,7 @@ interface MethodResult {
 
 export class ResultMerger {
 	merge(results: Map<string, RetrievalResult[]>, options: MergeOptions): RetrievalResult[] {
-		const { topK, dedup } = options;
+		const { topK } = options;
 		if (results.size === 0) return [];
 
 		// Normalize scores per method using min-max normalization
@@ -52,14 +53,7 @@ export class ResultMerger {
 			allResults.push(...methodResults.map((result) => ({ method, result })));
 		}
 
-		if (dedup) {
-			return aggregateBySource(allResults).slice(0, topK);
-		}
-
-		return allResults
-			.map(({ result }) => result)
-			.sort((a, b) => b.score - a.score)
-			.slice(0, topK);
+		return aggregateBySource(allResults).slice(0, topK);
 	}
 }
 

--- a/src/retrieval/merger.ts
+++ b/src/retrieval/merger.ts
@@ -12,6 +12,15 @@ export interface MergeOptions {
 	dedup: boolean;
 }
 
+const MAX_AGGREGATION_BONUS = 0.3;
+const MAX_SECONDARY_HITS = 3;
+const SECONDARY_HIT_WEIGHT = 0.15;
+
+interface MethodResult {
+	readonly method: string;
+	readonly result: RetrievalResult;
+}
+
 export class ResultMerger {
 	merge(results: Map<string, RetrievalResult[]>, options: MergeOptions): RetrievalResult[] {
 		const { topK, dedup } = options;
@@ -38,26 +47,58 @@ export class ResultMerger {
 		}
 
 		// Merge all results
-		const allResults: RetrievalResult[] = [];
-		for (const methodResults of normalized.values()) {
-			allResults.push(...methodResults);
+		const allResults: MethodResult[] = [];
+		for (const [method, methodResults] of normalized) {
+			allResults.push(...methodResults.map((result) => ({ method, result })));
 		}
 
 		if (dedup) {
-			// Deduplicate by source — keep highest scoring
-			const bySource = new Map<string, RetrievalResult>();
-			for (const r of allResults) {
-				const existing = bySource.get(r.source);
-				if (!existing || r.score > existing.score) {
-					bySource.set(r.source, r);
-				}
-			}
-			const deduped = Array.from(bySource.values());
-			return deduped.sort((a, b) => b.score - a.score).slice(0, topK);
+			return aggregateBySource(allResults).slice(0, topK);
 		}
 
-		return allResults.sort((a, b) => b.score - a.score).slice(0, topK);
+		return allResults
+			.map(({ result }) => result)
+			.sort((a, b) => b.score - a.score)
+			.slice(0, topK);
 	}
+}
+
+function aggregateBySource(results: readonly MethodResult[]): RetrievalResult[] {
+	const bySource = new Map<string, { readonly order: number; readonly hits: [MethodResult, ...MethodResult[]] }>();
+	for (const hit of results) {
+		const group = bySource.get(hit.result.source);
+		if (group) group.hits.push(hit);
+		else bySource.set(hit.result.source, { order: bySource.size, hits: [hit] });
+	}
+	return Array.from(bySource.values())
+		.map(({ order, hits }) => {
+			const ranked = hits
+				.map((hit, index) => ({ ...hit, index }))
+				.sort((a, b) => {
+					return b.result.score - a.result.score || a.index - b.index;
+				});
+			const representative = ranked[0];
+			if (!representative || ranked.length === 1) {
+				return { order, result: representative?.result ?? hits[0].result };
+			}
+			const bonus = ranked
+				.slice(1, MAX_SECONDARY_HITS + 1)
+				.reduce((sum, hit, index) => sum + hit.result.score / (index + 1), 0);
+			return {
+				order,
+				result: {
+					...representative.result,
+					score: representative.result.score + Math.min(MAX_AGGREGATION_BONUS, bonus * SECONDARY_HIT_WEIGHT),
+					metadata: {
+						...representative.result.metadata,
+						aggregateHitCount: ranked.length,
+						aggregateMethods: Array.from(new Set(ranked.map((hit) => hit.method))).sort(),
+					},
+				},
+			};
+		})
+		.sort((a, b) => b.result.score - a.result.score || a.order - b.order)
+		.map(({ result }) => result);
 }
 
 export class ParallelRetriever {

--- a/test/retrieval/merger.test.ts
+++ b/test/retrieval/merger.test.ts
@@ -35,6 +35,76 @@ describe("ResultMerger", () => {
 		expect(merged[0].id).toBe("a");
 	});
 
+	it("ranks repeated cross-method evidence above a comparable singleton", () => {
+		const merger = new ResultMerger();
+		const repeatedSource = "opaque:document:repeat-7f9c";
+		const singletonSource = "opaque:document:single-4a2d";
+		const results = new Map([
+			[
+				"bm25",
+				[
+					makeResult("single", singletonSource, 0.95),
+					makeResult("repeat-bm25", repeatedSource, 0.94),
+					makeResult("bm25-floor", "opaque:floor:bm25", 0.1),
+				],
+			],
+			[
+				"minsync",
+				[makeResult("repeat-vector", repeatedSource, 0.9), makeResult("vector-floor", "opaque:floor:vector", 0.1)],
+			],
+		]);
+
+		const merged = merger.merge(results, { topK: 5, dedup: true });
+
+		expect(merged.map((result) => result.source).slice(0, 2)).toEqual([repeatedSource, singletonSource]);
+		expect(merged[0].score).toBeGreaterThan(merged[1].score);
+		expect(merged[0].source).toBe(repeatedSource);
+		expect(merged[0].metadata).toMatchObject({
+			aggregateHitCount: 2,
+			aggregateMethods: ["bm25", "minsync"],
+		});
+	});
+
+	it("reinforces several same-method chunks with a bounded diminishing bonus", () => {
+		const merger = new ResultMerger();
+		const repeatedSource = "opaque:document:same-method";
+		const results = new Map([
+			[
+				"bm25",
+				[
+					makeResult("single", "opaque:document:single", 0.96),
+					makeResult("repeat-1", repeatedSource, 0.95),
+					makeResult("repeat-2", repeatedSource, 0.94),
+					makeResult("repeat-3", repeatedSource, 0.93),
+					makeResult("repeat-4", repeatedSource, 0.92),
+					makeResult("repeat-5", repeatedSource, 0.91),
+					makeResult("floor", "opaque:floor", 0.1),
+				],
+			],
+		]);
+
+		const merged = merger.merge(results, { topK: 5, dedup: true });
+		const repeated = merged.find((result) => result.source === repeatedSource);
+
+		expect(merged[0].source).toBe(repeatedSource);
+		expect(repeated?.score).toBeGreaterThan(1);
+		expect(repeated?.score).toBeLessThanOrEqual(1.3);
+		expect(repeated?.metadata.aggregateHitCount).toBe(5);
+		expect(repeated?.id).toBe("repeat-1");
+	});
+
+	it("keeps hit-level behavior unchanged when deduplication is disabled", () => {
+		const merger = new ResultMerger();
+		const results = new Map([
+			["method1", [makeResult("a", "opaque:same", 0.9), makeResult("b", "opaque:same", 0.8)]],
+		]);
+
+		const merged = merger.merge(results, { topK: 10, dedup: false });
+
+		expect(merged).toHaveLength(2);
+		expect(merged.every((result) => result.metadata.aggregateHitCount === undefined)).toBe(true);
+	});
+
 	it("enforces topK limit", () => {
 		const merger = new ResultMerger();
 		const results = new Map([

--- a/test/retrieval/merger.test.ts
+++ b/test/retrieval/merger.test.ts
@@ -120,7 +120,7 @@ describe("ResultMerger", () => {
 		expect(repeated?.score).toBeLessThanOrEqual(1);
 	});
 
-	it("keeps hit-level behavior unchanged when deduplication is disabled", () => {
+	it("always merges exact sources when deduplication is disabled", () => {
 		const merger = new ResultMerger();
 		const results = new Map([
 			["method1", [makeResult("a", "opaque:same", 0.9), makeResult("b", "opaque:same", 0.8)]],
@@ -128,8 +128,15 @@ describe("ResultMerger", () => {
 
 		const merged = merger.merge(results, { topK: 10, dedup: false });
 
-		expect(merged).toHaveLength(2);
-		expect(merged.every((result) => result.metadata.aggregateHitCount === undefined)).toBe(true);
+		expect(merged).toHaveLength(1);
+		expect(merged[0]).toMatchObject({
+			id: "a",
+			source: "opaque:same",
+			metadata: {
+				aggregateHitCount: 2,
+				aggregateMethods: ["method1"],
+			},
+		});
 	});
 
 	it("enforces topK limit", () => {

--- a/test/retrieval/merger.test.ts
+++ b/test/retrieval/merger.test.ts
@@ -58,6 +58,7 @@ describe("ResultMerger", () => {
 
 		expect(merged.map((result) => result.source).slice(0, 2)).toEqual([repeatedSource, singletonSource]);
 		expect(merged[0].score).toBeGreaterThan(merged[1].score);
+		expect(merged[0].score).toBeLessThanOrEqual(1);
 		expect(merged[0].source).toBe(repeatedSource);
 		expect(merged[0].metadata).toMatchObject({
 			aggregateHitCount: 2,
@@ -85,12 +86,38 @@ describe("ResultMerger", () => {
 
 		const merged = merger.merge(results, { topK: 5, dedup: true });
 		const repeated = merged.find((result) => result.source === repeatedSource);
+		const singleton = merged.find((result) => result.source === "opaque:document:single");
 
 		expect(merged[0].source).toBe(repeatedSource);
-		expect(repeated?.score).toBeGreaterThan(1);
-		expect(repeated?.score).toBeLessThanOrEqual(1.3);
+		expect(repeated?.score).toBeGreaterThan(singleton?.score ?? Number.POSITIVE_INFINITY);
+		expect(repeated?.score).toBeLessThanOrEqual(1);
 		expect(repeated?.metadata.aggregateHitCount).toBe(5);
 		expect(repeated?.id).toBe("repeat-1");
+	});
+
+	it("does not reward exact duplicate evidence identities", () => {
+		const merger = new ResultMerger();
+		const repeatedSource = "opaque:document:duplicate";
+		const duplicate = makeResult("same-chunk-id", repeatedSource, 0.9);
+		const results = new Map([
+			[
+				"bm25",
+				[
+					makeResult("single", "opaque:document:single", 0.95),
+					duplicate,
+					{ ...duplicate },
+					{ ...duplicate },
+					makeResult("floor", "opaque:floor", 0.1),
+				],
+			],
+		]);
+
+		const merged = merger.merge(results, { topK: 5, dedup: true });
+		const repeated = merged.find((result) => result.source === repeatedSource);
+
+		expect(merged[0].source).toBe("opaque:document:single");
+		expect(repeated?.metadata.aggregateHitCount).toBeUndefined();
+		expect(repeated?.score).toBeLessThanOrEqual(1);
 	});
 
 	it("keeps hit-level behavior unchanged when deduplication is disabled", () => {


### PR DESCRIPTION
## Summary
- aggregate normalized hits by exact `source` before curation
- always collapse exact-source matches, including legacy `dedup:false` calls
- add a bounded diminishing bonus for corroborating chunks/methods
- preserve representative content and opaque source identity
- retain the `dedup` option in the public type for compatibility without allowing it to disable source grouping

## Evidence
- RED: `dedup:false` returned two hits for the same exact source instead of one aggregate
- GREEN: `bun run test -- test/retrieval/merger.test.ts test/agent/search-all-tool.test.ts test/integration/retrieval-scope-flow.test.ts` (24 passed)
- Main synchronization: merged `main@8a4d08fd`; aggregation + merged MinSync suites passed (42 tests)
- Live E2E: both `dedup:true` and `dedup:false` returned one `opaque:same-source` result with `aggregateHitCount:2` and representative `same-1`; `pass:true`
- Biome 2.5.6: changed files clean
- `git diff --check`: clean

## Local baseline note
The shared local dependency install still reports pre-existing `src/subagents/runtime.ts:969:62 TS2554` during `bun run typecheck`; hosted CI is the authoritative clean-install check for the pushed head.

Closes #1297
