### PR TITLE
fix(legacy): reject hybrid retrieval top_k lists

### DIFF
--- a/legacy/autorag/schema/node.py
+++ b/legacy/autorag/schema/node.py
@@ -22,6 +22,12 @@ class Node:
 	run_node: Callable = field(init=False)
 
 	def __post_init__(self):
+		if self.node_type == "hybrid_retrieval" and isinstance(
+			self.node_params.get("top_k"), list
+		):
+			raise ValueError(
+				"hybrid_retrieval top_k must be an integer, not a list."
+			)
 		self.run_node = get_support_nodes(self.node_type)
 		if self.run_node is None:
 			raise ValueError(f"Node type {self.node_type} is not supported.")

--- a/legacy/tests/autorag/schema/test_node_schema.py
+++ b/legacy/tests/autorag/schema/test_node_schema.py
@@ -1,3 +1,5 @@
+import pytest
+
 from autorag.nodes.hybridretrieval import HybridRRF, HybridCC
 from autorag.nodes.lexicalretrieval.run import run_lexical_retrieval_node
 from autorag.schema import Node
@@ -77,6 +79,31 @@ def test_from_dict():
     assert len(node.modules) == 2
     assert node.modules[0].module_param == {}
     assert node.modules[1].module_param == {"key2": "value2"}
+
+
+def test_hybrid_retrieval_rejects_top_k_list():
+    node_dict = {
+        "node_type": "hybrid_retrieval",
+        "strategy": {"metrics": ["retrieval_f1"]},
+        "top_k": [3, 5],
+        "modules": [{"module_type": "hybrid_rrf"}],
+    }
+
+    with pytest.raises(ValueError, match="hybrid_retrieval top_k must be an integer"):
+        Node.from_dict(node_dict)
+
+
+def test_hybrid_retrieval_accepts_integer_top_k():
+    node = Node.from_dict(
+        {
+            "node_type": "hybrid_retrieval",
+            "strategy": {"metrics": ["retrieval_f1"]},
+            "top_k": 5,
+            "modules": [{"module_type": "hybrid_rrf"}],
+        }
+    )
+
+    assert node.node_params["top_k"] == 5
 
 
 def test_find_embedding_models():


### PR DESCRIPTION
## Summary
- reject list-valued `top_k` for hybrid retrieval during node configuration parsing
- return a clear validation error instead of failing later in hybrid retrieval
- keep integer `top_k` configurations accepted

## Verification
- `6 passed` in the full node schema test file
- Ruff and `ty check` passed
- manual driver: `REJECTED=True`, `SCALAR_ACCEPTED=True`

Closes #1010