### PR TITLE
fix(legacy): persist absolute vector database paths

### DIFF
--- a/legacy/autorag/evaluator.py
+++ b/legacy/autorag/evaluator.py
@@ -151,6 +151,9 @@ class Evaluator:
 		)
 		yaml_dict = load_yaml_config(yaml_path)
 		vectordb = yaml_dict.get("vectordb", [])
+		for vectordb_config in vectordb:
+			if "path" in vectordb_config:
+				vectordb_config["path"] = os.path.abspath(vectordb_config["path"])
 
 		vectordb_config_path = os.path.join(
 			self.project_dir, "resources", "vectordb.yaml"

--- a/legacy/tests/autorag/test_evaluator.py
+++ b/legacy/tests/autorag/test_evaluator.py
@@ -7,6 +7,7 @@ from shutil import copytree
 
 import pandas as pd
 import pytest
+import yaml
 from llama_index.core.base.llms.types import CompletionResponse
 from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.llms.openai import OpenAI
@@ -58,6 +59,38 @@ def test_evaluator_init(evaluator):
     )
     assert evaluator.qa_data.equals(loaded_qa_data)
     assert evaluator.corpus_data.equals(loaded_corpus_data)
+
+
+def test_start_trial_stores_absolute_vectordb_path(evaluator):
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as config_file:
+        yaml.safe_dump(
+            {
+                "vectordb": [
+                    {
+                        "name": "local",
+                        "db_type": "chroma",
+                        "path": "relative/chroma",
+                    }
+                ],
+                "node_lines": [],
+            },
+            config_file,
+        )
+
+    try:
+        evaluator.start_trial(config_file.name, skip_validation=True)
+    finally:
+        os.unlink(config_file.name)
+
+    with open(
+        os.path.join(evaluator.project_dir, "resources", "vectordb.yaml"),
+        encoding="utf-8",
+    ) as vectordb_file:
+        vectordb_config = yaml.safe_load(vectordb_file)
+
+    assert os.path.isabs(vectordb_config["vectordb"][0]["path"])
 
 
 def test_load_node_line(evaluator):


### PR DESCRIPTION
## Summary
- normalize relative vector database `path` values before writing `resources/vectordb.yaml`
- preserve entries that do not define a local path
- add a regression test through `Evaluator.start_trial()`

## Verification
- `4 passed, 4 warnings` in focused evaluator tests
- Ruff checks passed
- manual driver: `ABSOLUTE=True`, `MISSING_PATH_UNCHANGED=True`

Closes #1113