### PR TITLE
perf: cut index and query hot paths (ASCII decode, fingerprint skip, query cache)

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { watch as fsWatch, realpathSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { Agent, type AgentEvent, type AgentMessage, type AgentTool, type Skill } from "@earendil-works/pi-agent-core";
@@ -9,6 +9,7 @@ import { DatasourceAccessContext, type DatasourceAccessContextOptions } from "..
 import { mapDatasourceDiagnostics } from "../datasource/diagnostics.ts";
 import { DatasourceResultFilter } from "../datasource/result-filter.ts";
 import type { DatasourceIndexResult, DatasourceSkill } from "../datasource/types.ts";
+import type { FileLockHandle } from "../filesystem/file-lock.ts";
 import { jikjiFindDiagnostic, jikjiPrepareDiagnostic } from "../jikji/diagnostics.ts";
 import {
 	type JikjiAnswerPack,
@@ -32,6 +33,7 @@ import { RetrievalMemory } from "../memory/memory.ts";
 import { renderMemoryContext } from "../memory/renderer.ts";
 import { type MinSyncSyncResult, MinSyncVectorMethod, type MinSyncVectorMethodOptions } from "../minsync/index.ts";
 import { PARSED_MIRROR_SUBDIR } from "../mirror/paths.ts";
+import { acquireRefreshLock } from "../mirror/refresh-lock.ts";
 import {
 	detectMirrorStaleness,
 	type ParsedMirrorDiagnostic,
@@ -41,7 +43,12 @@ import {
 import { AutoRAGRunLogger } from "../observability/run-log.ts";
 import type { DefaultParserRegistryOptions } from "../parser/index.ts";
 import { ParallelRetriever, ResultMerger } from "../retrieval/merger.ts";
-import { BM25Method, type BM25MethodOptions, type BM25SyncResult } from "../retrieval/methods/bm25.ts";
+import {
+	BM25Method,
+	type BM25MethodOptions,
+	type BM25SyncResult,
+	INDEX_SEMANTICS_VERSION,
+} from "../retrieval/methods/bm25.ts";
 
 import { RetrievalMethodRegistry } from "../retrieval/registry.ts";
 import {
@@ -127,6 +134,12 @@ export type RefreshMethod = "parsed" | "bm25" | "minsync" | "datasources" | "jik
 export interface AutoRAGRefreshOptions {
 	/** Restrict refresh to specific methods. Defaults to all when undefined. */
 	readonly methods?: readonly RefreshMethod[];
+	/**
+	 * Externally held refresh lock to run under. `index rebuild` passes its own handle so the
+	 * deletion and the re-indexing stay inside one transaction. The caller keeps ownership:
+	 * refresh() never releases this lock and asserts it is still held before running.
+	 */
+	readonly lock?: FileLockHandle;
 }
 
 export interface AutoRAGMinSyncRefreshResult {
@@ -139,6 +152,12 @@ export interface AutoRAGRefreshResult extends ParsedMirrorSyncResult {
 	readonly bm25?: BM25SyncResult;
 	readonly minsync?: AutoRAGMinSyncRefreshResult;
 	readonly datasources?: readonly DatasourceIndexResult[];
+	/**
+	 * `"busy"` when a refresh with different parameters was already in flight and this call
+	 * therefore did no work. Optional so existing result producers stay source-compatible; an
+	 * absent value means the refresh ran to completion.
+	 */
+	readonly outcome?: "completed" | "busy";
 }
 
 export interface AutoRAGRefreshComponentStatus {
@@ -258,6 +277,11 @@ export class AutoRAGAgent {
 	private resultCapture: ((details: AutoRAGResultsDetails) => void) | undefined;
 	private autoRefreshTimer: NodeJS.Timeout | undefined;
 	private refreshing = false;
+	/**
+	 * The in-flight refresh transaction, if any. Holds the lock key so a concurrent caller can tell
+	 * "same work, join it" apart from "different work, refuse".
+	 */
+	private refreshInFlight: { readonly key: string; readonly promise: Promise<AutoRAGRefreshResult> } | undefined;
 	private refreshState: RefreshState = {
 		inFlight: false,
 		lastOutcome: "never",
@@ -1091,7 +1115,87 @@ export class AutoRAGAgent {
 		);
 	}
 
+	/**
+	 * Rebuild the local indexes.
+	 *
+	 * The whole pipeline is one transaction. Two refreshes that interleave can otherwise commit a
+	 * BM25 artifact and its fingerprint in different orders, leaving a fingerprint that describes a
+	 * newer mirror than the artifact it points at; the next refresh would then match that
+	 * fingerprint and silently keep the stale artifact. Guarding only the parsed stage is not enough
+	 * because the four downstream stages would still run once per caller.
+	 *
+	 * The guard has two layers because the collisions differ. Within one process, concurrent calls
+	 * with the same parameters join the in-flight run and share its result, and calls with different
+	 * parameters return `outcome: "busy"`. Across processes there is no promise to join, so a
+	 * refresh already running elsewhere makes this call `busy` regardless of parameters. The CLI
+	 * builds a fresh agent per command, so the cross-process layer is the one that matters in
+	 * practice: `autorag watch` in one terminal and `autorag refresh` in another are two processes
+	 * sharing one index directory. `index rebuild` passes an externally held lock via `opts.lock` so
+	 * the deletion and the re-indexing stay one transaction; refresh() then never releases it.
+	 */
 	async refresh(force = false, opts?: AutoRAGRefreshOptions): Promise<AutoRAGRefreshResult> {
+		const key = this.refreshLockKey(force, opts);
+		const inFlight = this.refreshInFlight;
+		if (inFlight) {
+			// Same parameters: join the running transaction rather than duplicating it.
+			if (inFlight.key === key) return inFlight.promise;
+			return this.busyRefreshResult();
+		}
+
+		const externalLock = opts?.lock;
+		const lock = externalLock ?? acquireRefreshLock(this.workspaceProjectRoot);
+		if (!lock) return this.busyRefreshResult();
+		if (externalLock !== undefined) externalLock.assertOwned();
+
+		const promise = this.runRefresh(force, opts).finally(() => {
+			// Both layers are cleared in `finally` so a rejected refresh cannot wedge either one.
+			// An external lock is owned and released by its caller (index rebuild), never here.
+			if (externalLock === undefined) lock.release();
+			if (this.refreshInFlight?.key === key) this.refreshInFlight = undefined;
+		});
+		this.refreshInFlight = { key, promise };
+		return promise;
+	}
+
+	/**
+	 * Identity of a refresh transaction.
+	 *
+	 * Two calls may share a run only when they would perform the same work. Search paths are sorted
+	 * so ordering does not create a spurious mismatch, and the index semantics version is included
+	 * so a semantics bump can never be absorbed into a run started under the old semantics.
+	 */
+	private refreshLockKey(force: boolean, opts?: AutoRAGRefreshOptions): string {
+		const material = JSON.stringify({
+			root: this.workspaceProjectRoot,
+			searchPaths: [...this.searchPaths].sort(),
+			force,
+			methods: opts?.methods ? [...opts.methods].sort() : null,
+			parserOptions: this.parserOptions ?? null,
+			semantics: INDEX_SEMANTICS_VERSION,
+		});
+		return createHash("sha256").update(material, "utf8").digest("hex");
+	}
+
+	/**
+	 * Result for a call rejected because a different refresh holds the transaction.
+	 *
+	 * Every downstream stage is absent rather than zero-valued, so a caller cannot mistake "did not
+	 * run" for "ran and found nothing". The counters are zero because this call performed no scan.
+	 */
+	private busyRefreshResult(): AutoRAGRefreshResult {
+		return {
+			scanned: 0,
+			written: 0,
+			deleted: 0,
+			skipped: 0,
+			indexPath: join(this.workspaceProjectRoot, PARSED_MIRROR_SUBDIR),
+			diagnostics: [],
+			datasources: [],
+			outcome: "busy",
+		};
+	}
+
+	private async runRefresh(force: boolean, opts?: AutoRAGRefreshOptions): Promise<AutoRAGRefreshResult> {
 		const methods = opts?.methods;
 		const allMethods = methods === undefined;
 		const wants = (m: RefreshMethod): boolean => allMethods || (methods as readonly RefreshMethod[]).includes(m);
@@ -1106,7 +1210,7 @@ export class AutoRAGAgent {
 		};
 		try {
 			const summary = needsParsed ? await this.syncParsedMirrors(force) : await this.scanMirrorStaleness();
-			const bm25 = wants("bm25") ? await this.syncBM25() : undefined;
+			const bm25 = wants("bm25") ? await this.syncBM25(force) : undefined;
 			const minsync = wants("minsync") ? await this.syncMinSync() : undefined;
 			const datasources = wants("datasources") ? await this.indexDatasources() : [];
 			const jikji = wants("jikji") ? await this.executeJikjiPrepare() : undefined;
@@ -1140,7 +1244,12 @@ export class AutoRAGAgent {
 						...(minsync.reason !== undefined ? { reason: minsync.reason } : {}),
 					}
 				: undefined;
-			return { ...(bm25 ? { ...summary, bm25 } : summary), minsync: publicMinsync, datasources };
+			return {
+				...(bm25 ? { ...summary, bm25 } : summary),
+				minsync: publicMinsync,
+				datasources,
+				outcome: "completed",
+			};
 		} catch (error) {
 			this.refreshState = {
 				...this.refreshState,
@@ -1310,8 +1419,9 @@ export class AutoRAGAgent {
 		};
 	}
 
-	async syncBM25(): Promise<BM25SyncResult | undefined> {
-		return this.bm25Method?.sync();
+	/** `force` bypasses the fingerprint skip and rebuilds the lexical index unconditionally. */
+	async syncBM25(force = false): Promise<BM25SyncResult | undefined> {
+		return this.bm25Method?.sync({ force });
 	}
 
 	async syncMinSync(): Promise<MinSyncSyncResult | undefined> {

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -3,6 +3,7 @@ import { join, resolve, sep } from "node:path";
 import { AutoRAGAgent, type AutoRAGRefreshResult, type RefreshMethod } from "../../agent/agent.ts";
 import { MINSYNC_SUBDIR } from "../../minsync/paths.ts";
 import { PARSED_MIRROR_SUBDIR } from "../../mirror/paths.ts";
+import { acquireRefreshLock } from "../../mirror/refresh-lock.ts";
 import { BM25_SUBDIR } from "../../retrieval/methods/bm25.ts";
 import { buildAgentOptions, type CliConfig, resolveConfig } from "../config.ts";
 import { renderError, renderIndex } from "../output.ts";
@@ -82,28 +83,67 @@ export async function runIndex(ctx: CommandContext): Promise<number> {
 		}
 	}
 
-	// Remove each existing target. force:true makes this idempotent.
-	for (const target of targets) {
-		rmSync(target, { recursive: true, force: true });
-	}
-
-	if (sub === "reset") {
-		ctx.stdout(renderIndex({ action: "reset", removed: [...targetNames] }, { json: ctx.json }));
-		return 0;
-	}
-
-	// rebuild: re-run a forced refresh with a model-free agent, scoped to methods.
-	let rebuilt: AutoRAGRefreshResult;
-	try {
-		const agent = new AutoRAGAgent(buildAgentOptions(config));
-		rebuilt = await agent.refresh(true, refreshMethods ? { methods: refreshMethods } : undefined);
-	} catch (error) {
-		ctx.stderr(renderError(error, { json: ctx.json }));
+	// Deleting index directories must not overlap a running refresh: that refresh would be writing
+	// artifacts into a subtree being removed underneath it, and could commit a fingerprint for
+	// artifacts that no longer exist. Take the same lock refresh takes, and refuse rather than
+	// queue — a destructive reset should never fire later than the operator expects. For rebuild
+	// the lock is held across the removal AND the re-indexing (`agent.refresh` runs under the same
+	// handle), so no other process can observe the window where the indexes are gone and the
+	// rebuild can never report busy after it has already deleted them.
+	const lock = acquireRefreshLock(config.workspacePath);
+	if (!lock) {
+		ctx.stderr(
+			renderError(new Error("A refresh is already running for this workspace; nothing was reset."), {
+				json: ctx.json,
+			}),
+		);
 		return 1;
 	}
+	try {
+		// Remove each existing target. force:true makes this idempotent.
+		for (const target of targets) {
+			rmSync(target, { recursive: true, force: true });
+		}
 
-	ctx.stdout(renderIndex({ action: "rebuild", removed: [...targetNames], rebuilt }, { json: ctx.json }));
-	return 0;
+		if (sub === "reset") {
+			ctx.stdout(renderIndex({ action: "reset", removed: [...targetNames] }, { json: ctx.json }));
+			return 0;
+		}
+
+		// rebuild: re-run a forced refresh with a model-free agent, scoped to methods, under the
+		// lock this command already holds.
+		let rebuilt: AutoRAGRefreshResult;
+		try {
+			const agent = new AutoRAGAgent(buildAgentOptions(config));
+			rebuilt = await agent.refresh(true, {
+				lock,
+				...(refreshMethods ? { methods: refreshMethods } : {}),
+			});
+		} catch (error) {
+			ctx.stderr(renderError(error, { json: ctx.json }));
+			return 1;
+		}
+
+		// With the external lock a busy outcome is unreachable (the lock is held, so only the
+		// in-process in-flight guard could produce it). If it ever happens, the deletion must not
+		// be reported as success: fail loudly rather than exit 0 with the indexes gone.
+		if (rebuilt.outcome === "busy") {
+			ctx.stderr(
+				renderError(
+					new Error("Rebuild was refused before re-indexing ran; indexes were removed and not rebuilt."),
+					{
+						json: ctx.json,
+					},
+				),
+			);
+			return 1;
+		}
+
+		ctx.stdout(renderIndex({ action: "rebuild", removed: [...targetNames], rebuilt }, { json: ctx.json }));
+		return 0;
+	} finally {
+		lock.release();
+	}
 }
 
 /**

--- a/src/cli/commands/refresh.ts
+++ b/src/cli/commands/refresh.ts
@@ -20,6 +20,11 @@ export async function runRefresh(ctx: CommandContext): Promise<number> {
 		const methods = parseMethodFlag(ctx.flags.method);
 		const result = await agent.refresh(ctx.flags.force === true, methods ? { methods } : undefined);
 		ctx.stdout(renderRefresh(result, { json: ctx.json, debug: ctx.debug }));
+		// An explicit refresh that was refused must not read as success: the index was not updated.
+		// Exit 1 (runtime refusal), the same code `index reset` uses for lock contention; exit 2 is
+		// reserved for usage errors, and the user used the command correctly. `watch` ticks treat
+		// busy as backpressure and are unchanged.
+		if (result.outcome === "busy") return 1;
 		return 0;
 	} catch (error) {
 		ctx.stderr(renderError(error, { json: ctx.json, debug: ctx.debug }));

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -27,7 +27,7 @@ function diagnosticProjection(d: SearchDocumentDiagnostic): {
 
 function refreshEnvelope(result: AutoRAGRefreshResult) {
 	const envelope: Record<string, unknown> = {
-		ok: true,
+		ok: result.outcome !== "busy",
 		counts: {
 			scanned: result.scanned,
 			written: result.written,
@@ -36,6 +36,12 @@ function refreshEnvelope(result: AutoRAGRefreshResult) {
 		},
 		diagnostics: (result.diagnostics ?? []).map(diagnosticProjection),
 	};
+	// A busy refresh did no work. `ok: false` matches the non-zero exit of an explicit `autorag
+	// refresh`; `outcome: "busy"` names the reason, and without it a busy call would read as an
+	// ok with zero counters, indistinguishable from a refresh that ran and found nothing to do.
+	if (result.outcome === "busy") {
+		envelope.outcome = "busy";
+	}
 	if (result.bm25) {
 		envelope.bm25 = {
 			indexedChunks: result.bm25.indexedChunks,
@@ -62,6 +68,10 @@ function refreshEnvelope(result: AutoRAGRefreshResult) {
 
 function renderRefreshHuman(result: AutoRAGRefreshResult, debug: boolean): string {
 	const lines: string[] = [];
+	if (result.outcome === "busy") {
+		// Report the refusal instead of an "ok" with zero counters, which would read as success.
+		return "refresh: busy (another refresh is already running for this workspace; nothing was indexed)";
+	}
 	lines.push("refresh: ok");
 	lines.push(
 		`  counts: scanned=${result.scanned} written=${result.written} deleted=${result.deleted} skipped=${result.skipped}`,

--- a/src/mirror/index-store.ts
+++ b/src/mirror/index-store.ts
@@ -11,6 +11,15 @@ export interface ParsedMirrorEntry {
 	readonly sourceMtimeNs: number;
 	readonly sourceSizeBytes: number;
 	readonly updatedAt: string;
+	/**
+	 * SHA-256 of the normalized parsed markdown written to `outputPath`.
+	 *
+	 * Optional so indexes written before this field existed stay loadable; those entries are
+	 * backfilled by a single mirror read on the next sync. Downstream indexes key their rebuild
+	 * decision on this digest rather than on `updatedAt` or mtime, because an mtime restore or an
+	 * equal-size edit leaves those unchanged while the content differs.
+	 */
+	readonly contentSha256?: string;
 }
 
 export interface ParsedMirrorIndex {
@@ -53,7 +62,8 @@ function isParsedMirrorEntry(value: unknown): value is ParsedMirrorEntry {
 		typeof value.parserName === "string" &&
 		typeof value.sourceMtimeNs === "number" &&
 		typeof value.sourceSizeBytes === "number" &&
-		typeof value.updatedAt === "string"
+		typeof value.updatedAt === "string" &&
+		(value.contentSha256 === undefined || typeof value.contentSha256 === "string")
 	);
 }
 

--- a/src/mirror/paths.ts
+++ b/src/mirror/paths.ts
@@ -1,7 +1,10 @@
 import { createHash } from "node:crypto";
 import { join } from "node:path";
 
-export const PARSED_MIRROR_SUBDIR = join(".autorag", "parsed");
+/** Single source of truth for the workspace-local autorag directory name. */
+export const AUTORAG_DIR = ".autorag";
+
+export const PARSED_MIRROR_SUBDIR = join(AUTORAG_DIR, "parsed");
 export const PARSED_FILES_SUBDIR = "files";
 export const PARSED_INDEX_FILE = "index.json";
 

--- a/src/mirror/refresh-lock.ts
+++ b/src/mirror/refresh-lock.ts
@@ -1,0 +1,101 @@
+import { lstatSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { acquireFileLock, type FileLockHandle } from "../filesystem/file-lock.ts";
+import { AUTORAG_DIR } from "./paths.ts";
+
+/**
+ * Cross-process mutual exclusion for the refresh pipeline.
+ *
+ * An in-process guard is not enough. The CLI builds a fresh agent in a fresh process for every
+ * command, so the realistic collision is `autorag watch` in one terminal and `autorag refresh` in
+ * another: two processes, one index directory. Without a lock on disk they can interleave their
+ * artifact and fingerprint commits, leaving a fingerprint that describes a newer corpus than the
+ * artifact it points at. The next refresh then matches that fingerprint and silently keeps the
+ * stale artifact.
+ *
+ * The locking primitive is `acquireFileLock`, the same one used for the memory store and the pi
+ * models file. It takes a lock directory containing a uniquely named owner marker, so a stale
+ * reaper can only unlink the exact marker it inspected and `rmdir` cannot succeed once a new owner
+ * has installed its own. A hand-rolled read-then-unlink scheme cannot offer that guarantee.
+ */
+
+/**
+ * Lock path for a workspace root: directly under `.autorag`, *not* inside any index directory.
+ *
+ * Placement is load-bearing. `index reset` deletes whole index subtrees with a recursive `rmSync`,
+ * so a lock stored inside one of them would be destroyed by the very operation it must exclude —
+ * the running refresh would keep a handle to a directory that no longer exists and a third process
+ * could then take the "free" lock. `.autorag` itself is never removed by reset, so the lock
+ * survives every scoped reset and stays a single rendezvous point for both writers.
+ */
+export function refreshLockPath(root: string): string {
+	return `${join(root, AUTORAG_DIR, "refresh")}.lock`;
+}
+
+/**
+ * Refresh is not queued behind another refresh: a caller that cannot take the lock is told the
+ * pipeline is busy and returns immediately. Waiting would stack watch ticks behind a long rebuild
+ * for no benefit, since the running refresh already covers the newer corpus.
+ */
+const REFRESH_LOCK_WAIT_TIMEOUT_MS = 0;
+
+/**
+ * How long a lock may sit untouched before a reaper may consider it abandoned.
+ *
+ * The reaper also requires the recorded owner process to be gone, so this bound only decides how
+ * long a *dead* owner's lock lingers; a live owner is never reaped regardless of age. It is set far
+ * above any refresh observed here, where the heaviest cold rebuild on the largest synthetic corpus
+ * finishes in under two seconds. Reclaiming too early would reintroduce the corruption this lock
+ * prevents, so the bias is deliberate.
+ */
+const REFRESH_LOCK_STALE_MS = 10 * 60 * 1000;
+
+export class RefreshBusyError extends Error {
+	constructor() {
+		super("A refresh is already running for this workspace");
+		this.name = "RefreshBusyError";
+	}
+}
+
+/** True when the filesystem entry does not exist. */
+function isMissingEntryError(error: unknown): boolean {
+	return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+/** Take the refresh lock, or return undefined when another refresh already holds it. */
+export function acquireRefreshLock(root: string): FileLockHandle | undefined {
+	// `.autorag` may not exist yet on a first refresh; the lock lives directly under it.
+	mkdirSync(join(root, AUTORAG_DIR), { recursive: true });
+
+	// A refresh lock is a directory containing an owner marker. Anything else at the lock path is a
+	// structural anomaly, not contention: `acquireFileLock`'s legacy-file reaper would unlink a
+	// stale-looking regular file (deleting whatever the user put there), and a regular file that
+	// parses as an owner with a live pid would read as contention forever. Refuse loudly, leave the
+	// entry untouched, and tell the user exactly what to fix.
+	const lockPath = refreshLockPath(root);
+	let stats: ReturnType<typeof lstatSync> | undefined;
+	try {
+		stats = lstatSync(lockPath);
+	} catch (error) {
+		if (!isMissingEntryError(error)) throw error;
+	}
+	if (stats !== undefined && !stats.isDirectory()) {
+		throw new Error(
+			`The refresh lock at ${join(AUTORAG_DIR, "refresh.lock")} exists but is not a lock directory. ` +
+				"A lock is a directory with an owner marker; move the file aside or delete it, then run the command again.",
+		);
+	}
+
+	try {
+		return acquireFileLock(lockPath, {
+			timeoutMs: REFRESH_LOCK_WAIT_TIMEOUT_MS,
+			staleMs: REFRESH_LOCK_STALE_MS,
+			timeoutError: () => new RefreshBusyError(),
+		});
+	} catch (error) {
+		// Contention is the only expected failure. Anything else (permissions, a full disk) is a real
+		// fault and must surface rather than masquerade as a busy pipeline.
+		if (error instanceof RefreshBusyError) return undefined;
+		throw error;
+	}
+}

--- a/src/mirror/sync.ts
+++ b/src/mirror/sync.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { type Dir, existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { opendir, readFile, stat } from "node:fs/promises";
 import { dirname, extname, resolve } from "node:path";
@@ -141,6 +141,8 @@ export async function syncParsedMirrors(options: ParsedMirrorSyncOptions): Promi
 			previousEntry.parserName === parser.name &&
 			existsSync(outputPath);
 
+		let contentSha256 = unchanged ? previousEntry?.contentSha256 : undefined;
+
 		if (!unchanged) {
 			let parsed: ParseOutput;
 			try {
@@ -163,9 +165,18 @@ export async function syncParsedMirrors(options: ParsedMirrorSyncOptions): Promi
 				if (sinceCheckpoint >= MIRROR_CHECKPOINT_EVERY) checkpoint();
 				continue;
 			}
-			writeAtomic(outputPath, normalizeMarkdown(parsed.markdown));
+			const markdown = normalizeMarkdown(parsed.markdown);
+			// The digest is taken from the exact string handed to writeAtomic, so it always describes
+			// the bytes now on disk without re-reading them.
+			contentSha256 = sha256Utf8(markdown);
+			writeAtomic(outputPath, markdown);
 			written += 1;
 			sinceCheckpoint += 1;
+		} else if (contentSha256 === undefined) {
+			// One-time backfill for entries written before contentSha256 existed. Costs one read per
+			// legacy entry on the first sync only; afterwards the digest is carried forward and this
+			// branch is never taken again for that entry.
+			contentSha256 = await backfillContentSha256(outputPath);
 		}
 
 		nextEntries[entry.virtualPath] = {
@@ -176,6 +187,7 @@ export async function syncParsedMirrors(options: ParsedMirrorSyncOptions): Promi
 			sourceMtimeNs: entry.mtimeNs,
 			sourceSizeBytes: entry.sizeBytes,
 			updatedAt: unchanged ? (previousEntry?.updatedAt ?? new Date().toISOString()) : new Date().toISOString(),
+			...(contentSha256 === undefined ? {} : { contentSha256 }),
 		};
 		handledPrevious.add(entry.virtualPath);
 
@@ -298,6 +310,25 @@ async function collectFiles(
 			sizeBytes: Number(fileStat.size),
 			mtimeNs: Number(fileStat.mtimeNs),
 		});
+	}
+}
+
+/** SHA-256 of a UTF-8 string, hex encoded. Matches the on-disk bytes written by `writeAtomic`. */
+function sha256Utf8(content: string): string {
+	return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+/**
+ * Read an existing mirror once to recover its digest.
+ *
+ * Returns `undefined` when the mirror cannot be read; the entry then keeps an absent digest and is
+ * retried on the next sync rather than poisoning the index with a wrong value.
+ */
+async function backfillContentSha256(outputPath: string): Promise<string | undefined> {
+	try {
+		return sha256Utf8(await readFile(outputPath, "utf8"));
+	} catch {
+		return undefined;
 	}
 }
 

--- a/src/parser/text.ts
+++ b/src/parser/text.ts
@@ -1,10 +1,27 @@
 import { detect } from "chardet";
 import iconv from "iconv-lite";
 
+// INDEX_SEMANTIC_REGION_START
+// Text decoding and normalization applied to mirror content before BM25 chunking: the stored
+// artifact contains exactly the text produced here, so a change invalidates every stored index.
+// Guarded by test/bench/index-semantics-guard.test.ts together with the regions in
+// src/retrieval/methods/bm25.ts.
 const WINDOWS_949_LABELS = new Set(["EUC-KR", "ISO-2022-KR", "windows-949", "CP949"]);
 
 export function decodeText(bytes: Uint8Array): string {
 	const buffer = Buffer.from(bytes);
+	if (isPureAscii(bytes)) {
+		// Bytes 0x01-0x7F decode to the same code points under utf8, cp949, and every single-byte
+		// encoding chardet can name, and NFC normalization is the identity on them, so the result
+		// is fixed without consulting chardet. ESC (0x1B) is excluded: chardet can claim
+		// ISO-2022-JP/CN for buffers containing its escape sequences, which iconv-lite cannot
+		// decode, so those bytes must keep the legacy path. Buffers shorter than one 4-byte unit
+		// are excluded too: chardet's UTF-32LE heuristic can claim UTF-32LE for control-character
+		// and DEL bytes, and iconv-lite then drops the incomplete trailing unit, making the legacy
+		// output "". Pure printable ASCII decodes normally ("A"/"AB"/"ABC"), so excluding every
+		// sub-4-byte buffer is just the conservative choice and must keep the legacy path.
+		return iconv.decode(buffer, "ascii");
+	}
 	const utf8 = iconv.decode(buffer, "utf8");
 	if (replacementCount(utf8) > 0) {
 		const cp949 = iconv.decode(buffer, "cp949");
@@ -22,3 +39,14 @@ export function normalizeMarkdown(markdown: string): string {
 function replacementCount(value: string): number {
 	return [...value].filter((character) => character === "\uFFFD").length;
 }
+
+function isPureAscii(bytes: Uint8Array): boolean {
+	if (bytes.length === 0) return true;
+	if (bytes.length < 4) return false;
+	for (let i = 0; i < bytes.length; i += 1) {
+		const byte = bytes[i] as number;
+		if (byte < 0x01 || byte === 0x1b || byte > 0x7f) return false;
+	}
+	return true;
+}
+// INDEX_SEMANTIC_REGION_END

--- a/src/retrieval/methods/bm25.ts
+++ b/src/retrieval/methods/bm25.ts
@@ -1,5 +1,5 @@
-import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { loadMirrorIndex } from "../../mirror/index-store.ts";
 import { normalizeMarkdown } from "../../parser/text.ts";
@@ -27,11 +27,18 @@ export interface BM25MethodOptions {
 	readonly importBinding?: () => Promise<TantivyBinding>;
 }
 
+export interface BM25SyncOptions {
+	/** Rebuild even when the stored fingerprint already matches the current mirror content. */
+	readonly force?: boolean;
+}
+
 export interface BM25SyncResult {
 	readonly indexPath: string;
 	readonly indexedChunks: number;
 	readonly readiness: BM25ReadinessState;
 	readonly engine: BM25Engine;
+	/** True when the rebuild was skipped because the stored fingerprint matched. */
+	readonly skipped?: boolean;
 }
 
 export interface BM25Status {
@@ -41,6 +48,10 @@ export interface BM25Status {
 }
 
 type TantivyBinding = typeof import("@pngwasi/node-tantivy-binding");
+// INDEX_SEMANTIC_REGION_START
+// Persistence schemas: what a stored fallback-index.json and index-fingerprint.json contain and
+// mean. The sidecar records the identity a stored index claims to have been built from, so its
+// shape decides trust as much as the artifact itself.
 
 type IndexedChunk = {
 	readonly id: string;
@@ -54,11 +65,90 @@ type FallbackIndex = {
 	readonly chunks: readonly IndexedChunk[];
 };
 
+type IndexFingerprint = {
+	readonly version: 1;
+	readonly fingerprint: string;
+	readonly engine: Exclude<BM25Engine, "none">;
+	readonly indexedChunks: number;
+	/**
+	 * Byte length of the fallback artifact when it was written.
+	 *
+	 * Skipping a rebuild trusts an artifact it never opens, so a truncated file would otherwise pass
+	 * the existence check and only fail later at query time. Comparing the recorded size costs one
+	 * stat. Absent for the Tantivy engine, whose artifact is a directory.
+	 */
+	readonly artifactBytes?: number;
+};
+// INDEX_SEMANTIC_REGION_END
+
+/** Per-chunk tokenization plus term postings, derived once per built artifact. */
+type PreparedFallback = {
+	readonly entries: readonly { readonly chunk: IndexedChunk; readonly terms: string[] }[];
+	/** term -> positions in `entries`. One entry per chunk containing the term. */
+	readonly postings: ReadonlyMap<string, number[]>;
+	readonly totalTermCount: number;
+};
+
+/** An opened Tantivy index and its searcher, reused while the artifact is unchanged. */
+type PreparedTantivy = {
+	readonly index: ReturnType<TantivyBinding["Index"]["open"]>;
+	readonly searcher: ReturnType<ReturnType<TantivyBinding["Index"]["open"]>["searcher"]>;
+};
+
 export const BM25_SUBDIR = join(".autorag", "bm25");
 const TANTIVY_SUBDIR = "tantivy";
 const FALLBACK_INDEX_FILE = "fallback-index.json";
+const FINGERPRINT_FILE = "index-fingerprint.json";
+/**
+ * Upper bound on the bytes retained by the query-time fallback cache.
+ *
+ * Token count alone does not bound retained memory: the prepared structure also holds the chunk
+ * content strings (2 B/char, plus the lowercased buffer the term views share), the per-term string
+ * objects, and the posting lists. Measured on Bun 1.3.14 with 450k-token corpora of different
+ * shapes - short English tokens, 64-char tokens, Korean, punctuation-heavy, repetitive - a
+ * fresh-process RSS differential retains 88-155 MB for the same token count, so per-token cost
+ * ranges from ~200 B to ~330 B. The estimate in `preparedFallback` covers those measurements as an
+ * upper bound (2 B per content char, 300 B per term occurrence, 8 B per posting, 300 B per unique
+ * term for its posting array and map entry, 100 B per chunk for the entry objects), keeping the
+ * cache near this 60 MB budget: corpora of roughly 150-200k typical tokens. Above it the cache is
+ * not retained and each query recomputes, which is slower but returns identical results.
+ */
+const MAX_CACHED_BYTES = 60_000_000;
 const DEFAULT_TOP_K = 20;
 const MAX_CHUNK_CHARS = 2_400;
+/**
+ * BM25 scoring parameters, hoisted out of `bm25Score` for readability. Scoring runs at query time
+ * against the raw chunks stored in the artifact (retrieveFallback), so tuning these applies to an
+ * existing index immediately. They are deliberately NOT part of the index fingerprint: including
+ * them would force a global rebuild for a change that needs none.
+ */
+const BM25_K1 = 1.2;
+const BM25_B = 0.75;
+
+/**
+ * Bumped whenever the fingerprint material changes: the fingerprint hashes this version, the
+ * chunking constant, and the mirror entries, so a bump invalidates every stored fingerprint and
+ * forces one rebuild.
+ *
+ * What is covered, and how:
+ * - Automatically at runtime: mirror entries (membership, content digest, parser name) and
+ *   MAX_CHUNK_CHARS are hashed into the fingerprint, so they invalidate stored indexes with no
+ *   manual step. INDEX_SEMANTICS_VERSION itself is part of that material.
+ * - Automatically in CI: the INDEX_SEMANTIC_REGION blocks (fallback persistence schema, tantivy
+ *   schema and document construction, fallback serialization/deserialization, chunk creation,
+ *   fingerprint material, chunk-id hashing) in this file, plus normalizeMarkdown in
+ *   src/parser/text.ts, are digested by test/bench/index-semantics-guard.test.ts, which fails
+ *   until this version is bumped or the recorded digest is refreshed.
+ * - Still a manual decision: parser behavior. The mirror index re-parses only when parserName,
+ *   source mtime, or source size changes (src/mirror/sync.ts), so a new parser implementation
+ *   that keeps its name and sees the same source identity is not re-mirrored; a bump here alone
+ *   cannot produce new parser artifacts for BM25 to index.
+ *
+ * Query-time behavior (tokenizer regex, BM25_K1/BM25_B, the scoring formula) is deliberately NOT
+ * covered: it runs against the already-stored raw chunks at query time, so changes apply to
+ * existing artifacts immediately and never require a rebuild.
+ */
+export const INDEX_SEMANTICS_VERSION = 2;
 
 export class BM25UnavailableError extends Error {
 	readonly readiness: BM25ReadinessState;
@@ -77,6 +167,9 @@ export class BM25Method implements RetrievalMethod {
 	private readonly forceEngine: BM25Engine | undefined;
 	private readonly importBinding: () => Promise<TantivyBinding>;
 	private status: BM25Status;
+	/** Derived query-time state, keyed by the fingerprint of the artifact it was derived from. */
+	private fallbackCache: { readonly stamp: string | undefined; readonly prepared: PreparedFallback } | undefined;
+	private tantivyCache: { readonly stamp: string | undefined; readonly prepared: PreparedTantivy } | undefined;
 
 	constructor(options: BM25MethodOptions) {
 		this.root = options.root;
@@ -124,19 +217,50 @@ export class BM25Method implements RetrievalMethod {
 		return this.status;
 	}
 
-	async sync(): Promise<BM25SyncResult> {
+	/**
+	 * Build the lexical index from the parsed mirrors.
+	 *
+	 * The rebuild is skipped when the stored fingerprint already matches the current mirror content
+	 * and the built artifact is still present. Computing the fingerprint reads only the mirror index
+	 * file, so an unchanged refresh never opens a single mirror document.
+	 *
+	 * In auto engine mode a failed Tantivy build commits the fallback artifact (when the fallback
+	 * engine is enabled) and records the fallback engine in the fingerprint, so later non-force
+	 * refreshes skip with `skipped: true` and keep serving the fallback even after Tantivy recovers.
+	 * That is deliberate: the sidecar records the engine the artifact was actually built with, and
+	 * retrying Tantivy on every refresh would rebuild an unchanged workspace. Recovery is explicit:
+	 * `autorag index rebuild` (force), or a config change to `forceEngine: "tantivy"`, which
+	 * changes the fingerprint material and invalidates the stored artifact.
+	 */
+	async sync(options: BM25SyncOptions = {}): Promise<BM25SyncResult> {
 		if (this.status.readiness === "disabled") return this.syncResult(0);
+
+		const fingerprint = this.computeFingerprint();
+		if (!options.force) {
+			const reused = this.reuseExistingIndex(fingerprint);
+			if (reused) return reused;
+		}
+
+		// About to replace the artifact: drop derived state before the old files disappear, so a
+		// cached handle can never outlive the index it was opened against.
+		this.fallbackCache = undefined;
+		this.tantivyCache = undefined;
 		this.status = { readiness: "indexing", engine: this.status.engine };
 		const chunks = loadChunks(this.root);
+
+		// The catch below covers engine selection/build failure only. Committing the chosen artifact
+		// and recording its fingerprint happen after it, exactly once, so a failure to record the
+		// fingerprint can never be mistaken for an engine failure - which would rewrite the artifact
+		// and write the fingerprint twice.
+		let engine: Exclude<BM25Engine, "none">;
 		try {
 			if (this.forceEngine === "typescript-fallback") {
 				this.writeFallbackIndex(chunks);
-				this.status = { readiness: "degraded_fallback", engine: "typescript-fallback" };
-				return this.syncResult(chunks.length);
+				engine = "typescript-fallback";
+			} else {
+				await this.writeTantivyIndex(chunks);
+				engine = "tantivy";
 			}
-			await this.writeTantivyIndex(chunks);
-			this.status = { readiness: "ready", engine: "tantivy" };
-			return this.syncResult(chunks.length);
 		} catch (error) {
 			if (this.fallback === "typescript") {
 				this.writeFallbackIndex(chunks);
@@ -145,6 +269,7 @@ export class BM25Method implements RetrievalMethod {
 					engine: "typescript-fallback",
 					message: error instanceof Error ? error.message : String(error),
 				};
+				this.writeFingerprint(fingerprint, "typescript-fallback", chunks.length);
 				return this.syncResult(chunks.length);
 			}
 			this.status = {
@@ -152,10 +277,147 @@ export class BM25Method implements RetrievalMethod {
 				engine: "none",
 				message: error instanceof Error ? error.message : String(error),
 			};
+			// No fingerprint is written on hard failure, so the next sync retries the build.
 			return this.syncResult(0);
+		}
+
+		if (engine === "tantivy") {
+			this.status = { readiness: "ready", engine: "tantivy" };
+		} else {
+			this.status = { readiness: "degraded_fallback", engine: "typescript-fallback" };
+		}
+		this.writeFingerprint(fingerprint, engine, chunks.length);
+		return this.syncResult(chunks.length);
+	}
+
+	// INDEX_SEMANTIC_REGION_START
+	// Fingerprint material and sidecar trust path: the exact identity a stored index claims to
+	// have been built from, plus how that identity is read, compared, and recorded. Weakening any
+	// of it - the material, the equality check, the engine check, or the artifact-size check -
+	// lets a stale artifact pass the skip and be trusted against new input, so this block is
+	// guarded exactly like the artifact formats above.
+	/**
+	 * Identity of the inputs the index is built from.
+	 *
+	 * Covers mirror membership, per-entry parsed-content digest, the parser that produced it, the
+	 * chunking constant, and this version. Query-time semantics (tokenizer, scoring parameters) are
+	 * deliberately absent: they run against the stored raw chunks at query time, so tuning them
+	 * applies to an existing artifact immediately and never needs a rebuild. Entries whose digest
+	 * is still absent contribute a sentinel so a legacy index can never be mistaken for a
+	 * fingerprinted one.
+	 */
+	private computeFingerprint(): string {
+		const index = loadMirrorIndex(this.root);
+		const entries = Object.values(index.entries)
+			.map((entry) => `${entry.virtualPath}\u0000${entry.contentSha256 ?? "-"}\u0000${entry.parserName}`)
+			.sort();
+		const material = [
+			`semantics:${INDEX_SEMANTICS_VERSION}`,
+			`chunk:${MAX_CHUNK_CHARS}`,
+			`engine:${this.forceEngine ?? "auto"}`,
+			`fallback:${this.fallback}`,
+			`entries:${entries.length}`,
+			...entries,
+		].join("\n");
+		return createHash("sha256").update(material, "utf8").digest("hex");
+	}
+
+	/** Completed result when the on-disk artifact already matches `fingerprint`, else undefined. */
+	private reuseExistingIndex(fingerprint: string): BM25SyncResult | undefined {
+		const stored = this.readFingerprint();
+		if (!stored || stored.fingerprint !== fingerprint) return undefined;
+		if (stored.engine === "tantivy" && existsSync(join(this.tantivyIndexPath(), "meta.json"))) {
+			this.status = { readiness: "ready", engine: "tantivy" };
+			return { ...this.syncResult(stored.indexedChunks), skipped: true };
+		}
+		if (
+			stored.engine === "typescript-fallback" &&
+			this.fallback !== "disabled" &&
+			this.hasFallbackIndex() &&
+			this.fallbackArtifactBytes() === stored.artifactBytes
+		) {
+			this.status = { readiness: "degraded_fallback", engine: "typescript-fallback" };
+			return { ...this.syncResult(stored.indexedChunks), skipped: true };
+		}
+		return undefined;
+	}
+
+	private readFingerprint(): IndexFingerprint | undefined {
+		const path = this.fingerprintPath();
+		if (!existsSync(path)) return undefined;
+		try {
+			const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<IndexFingerprint>;
+			if (parsed.version !== 1) return undefined;
+			if (typeof parsed.fingerprint !== "string" || typeof parsed.indexedChunks !== "number") return undefined;
+			if (parsed.engine !== "tantivy" && parsed.engine !== "typescript-fallback") return undefined;
+			return {
+				version: 1,
+				fingerprint: parsed.fingerprint,
+				engine: parsed.engine,
+				indexedChunks: parsed.indexedChunks,
+				...(typeof parsed.artifactBytes === "number" ? { artifactBytes: parsed.artifactBytes } : {}),
+			};
+		} catch {
+			return undefined;
 		}
 	}
 
+	/**
+	 * Record the fingerprint after the artifact is on disk.
+	 *
+	 * Written tmp-then-rename so a crash mid-write leaves either the old fingerprint or none, never
+	 * a torn one. Ordering matters: the artifact is committed first, so a fingerprint can never
+	 * claim an index that was not built. When the write fails, the stale fingerprint is removed and
+	 * the error propagates: a fresh artifact must never sit under an old fingerprint, because the
+	 * next sync would trust it and skip the rebuild the new artifact needs. A missing fingerprint
+	 * only costs one rebuild next time; a stale one silently serves the wrong index.
+	 */
+	private writeFingerprint(fingerprint: string, engine: Exclude<BM25Engine, "none">, indexedChunks: number): void {
+		const artifactBytes = engine === "typescript-fallback" ? this.fallbackArtifactBytes() : undefined;
+		const payload: IndexFingerprint = {
+			version: 1,
+			fingerprint,
+			engine,
+			indexedChunks,
+			...(artifactBytes === undefined ? {} : { artifactBytes }),
+		};
+		const tmp = join(this.indexPath, `${FINGERPRINT_FILE}.${randomUUID()}.tmp`);
+		try {
+			mkdirSync(this.indexPath, { recursive: true });
+			writeFileSync(tmp, `${JSON.stringify(payload)}\n`);
+			renameSync(tmp, this.fingerprintPath());
+		} catch (error) {
+			// The new fingerprint could not be recorded. Remove whatever occupies the fingerprint
+			// path so no stale identity survives next to the freshly built artifact, then surface
+			// the original error instead of hiding it. Removal is best-effort: if it fails too the
+			// rethrow below still makes the failure loud.
+			try {
+				rmSync(this.fingerprintPath(), { recursive: true, force: true });
+			} catch {
+				// Fall through to the rethrow; the write failure is the primary signal.
+			}
+			throw error;
+		} finally {
+			// A failed write or rename must not leave the tmp behind occupying space (e.g. under
+			// ENOSPC); on success the rename already consumed it. Removal is best-effort so it can
+			// never mask the original error.
+			try {
+				rmSync(tmp, { force: true });
+			} catch {
+				// Fall through; the write failure is the primary signal.
+			}
+		}
+	}
+
+	/** Size of the fallback artifact, or undefined when it cannot be stat'ed. */
+	private fallbackArtifactBytes(): number | undefined {
+		try {
+			return statSync(this.fallbackIndexPath()).size;
+		} catch {
+			return undefined;
+		}
+	}
+	// INDEX_SEMANTIC_REGION_END
 	async retrieve(query: string, options: RetrievalOptions): Promise<RetrievalResult[]> {
 		const trimmedQuery = query.trim();
 		if (trimmedQuery.length === 0) return [];
@@ -176,6 +438,10 @@ export class BM25Method implements RetrievalMethod {
 		throw new BM25UnavailableError("index_missing", "BM25 index has not been built; call refresh() first");
 	}
 
+	// INDEX_SEMANTIC_REGION_START
+	// Tantivy schema, analyzer, and document construction: the stored tantivy index means exactly
+	// what is written here. Adding a field or changing a tokenizerName/indexOption invalidates
+	// every stored index.
 	private async writeTantivyIndex(chunks: readonly IndexedChunk[]): Promise<void> {
 		if (this.forceEngine === "typescript-fallback") throw new Error("Tantivy engine disabled by configuration");
 		let binding: TantivyBinding;
@@ -206,6 +472,7 @@ export class BM25Method implements RetrievalMethod {
 		}
 		writer.commit();
 	}
+	// INDEX_SEMANTIC_REGION_END
 
 	private async retrieveTantivy(
 		queryText: string,
@@ -218,8 +485,19 @@ export class BM25Method implements RetrievalMethod {
 			this.status = { readiness: "index_missing", engine: "none", message: "Tantivy BM25 index is missing" };
 			throw new BM25UnavailableError("index_missing", "Tantivy BM25 index is missing; call refresh() first");
 		}
-		const index = binding.Index.open(indexDir);
-		const searcher = index.searcher();
+		// Opening the index and creating a searcher is per-artifact work, not per-query work. Both are
+		// reused until the fingerprint changes; a searcher observes a fixed commit, so reusing one
+		// returns exactly what a freshly opened one would for the same artifact.
+		const stamp = this.artifactStamp();
+		let prepared = this.tantivyCache?.stamp === stamp ? this.tantivyCache?.prepared : undefined;
+		if (!prepared) {
+			const opened = binding.Index.open(indexDir);
+			prepared = { index: opened, searcher: opened.searcher() };
+			// Without a fingerprint the stamp is undefined and could never change, so a retained
+			// handle would outlive a replacement of the index directory; reopen per query instead.
+			this.tantivyCache = stamp === undefined ? undefined : { stamp, prepared };
+		}
+		const { index, searcher } = prepared;
 		const query = index.parseQueryLenient(queryText, ["content"])[0];
 		const pageSize = scope ? 100 : topK;
 		let offset = 0;
@@ -254,29 +532,89 @@ export class BM25Method implements RetrievalMethod {
 		return results;
 	}
 
+	// INDEX_SEMANTIC_REGION_START
+	// Fallback serialization: the exact bytes of fallback-index.json are decided here.
 	private writeFallbackIndex(chunks: readonly IndexedChunk[]): void {
 		const index: FallbackIndex = { version: 1, chunks };
 		const path = this.fallbackIndexPath();
 		mkdirSync(dirname(path), { recursive: true });
-		writeFileSync(path, `${JSON.stringify(index, null, 2)}\n`);
+		// Written tmp-then-rename, matching src/mirror/sync.ts writeAtomic: a crash mid-write can
+		// never leave a torn artifact, and a read-only directory cannot silently accept an in-place
+		// overwrite of the existing file. The tmp is removed in `finally` so a failed write or
+		// rename (e.g. ENOSPC) cannot leave it behind occupying space; removal failure must not
+		// mask the original error.
+		const tmp = `${path}.${randomUUID()}.tmp`;
+		try {
+			writeFileSync(tmp, `${JSON.stringify(index, null, 2)}\n`);
+			renameSync(tmp, path);
+		} finally {
+			try {
+				rmSync(tmp, { force: true });
+			} catch {
+				// Fall through; the write failure is the primary signal.
+			}
+		}
 	}
+	// INDEX_SEMANTIC_REGION_END
 
 	private retrieveFallback(query: string, topK: number, scope: string | undefined): RetrievalResult[] {
-		const index = this.readFallbackIndex();
 		const queryTerms = tokenize(query);
 		if (queryTerms.length === 0) return [];
-		const scopedChunks = index.chunks.filter((chunk) => matchesVirtualPathScope(chunk.virtualPath, scope));
+		const prepared = this.preparedFallback();
+
+		// Scope selects the subset that defines the corpus statistics. Document frequency and average
+		// length are therefore computed over the scoped subset, exactly as before; only the
+		// per-chunk tokenization is reused instead of being redone on every query.
+		const tokenized =
+			scope === undefined
+				? prepared.entries
+				: prepared.entries.filter(({ chunk }) => matchesVirtualPathScope(chunk.virtualPath, scope));
+
 		const documentFrequencies = new Map<string, number>();
-		const tokenized = scopedChunks.map((chunk) => ({ chunk, terms: tokenize(chunk.content) }));
 		for (const term of new Set(queryTerms)) {
-			documentFrequencies.set(term, tokenized.filter(({ terms }) => terms.includes(term)).length);
+			if (scope === undefined) {
+				// Unscoped: the posting list length is the document frequency.
+				documentFrequencies.set(term, prepared.postings.get(term)?.length ?? 0);
+				continue;
+			}
+			// Scoped: count only postings inside the subset. This visits the term's postings rather
+			// than every chunk, but yields the identical count.
+			let count = 0;
+			for (const position of prepared.postings.get(term) ?? []) {
+				const entry = prepared.entries[position];
+				if (entry && matchesVirtualPathScope(entry.chunk.virtualPath, scope)) count += 1;
+			}
+			documentFrequencies.set(term, count);
 		}
-		const avgLength = tokenized.reduce((sum, entry) => sum + entry.terms.length, 0) / Math.max(tokenized.length, 1);
-		return tokenized
-			.map(({ chunk, terms }) => ({
-				chunk,
-				score: bm25Score(queryTerms, terms, documentFrequencies, tokenized.length, avgLength),
-			}))
+
+		const totalTermCount =
+			scope === undefined ? prepared.totalTermCount : tokenized.reduce((sum, entry) => sum + entry.terms.length, 0);
+		const avgLength = totalTermCount / Math.max(tokenized.length, 1);
+		// Only chunks that contain at least one query term can score above zero: bm25Score skips terms
+		// with zero frequency, and its idf term is positive for every df <= N. Chunks outside the
+		// posting union would therefore score exactly 0 and be dropped by the filter below, so
+		// visiting them changes nothing except cost.
+		const candidates: number[] = [];
+		const seen = new Set<number>();
+		for (const term of new Set(queryTerms)) {
+			for (const position of prepared.postings.get(term) ?? []) {
+				if (seen.has(position)) continue;
+				seen.add(position);
+				const entry = prepared.entries[position];
+				if (!entry) continue;
+				if (scope !== undefined && !matchesVirtualPathScope(entry.chunk.virtualPath, scope)) continue;
+				candidates.push(position);
+			}
+		}
+
+		return candidates
+			.map((position) => {
+				const entry = prepared.entries[position] as { chunk: IndexedChunk; terms: string[] };
+				return {
+					chunk: entry.chunk,
+					score: bm25Score(queryTerms, entry.terms, documentFrequencies, tokenized.length, avgLength),
+				};
+			})
 			.filter((entry) => entry.score > 0)
 			.sort((a, b) => b.score - a.score || a.chunk.virtualPath.localeCompare(b.chunk.virtualPath))
 			.slice(0, topK)
@@ -294,12 +632,72 @@ export class BM25Method implements RetrievalMethod {
 			}));
 	}
 
+	/**
+	 * Tokenized view of the fallback index, reused across queries.
+	 *
+	 * Rebuilt whenever the stored fingerprint changes, so a cache entry can never outlive the index
+	 * it describes. Tokenization is deterministic, so reusing it cannot change a score; it only
+	 * stops the same work from being repeated on every query.
+	 */
+	private preparedFallback(): PreparedFallback {
+		const stamp = this.artifactStamp();
+		const cached = this.fallbackCache;
+		if (cached && cached.stamp === stamp) return cached.prepared;
+
+		const index = this.readFallbackIndex();
+		const entries = index.chunks.map((chunk) => ({ chunk, terms: tokenize(chunk.content) }));
+		const postings = new Map<string, number[]>();
+		let totalTermCount = 0;
+		let contentChars = 0;
+		let postingsCount = 0;
+		for (const [position, entry] of entries.entries()) {
+			totalTermCount += entry.terms.length;
+			contentChars += entry.chunk.content.length;
+			// One posting per distinct term per chunk: the count matches "chunks containing term".
+			for (const term of new Set(entry.terms)) {
+				const list = postings.get(term);
+				if (list) list.push(position);
+				else postings.set(term, [position]);
+				postingsCount += 1;
+			}
+		}
+		const prepared: PreparedFallback = { entries, postings, totalTermCount };
+		// The retention bound is an estimate of the bytes the structure actually pins, not a token
+		// count: content strings and term objects dominate and vary with corpus shape (see
+		// MAX_CACHED_BYTES). Above the bound the structure is used for this query but not retained,
+		// so a large corpus cannot pin tens of megabytes for the process lifetime. Results are
+		// unaffected: the next query simply rebuilds the same structure. Without a fingerprint the
+		// stamp can never change, so a retained entry would outlive the artifact it was derived
+		// from; the cache is not retained either.
+		const estimatedBytes =
+			contentChars * 2 + totalTermCount * 300 + postingsCount * 8 + postings.size * 300 + entries.length * 100;
+		this.fallbackCache = stamp === undefined || estimatedBytes > MAX_CACHED_BYTES ? undefined : { stamp, prepared };
+		return prepared;
+	}
+
+	/**
+	 * Identity of the currently built artifact.
+	 *
+	 * The fingerprint sidecar is authoritative and is rewritten on every successful build, including
+	 * builds performed by another process. Reading it costs one small file read per query, which is
+	 * orders of magnitude cheaper than the work it guards. When no fingerprint exists the stamp is
+	 * `undefined`, and the caches never retain an entry with an undefined stamp: such an entry
+	 * could never be invalidated by an artifact replacement, so a sidecar-less artifact must be
+	 * re-derived on every query.
+	 */
+	private artifactStamp(): string | undefined {
+		return this.readFingerprint()?.fingerprint;
+	}
+
+	// INDEX_SEMANTIC_REGION_START
+	// Fallback deserialization: how a stored fallback-index.json is read back.
 	private readFallbackIndex(): FallbackIndex {
 		const path = this.fallbackIndexPath();
 		if (!existsSync(path)) throw new BM25UnavailableError("index_missing", "BM25 fallback index is missing");
 		const parsed = JSON.parse(readFileSync(path, "utf8")) as FallbackIndex;
 		return parsed.version === 1 && Array.isArray(parsed.chunks) ? parsed : { version: 1, chunks: [] };
 	}
+	// INDEX_SEMANTIC_REGION_END
 
 	private hasFallbackIndex(): boolean {
 		return existsSync(this.fallbackIndexPath());
@@ -307,6 +705,10 @@ export class BM25Method implements RetrievalMethod {
 
 	private tantivyIndexPath(): string {
 		return join(this.indexPath, TANTIVY_SUBDIR);
+	}
+
+	private fingerprintPath(): string {
+		return join(this.indexPath, FINGERPRINT_FILE);
 	}
 
 	private fallbackIndexPath(): string {
@@ -323,6 +725,10 @@ export class BM25Method implements RetrievalMethod {
 	}
 }
 
+// INDEX_SEMANTIC_REGION_START
+// Chunk creation: loadChunks reads each mirror document, normalizes it, and chunkMarkdown splits
+// it into the exact text that is stored in the artifact. `hash` derives the chunk id stored with
+// each chunk, so its truncation length is part of the artifact's meaning.
 function loadChunks(root: string): IndexedChunk[] {
 	const index = loadMirrorIndex(root);
 	const chunks: IndexedChunk[] = [];
@@ -359,6 +765,16 @@ function chunkMarkdown(markdown: string): string[] {
 	if (current.length > 0) chunks.push(current);
 	return chunks;
 }
+function hash(value: string): string {
+	return createHash("sha256").update(value).digest("hex").slice(0, 12);
+}
+// INDEX_SEMANTIC_REGION_END
+
+// Query-time scoring semantics: `tokenize` and `bm25Score` run only at query time against the raw
+// chunks already stored in the artifact (retrieveFallback / preparedFallback). A change here
+// applies to existing artifacts immediately and never invalidates them, so these functions are
+// deliberately kept OUTSIDE the INDEX_SEMANTIC_REGION: guarding them would force a global rebuild
+// for a change that needs none.
 
 function tokenize(value: string): string[] {
 	return value.toLowerCase().match(/[\p{Letter}\p{Number}_]+/gu) ?? [];
@@ -371,8 +787,6 @@ function bm25Score(
 	documentCount: number,
 	avgDocumentLength: number,
 ): number {
-	const k1 = 1.2;
-	const b = 0.75;
 	const termCounts = new Map<string, number>();
 	for (const term of documentTerms) termCounts.set(term, (termCounts.get(term) ?? 0) + 1);
 	let score = 0;
@@ -381,8 +795,9 @@ function bm25Score(
 		if (frequency === 0) continue;
 		const docsWithTerm = documentFrequencies.get(term) ?? 0;
 		const idf = Math.log(1 + (documentCount - docsWithTerm + 0.5) / (docsWithTerm + 0.5));
-		const denominator = frequency + k1 * (1 - b + b * (documentTerms.length / Math.max(avgDocumentLength, 1)));
-		score += idf * ((frequency * (k1 + 1)) / denominator);
+		const lengthNorm = documentTerms.length / Math.max(avgDocumentLength, 1);
+		const denominator = frequency + BM25_K1 * (1 - BM25_B + BM25_B * lengthNorm);
+		score += idf * ((frequency * (BM25_K1 + 1)) / denominator);
 	}
 	return score;
 }
@@ -390,8 +805,4 @@ function bm25Score(
 function firstString(values: unknown[] | undefined): string | undefined {
 	const first = values?.[0];
 	return typeof first === "string" ? first : undefined;
-}
-
-function hash(value: string): string {
-	return createHash("sha256").update(value).digest("hex").slice(0, 12);
 }

--- a/test/bench/README.md
+++ b/test/bench/README.md
@@ -1,0 +1,56 @@
+# Indexing and retrieval benchmarks
+
+Two kinds of file live here.
+
+**`*.test.ts` are correctness gates.** They run in the normal suite (`vitest run`) and assert the
+properties that make the optimisations legitimate: identical results, correct invalidation, no stale
+answers. They are not timing tests and do not assert wall-clock numbers, so they are stable in CI.
+
+**`measure-*.ts` are measurement scripts.** They are not tests and are not collected by vitest
+(`vitest.config.ts` includes only `test/**/*.test.ts`). They print a table and exit. Run them by
+hand when a performance claim needs re-checking; they build their own throwaway corpora under the
+system temp directory and clean up after themselves.
+
+## Correctness gates
+
+| File | What it pins |
+|---|---|
+| `fingerprint-skip.test.ts` | An unchanged rebuild opens no mirror document and does not rewrite the artifact, while the first build provably needs those same documents. Also covers digest backfill for indexes written before `contentSha256` existed, and rebuild-on-change including the size-and-mtime-restored case. |
+| `query-cache-equivalence.test.ts` | Query-time reuse is invisible: repeated queries, a warm instance versus a cold one, and every scope return byte-identical `[id, source, score]`. Mutation cases prove the reuse never serves stale results, including with the fingerprint sidecar missing. Runs against both engines. |
+| `query-cache-bounds.test.ts` | Dropping the cache never changes an answer, the cache is retained below the byte budget (and dropped when the retained-byte estimate exceeds it even far below the old token bound), a missing fingerprint sidecar never pins a stale cache entry, and a rebuild performed by a separate operating system process is observed by a warm reader. |
+| `refresh-lock.test.ts` | `refresh()` is one transaction: concurrent same-parameter calls run the pipeline once and share a result, different-parameter calls are refused without running any downstream stage, artifact and fingerprint stay consistent under twenty rounds of interleaving, and a thrown refresh releases the lock. |
+| `refresh-lock-cross-process.test.ts` | The lock works between operating system processes, which is the collision that actually happens: a held lock refuses a second process, an owner that no longer exists is reclaimed, a live owner is honoured, racing processes leave a consistent artifact, and deterministic controls prove the refusal is the lock's doing (a child is refused while the parent holds the lock and completes after release) and that two concurrent completions are reachable. The racing pair overlaps by construction rather than scheduling luck: both children race on the lock primitive itself, then the winner holds the lock across a file-signal handshake until the loser has attempted its refresh, so the one-completion outcome holds however CI schedules them. |
+| `artifact-integrity.test.ts` | Damaged on-disk state rebuilds instead of skipping: fingerprint deleted, artifact deleted, artifact truncated, fingerprint corrupt, or a different engine requested. |
+| `mirror-sync-equivalence.test.ts` | The serial `syncParsedMirrors()` loop, pinned as an observable contract before it is parallelized: repeat-run determinism, per-corpus-shape counts and diagnostics, virtualPath `localeCompare` ordering independent of creation order, checkpoint-resume without reparsing, and the invariants parallelism must not break (no cross-file contamination, `contentSha256` matches disk bytes, path-opaque diagnostics). |
+
+## Measurement scripts
+
+| File | Command | What it measures |
+|---|---|---|
+| `measure-noop-refresh.ts` | `bun run test/bench/measure-noop-refresh.ts` | Cost of an unchanged BM25 sync across corpus sizes, with the fingerprint skip enabled and disabled. `force: true` reproduces the pre-change path. |
+| `measure-stage-share.ts` | `bun run test/bench/measure-stage-share.ts` | Splits an unchanged refresh into its mirror and BM25 stages, so the end-to-end effect is reported instead of the BM25 stage alone. |
+| `measure-query-cost.ts` | `bun run test/bench/measure-query-cost.ts [tantivy\|typescript-fallback]` | Per-query retrieval cost against corpus size **and query selectivity**. Selectivity is a required axis: a query matching every document exercises a different cost than one matching a handful, and reporting only one of them would misstate any change that narrows the candidate set. |
+| `measure-break-even.ts` | `bun run test/bench/measure-break-even.ts` | How many queries a rebuild must be followed by before query-time reuse pays for itself, reported for a broad and a selective query. Reuse moves work onto the first query after a rebuild, so the honest question is whether the total is lower, not whether later queries are faster. |
+| `measure-decode.ts` | `bun run test/bench/measure-decode.ts` | Per-document `decodeText` cost before and after the pure-ASCII fast path (ASCII / Korean UTF-8 / CP949), the isolated purity-scan cost, and full mirror refresh deltas at two corpus sizes per document shape. The Korean rows are expected to stay at 1x: chardet still runs there, and the scan is the only added cost. |
+
+### Reading the numbers
+
+These run on synthetic corpora, so treat the **shape** of each curve as the result and the absolute
+milliseconds as environment-specific. A cost that grows with corpus size for a query that never
+changes is the signal worth acting on; a flat curve for a selective query is what an index is
+supposed to produce.
+
+`measure-query-cost.ts` defaults to the `tantivy` engine because that is the default when the native
+binding loads. The `typescript-fallback` figures describe the degraded path only.
+
+### `reset-lock.test.ts` (5건)
+
+`index reset`이 refresh lock에 참여함을 고정한다. lock이 잡힌 동안 reset은 센티널 파일을 하나도 지우지 못하고 종료 코드 1로 거부하며, 해제 후에는 정상 삭제된다. 네 번째 케이스는 lock 파일이 reset이 지우는 어떤 디렉터리 안에도 있지 않음을 단언한다 — 배치 회귀 전용이다.
+
+변이 검증: `runIndex`의 lock 획득을 무력화하면 2건 실패, lock 경로를 `parsed/` 안으로 되돌려도 2건 실패.
+
+### `mirror-sync-equivalence.test.ts` (13건)
+
+`syncParsedMirrors()`의 **직렬 루프를 병렬화하기 전에 관찰 가능한 계약으로 고정**하는 안전망이다. 병렬화 이후 이 파일이 그대로 통과하는 것이 완료 조건이다. 고정 대상: (a) 같은 코퍼스를 새 워크스페이스에서 `force: true`로 두 번 돌렸을 때 카운트·진단 전체(순서 포함)·인덱스 필드·미러 바이트의 완전한 결정성, (b) 코퍼스 형태별 덤(신규 전량·일부 변경·일부 삭제·파싱 실패 섞임·크기 상한 초과·빈 코퍼스·중첩 디렉토리), (c) 생성 순서와 무관한 `virtualPath` `localeCompare` 정렬(병렬화 후 가장 깨지기 쉬운 계약), (d) 25개마다 찍히는 체크포인트가 진행 중에 디스크에 남고, 그 후 재동기화가 파서 호출을 한 번도 하지 않음, (e) 병렬화가 깨뜨리면 안 되는 불변식(미러-소스 교차 오염 없음, `contentSha256`과 디스크 바이트 일치, 진단 `source`의 path-opaque). 실행마다 달라지는 필드(`sourceMtimeNs`, `updatedAt`, 절대 경로)는 비교에서 제외하거나 정규화하며, 이유는 테스트 주석에 적혀 있다.
+
+변이 검증: `listCurrentFiles`의 `entries.sort` 제거 → 5건 실패(결정적 순서 포함), `ParseError` catch의 `throw` 전환 → 4건 실패(실패 격리 포함), `deleted-mirror` 진단 push 제거 → 1건 실패, 진단 배열 reverse → 3건 실패(진단 순서 포함).

--- a/test/bench/artifact-integrity.test.ts
+++ b/test/bench/artifact-integrity.test.ts
@@ -1,0 +1,175 @@
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { syncParsedMirrors } from "../../src/mirror/sync.ts";
+import { BM25Method } from "../../src/retrieval/methods/bm25.ts";
+
+/**
+ * Recovery when the on-disk index state is damaged.
+ *
+ * Skipping a rebuild means trusting an artifact without opening it, so every way that trust can be
+ * misplaced needs a defined outcome. The rule these tests pin is simple: when anything about the
+ * stored state is missing or does not match what was recorded, rebuild rather than skip.
+ */
+
+const roots: string[] = [];
+
+function makeWorkspace(documentCount = 6): { root: string; searchPaths: string[] } {
+	const root = mkdtempSync(join(tmpdir(), "autorag-integrity-"));
+	roots.push(root);
+	const docs = join(root, "docs");
+	mkdirSync(docs, { recursive: true });
+	for (let i = 0; i < documentCount; i += 1) {
+		writeFileSync(join(docs, `doc-${i}.md`), `# Document ${i}\n\nRefund approval policy and escalation threshold.\n`);
+	}
+	return { root, searchPaths: [docs] };
+}
+
+function paths(root: string): { fingerprint: string; artifact: string } {
+	return {
+		fingerprint: join(root, ".autorag", "bm25", "index-fingerprint.json"),
+		artifact: join(root, ".autorag", "bm25", "fallback-index.json"),
+	};
+}
+
+async function buildFallback(root: string, searchPaths: string[]): Promise<BM25Method> {
+	await syncParsedMirrors({ root, searchPaths });
+	const method = new BM25Method({ root, forceEngine: "typescript-fallback" });
+	await method.sync();
+	return method;
+}
+
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("artifact integrity", () => {
+	it("rebuilds when only the fingerprint sidecar is deleted", async () => {
+		const { root, searchPaths } = makeWorkspace();
+		const method = await buildFallback(root, searchPaths);
+		expect((await method.sync()).skipped).toBe(true);
+
+		rmSync(paths(root).fingerprint);
+
+		const rebuilt = await method.sync();
+		expect(rebuilt.skipped).toBeUndefined();
+		expect(rebuilt.indexedChunks).toBeGreaterThan(0);
+		expect((await method.retrieve("refund", { topK: 5 })).length).toBeGreaterThan(0);
+	});
+
+	it("rebuilds when only the artifact is deleted", async () => {
+		const { root, searchPaths } = makeWorkspace();
+		const method = await buildFallback(root, searchPaths);
+		expect((await method.sync()).skipped).toBe(true);
+
+		rmSync(paths(root).artifact);
+
+		const rebuilt = await method.sync();
+		expect(rebuilt.skipped).toBeUndefined();
+		expect((await method.retrieve("refund", { topK: 5 })).length).toBeGreaterThan(0);
+	});
+
+	it("rebuilds when the artifact is truncated", async () => {
+		const { root, searchPaths } = makeWorkspace();
+		const method = await buildFallback(root, searchPaths);
+		expect((await method.sync()).skipped).toBe(true);
+
+		// Truncation leaves a file that exists but cannot be parsed. Existence alone would wave it
+		// through and the failure would only surface at query time.
+		const artifact = paths(root).artifact;
+		const original = readFileSync(artifact, "utf8");
+		writeFileSync(artifact, original.slice(0, Math.floor(original.length / 2)));
+
+		const rebuilt = await method.sync();
+		expect(rebuilt.skipped).toBeUndefined();
+		expect((await method.retrieve("refund", { topK: 5 })).length).toBeGreaterThan(0);
+	});
+
+	it("rebuilds when the fingerprint sidecar is corrupt", async () => {
+		const { root, searchPaths } = makeWorkspace();
+		const method = await buildFallback(root, searchPaths);
+		expect((await method.sync()).skipped).toBe(true);
+
+		writeFileSync(paths(root).fingerprint, "{ not valid json");
+
+		const rebuilt = await method.sync();
+		expect(rebuilt.skipped).toBeUndefined();
+		expect((await method.retrieve("refund", { topK: 5 })).length).toBeGreaterThan(0);
+	});
+
+	it("rebuilds when the recorded engine differs from the requested one", async () => {
+		const { root, searchPaths } = makeWorkspace();
+		await buildFallback(root, searchPaths);
+
+		// A different engine means a different artifact, so the stored fingerprint must not be
+		// honoured even though the mirror content is unchanged.
+		const tantivy = new BM25Method({ root, forceEngine: "tantivy" });
+		const rebuilt = await tantivy.sync();
+		expect(rebuilt.skipped).toBeUndefined();
+	});
+	it("never leaves a stale fingerprint beside a freshly built artifact", async () => {
+		const { root, searchPaths } = makeWorkspace();
+		const method = await buildFallback(root, searchPaths);
+		expect((await method.sync()).skipped).toBe(true);
+
+		// Sabotage the fingerprint path: replace the sidecar with a directory so the rename that
+		// commits a new fingerprint is refused (rename over a directory fails). A fingerprint
+		// write failure is a commit failure, not an engine failure, so the rebuild fails loudly
+		// instead of rewriting the artifact and silently retrying the fingerprint.
+		rmSync(paths(root).fingerprint);
+		mkdirSync(paths(root).fingerprint);
+
+		writeFileSync(
+			join(searchPaths[0] as string, "doc-0.md"),
+			"# Changed\n\nEntirely different chargeback content.\n",
+		);
+		await syncParsedMirrors({ root, searchPaths });
+
+		await expect(method.sync()).rejects.toThrow();
+		// The failed commit removed the sabotage and left no sidecar behind, so no stale identity
+		// can claim the fresh artifact; the next sync retries and records the real fingerprint.
+		expect(existsSync(paths(root).fingerprint)).toBe(false);
+
+		const rebuilt = await method.sync();
+		expect(rebuilt.skipped).toBeUndefined();
+		// A real sidecar now describes the artifact.
+		expect(statSync(paths(root).fingerprint).isFile()).toBe(true);
+		expect((await method.retrieve("chargeback", { topK: 5 })).length).toBeGreaterThan(0);
+		// The fingerprint now matches the corpus: the next sync skips instead of rebuilding.
+		expect((await method.sync()).skipped).toBe(true);
+	});
+
+	it("does not commit a new artifact into a read-only index directory", async () => {
+		const { root, searchPaths } = makeWorkspace();
+		const method = await buildFallback(root, searchPaths);
+		expect((await method.sync()).skipped).toBe(true);
+
+		const { fingerprint, artifact } = paths(root);
+		const artifactBefore = readFileSync(artifact);
+		const fingerprintBefore = readFileSync(fingerprint, "utf8");
+
+		// A fresh corpus forces a rebuild. With the directory read-only the rebuild must fail
+		// instead of overwriting the existing artifact in place and leaving the old fingerprint to
+		// claim a new artifact it was never computed for.
+		writeFileSync(
+			join(searchPaths[0] as string, "doc-0.md"),
+			"# Changed\n\nEntirely different chargeback content.\n",
+		);
+		await syncParsedMirrors({ root, searchPaths });
+		chmodSync(join(root, ".autorag", "bm25"), 0o555);
+		try {
+			await expect(method.sync()).rejects.toThrow(/EACCES|permission denied/i);
+		} finally {
+			chmodSync(join(root, ".autorag", "bm25"), 0o755);
+		}
+		// Neither the artifact nor the fingerprint moved: no half-built state was committed.
+		expect(readFileSync(artifact)).toEqual(artifactBefore);
+		expect(readFileSync(fingerprint, "utf8")).toBe(fingerprintBefore);
+
+		// Once writable again, the same refresh completes and serves the new corpus.
+		const rebuilt = await method.sync();
+		expect(rebuilt.skipped).toBeUndefined();
+		expect((await method.retrieve("chargeback", { topK: 5 })).length).toBeGreaterThan(0);
+	});
+});

--- a/test/bench/fingerprint-skip.test.ts
+++ b/test/bench/fingerprint-skip.test.ts
@@ -1,0 +1,238 @@
+import { createHash } from "node:crypto";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	utimesSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadMirrorIndex } from "../../src/mirror/index-store.ts";
+import { syncParsedMirrors } from "../../src/mirror/sync.ts";
+import { BM25Method } from "../../src/retrieval/methods/bm25.ts";
+
+/**
+ * Proof harness for the BM25 fingerprint skip.
+ *
+ * Wall-clock timing cannot show *why* an unchanged refresh became cheaper, so these tests establish
+ * the mechanism directly: an unchanged rebuild must not open a single parsed mirror document, and
+ * must not rewrite the built artifact.
+ */
+
+const roots: string[] = [];
+
+function makeWorkspace(documentCount: number): { root: string; searchPaths: string[] } {
+	const root = mkdtempSync(join(tmpdir(), "autorag-fp-"));
+	roots.push(root);
+	const docs = join(root, "docs");
+	mkdirSync(docs, { recursive: true });
+	for (let i = 0; i < documentCount; i += 1) {
+		const body = Array.from(
+			{ length: 12 },
+			(_, p) => `Paragraph ${p} of document ${i} about refund approval policy.`,
+		).join("\n\n");
+		writeFileSync(join(docs, `doc-${String(i).padStart(4, "0")}.md`), `# Document ${i}\n\n${body}\n`);
+	}
+	return { root, searchPaths: [docs] };
+}
+
+function mirrorFiles(root: string): string[] {
+	// Mirrors are written to .autorag/parsed/files/<sha256>.md; the sibling index.json is metadata.
+	const filesDir = join(root, ".autorag", "parsed", "files");
+	if (!existsSync(filesDir)) return [];
+	return readdirSync(filesDir).map((name) => join(filesDir, name));
+}
+
+/**
+ * Run `fn` with every parsed mirror document unreadable, then restore permissions.
+ *
+ * This is the load-bearing measurement. Instrumenting `fs` does not work here because the modules
+ * under test bind `readFileSync` at import time, so a patched property is never consulted. Denying
+ * read permission proves the property directly: a sync that completes while the mirror documents
+ * cannot be opened provably did not open them.
+ */
+async function withUnreadableMirrors(root: string, fn: () => Promise<void>): Promise<void> {
+	const files = mirrorFiles(root);
+	for (const file of files) chmodSync(file, 0o000);
+	try {
+		await fn();
+	} finally {
+		for (const file of files) chmodSync(file, 0o644);
+	}
+}
+
+/** sha256 of the built artifact, or undefined when it does not exist. */
+function artifactDigest(root: string): string | undefined {
+	const path = join(root, ".autorag", "bm25", "fallback-index.json");
+	if (!existsSync(path)) return undefined;
+	return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function bm25(root: string): BM25Method {
+	// Pin the pure-TypeScript engine so the measurement does not depend on the native binding.
+	return new BM25Method({ root, forceEngine: "typescript-fallback" });
+}
+
+afterEach(() => {
+	for (const root of roots.splice(0)) {
+		try {
+			for (const file of mirrorFiles(root)) chmodSync(file, 0o644);
+		} catch {
+			// Workspace may already be gone or never built; cleanup below still applies.
+		}
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+describe("BM25 fingerprint skip", () => {
+	it("completes an unchanged rebuild without opening any mirror document", async () => {
+		const { root, searchPaths } = makeWorkspace(40);
+		await syncParsedMirrors({ root, searchPaths });
+		const method = bm25(root);
+
+		const first = await method.sync();
+		expect(first.skipped).toBeUndefined();
+		expect(first.indexedChunks).toBeGreaterThan(0);
+
+		// If the skip really avoids mirror reads, revoking read permission changes nothing.
+		await withUnreadableMirrors(root, async () => {
+			const second = await method.sync();
+			expect(second.skipped).toBe(true);
+			expect(second.indexedChunks).toBe(first.indexedChunks);
+		});
+	});
+
+	it("proves the first build does need those same documents", async () => {
+		const { root, searchPaths } = makeWorkspace(8);
+		await syncParsedMirrors({ root, searchPaths });
+		const method = bm25(root);
+
+		// Control for the test above. With no stored fingerprint there is nothing to skip, so the
+		// build must reach for the mirror documents and cannot get past the denied read. The skip
+		// path succeeding under the exact same permissions is therefore evidence about the skip, not
+		// an artifact of the corpus being trivially cheap.
+		await withUnreadableMirrors(root, async () => {
+			await expect(method.sync()).rejects.toThrow(/EACCES|permission denied/i);
+		});
+	});
+
+	it("does not rewrite the built artifact on a skipped rebuild", async () => {
+		const { root, searchPaths } = makeWorkspace(12);
+		await syncParsedMirrors({ root, searchPaths });
+		const method = bm25(root);
+		await method.sync();
+
+		const digestBefore = artifactDigest(root);
+		const mtimeBefore = statSync(join(root, ".autorag", "bm25", "fallback-index.json")).mtimeMs;
+		expect(digestBefore).toBeDefined();
+
+		const skipped = await method.sync();
+		expect(skipped.skipped).toBe(true);
+		expect(artifactDigest(root)).toBe(digestBefore);
+		expect(statSync(join(root, ".autorag", "bm25", "fallback-index.json")).mtimeMs).toBe(mtimeBefore);
+	});
+
+	it("still answers queries identically after a skipped rebuild", async () => {
+		const { root, searchPaths } = makeWorkspace(10);
+		await syncParsedMirrors({ root, searchPaths });
+		const method = bm25(root);
+		await method.sync();
+		const before = await method.retrieve("refund approval policy", { topK: 5 });
+
+		expect((await method.sync()).skipped).toBe(true);
+		const after = await method.retrieve("refund approval policy", { topK: 5 });
+
+		expect(after.length).toBeGreaterThan(0);
+		expect(after.map((r) => r.id)).toEqual(before.map((r) => r.id));
+	});
+
+	it("rebuilds when a document changes", async () => {
+		const { root, searchPaths } = makeWorkspace(5);
+		await syncParsedMirrors({ root, searchPaths });
+		const method = bm25(root);
+		await method.sync();
+		expect((await method.sync()).skipped).toBe(true);
+
+		writeFileSync(
+			join(searchPaths[0] as string, "doc-0000.md"),
+			"# Changed\n\nEntirely different chargeback content.\n",
+		);
+		await syncParsedMirrors({ root, searchPaths });
+
+		expect((await method.sync()).skipped).toBeUndefined();
+		expect((await method.retrieve("chargeback", { topK: 5 })).length).toBeGreaterThan(0);
+	});
+
+	it("rebuilds when content changes but size and mtime are restored", async () => {
+		const { root, searchPaths } = makeWorkspace(3);
+		const target = join(searchPaths[0] as string, "doc-0000.md");
+		const originalBytes = readFileSync(target);
+		const originalStat = statSync(target);
+
+		await syncParsedMirrors({ root, searchPaths });
+		const method = bm25(root);
+		await method.sync();
+		expect((await method.sync()).skipped).toBe(true);
+
+		// Same byte length, restored mtime: size+mtime alone cannot tell these apart.
+		const swapped = Buffer.from(originalBytes);
+		swapped.fill(0x7a, swapped.length - 8, swapped.length - 1);
+		writeFileSync(target, swapped);
+		utimesSync(target, originalStat.atime, originalStat.mtime);
+
+		await syncParsedMirrors({ root, searchPaths, force: true });
+		expect((await method.sync()).skipped).toBeUndefined();
+	});
+
+	it("opens no mirror documents regardless of corpus size", async () => {
+		const small = makeWorkspace(10);
+		const large = makeWorkspace(80);
+		await syncParsedMirrors({ root: small.root, searchPaths: small.searchPaths });
+		await syncParsedMirrors({ root: large.root, searchPaths: large.searchPaths });
+
+		const smallMethod = bm25(small.root);
+		const largeMethod = bm25(large.root);
+		await smallMethod.sync();
+		await largeMethod.sync();
+
+		// Eight times the corpus, and neither skip touches a mirror document.
+		await withUnreadableMirrors(small.root, async () => {
+			expect((await smallMethod.sync()).skipped).toBe(true);
+		});
+		await withUnreadableMirrors(large.root, async () => {
+			expect((await largeMethod.sync()).skipped).toBe(true);
+		});
+	});
+
+	it("backfills a legacy index that has no content digests", async () => {
+		const { root, searchPaths } = makeWorkspace(6);
+		await syncParsedMirrors({ root, searchPaths });
+
+		// Simulate an index written before contentSha256 existed.
+		const indexPath = join(root, ".autorag", "parsed", "index.json");
+		const current = JSON.parse(readFileSync(indexPath, "utf8")) as {
+			version: 1;
+			entries: Record<string, Record<string, unknown>>;
+		};
+		for (const entry of Object.values(current.entries)) delete entry.contentSha256;
+		writeFileSync(indexPath, JSON.stringify(current, null, 2));
+
+		expect(Object.values(loadMirrorIndex(root).entries).every((e) => e.contentSha256 === undefined)).toBe(true);
+
+		await syncParsedMirrors({ root, searchPaths });
+		expect(Object.values(loadMirrorIndex(root).entries).every((e) => typeof e.contentSha256 === "string")).toBe(true);
+
+		// The backfill is one-time: a further sync needs no mirror reads at all.
+		await withUnreadableMirrors(root, async () => {
+			await syncParsedMirrors({ root, searchPaths });
+		});
+		expect(Object.values(loadMirrorIndex(root).entries).every((e) => typeof e.contentSha256 === "string")).toBe(true);
+	});
+});

--- a/test/bench/index-semantics-guard.test.ts
+++ b/test/bench/index-semantics-guard.test.ts
@@ -1,0 +1,784 @@
+import { createHash } from "node:crypto";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AutoRAGAgent } from "../../src/agent/agent.ts";
+import { loadMirrorIndex } from "../../src/mirror/index-store.ts";
+import { syncParsedMirrors } from "../../src/mirror/sync.ts";
+import { BM25Method, INDEX_SEMANTICS_VERSION } from "../../src/retrieval/methods/bm25.ts";
+import type { RetrievalResult } from "../../src/retrieval/types.ts";
+
+/**
+ * Guard and proof harness for the BM25 index-semantics layers.
+ *
+ * The fingerprint skip trusts a stored artifact without opening it, so anything that changes what
+ * an index *means* must invalidate the stored fingerprint or stale results get reused silently.
+ * Two layers close the gap:
+ * - Runtime: mirror entries (membership, content digest, parser name), MAX_CHUNK_CHARS, and
+ *   INDEX_SEMANTICS_VERSION are hashed into the fingerprint, so tuning the chunking constant
+ *   invalidates stored indexes automatically.
+ * - CI: every INDEX_SEMANTIC_REGION block in the guarded sources is digested below in
+ *   deterministic path-sorted order. The guarded sources are src/retrieval/methods/bm25.ts
+ *   (fallback persistence schema, tantivy schema and document construction, fallback
+ *   serialization/deserialization, chunk creation, chunk-id hashing, fingerprint material, and
+ *   the sidecar trust path that decides whether a stored artifact is reused: fingerprint
+ *   computation, equality, engine and artifact-size checks, and fingerprint recording) and
+ *   src/parser/text.ts (decodeText and its helpers, which turn file bytes into the text stored in
+ *   every chunk, and normalizeMarkdown, which shapes that text). Bundling
+ *   bundle and force rebuilds when nothing changed; a CI-time digest of the real files has no such
+ *   problem. The guard fails until the developer bumps INDEX_SEMANTICS_VERSION or consciously
+ *   refreshes the recorded digest for a pure refactor.
+ *
+ * Query-time semantics (tokenize, bm25Score, BM25_K1/BM25_B) are deliberately excluded from both
+ * layers: they run against the raw chunks already stored in the artifact, so a change applies to
+ * existing artifacts immediately and never requires a rebuild. A test below fixes that contract
+ * end to end by swapping the tokenizer regex in a copy of bm25.ts and proving that the artifact is
+ * reused byte-for-byte while the query results change.
+ */
+/**
+ * Tracks artifact commits performed through node:fs during a sync.
+ *
+ * `sync()` must commit the chosen artifact and record its fingerprint exactly once. The mock wraps
+ * only writeFileSync/renameSync, delegating everything else to the real module, so every test in
+ * this file runs against the real filesystem behavior. `renamedDestinations` records every rename
+ * destination so tests can count artifact commits directly.
+ */
+const fsSpy = vi.hoisted(() => ({
+	writeFileSync: undefined as
+		| ((
+				...args: Parameters<typeof import("node:fs").writeFileSync>
+		  ) => ReturnType<typeof import("node:fs").writeFileSync>)
+		| undefined,
+	renameSync: undefined as
+		| ((...args: Parameters<typeof import("node:fs").renameSync>) => ReturnType<typeof import("node:fs").renameSync>)
+		| undefined,
+	renamedDestinations: [] as string[],
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return {
+		...actual,
+		writeFileSync: (...args: Parameters<typeof actual.writeFileSync>) => {
+			if (fsSpy.writeFileSync) return fsSpy.writeFileSync(...args);
+			return actual.writeFileSync(...args);
+		},
+		renameSync: (...args: Parameters<typeof actual.renameSync>) => {
+			fsSpy.renamedDestinations.push(String(args[1]));
+			if (fsSpy.renameSync) return fsSpy.renameSync(...args);
+			return actual.renameSync(...args);
+		},
+	};
+});
+
+const BM25_SOURCE_PATH = fileURLToPath(new URL("../../src/retrieval/methods/bm25.ts", import.meta.url));
+const TEXT_SOURCE_PATH = fileURLToPath(new URL("../../src/parser/text.ts", import.meta.url));
+
+/** Every file the guard digests; `semanticDigest` sorts by path, so the order is deterministic. */
+const GUARDED_SOURCE_PATHS = [BM25_SOURCE_PATH, TEXT_SOURCE_PATH] as const;
+
+const REGION_START_MARKER = "// INDEX_SEMANTIC_REGION_START";
+const REGION_END_MARKER = "// INDEX_SEMANTIC_REGION_END";
+
+/**
+ * Artifact-producing declarations that must live inside a marked region, keyed by the file that
+ * owns them. Each entry is a declaration-only string so call sites elsewhere in the file cannot
+ * satisfy the check.
+ */
+const ARTIFACT_SYMBOLS: Readonly<Record<string, readonly string[]>> = {
+	[BM25_SOURCE_PATH]: [
+		"type IndexedChunk = {",
+		"type FallbackIndex = {",
+		"type IndexFingerprint = {",
+		"private async writeTantivyIndex(",
+		"private writeFallbackIndex(",
+		"private readFallbackIndex(",
+		"private computeFingerprint(",
+		"private reuseExistingIndex(",
+		"private readFingerprint(",
+		"private writeFingerprint(",
+		"private fallbackArtifactBytes(",
+		"function loadChunks(",
+		"function chunkMarkdown(",
+		"function hash(",
+	],
+	[TEXT_SOURCE_PATH]: [
+		"const WINDOWS_949_LABELS =",
+		"function decodeText(",
+		"function normalizeMarkdown(",
+		"function replacementCount(",
+		"function isPureAscii(",
+	],
+};
+
+/** Query-time declarations that must stay OUTSIDE the marked regions. */
+const QUERY_TIME_SYMBOLS = ["function tokenize(", "function bm25Score("] as const;
+
+/**
+ * Version and digest recorded when this test last passed.
+ *
+ * The digest covers every marked INDEX_SEMANTIC_REGION in the guarded sources, concatenated in
+ * path-sorted then document order after normalizing CRLF/CR to LF; INDEX_SEMANTICS_VERSION is what
+ * the runtime fingerprint hashes. A change to either must be a deliberate act - that is the point,
+ * the guard exists to force the decision, not to make it.
+ */
+const RECORDED_SEMANTICS_VERSION = 2;
+const RECORDED_SEMANTIC_DIGEST = "19bfe457904aff62876c66fdd7a35ac739fcd4ce14893a713b976958cc1aed6b";
+
+type GuardedSource = { readonly path: string; readonly source: string };
+
+function readGuardedSources(): GuardedSource[] {
+	return [...GUARDED_SOURCE_PATHS]
+		.sort((a, b) => a.localeCompare(b))
+		.map((path) => ({ path, source: readFileSync(path, "utf8") }));
+}
+
+/**
+ * All marked regions in one source file, in document order, with line endings normalized to LF.
+ * The markers are located with plain string indexes; the guard throws when a marker is missing,
+ * when start/end counts differ, when an end precedes its start, when regions overlap, or when a
+ * region has no content between its markers - so removing or scrambling a marker can never quietly
+ * disable the digest. Every guarded file must satisfy this, or the guard fails.
+ */
+function semanticRegions(source: string, sourcePath: string): string[] {
+	const normalized = source.replaceAll("\r\n", "\n").replaceAll("\r", "\n");
+	const starts: number[] = [];
+	let from = 0;
+	while (from < normalized.length) {
+		const at = normalized.indexOf(REGION_START_MARKER, from);
+		if (at === -1) break;
+		starts.push(at);
+		from = at + REGION_START_MARKER.length;
+	}
+	const ends: number[] = [];
+	from = 0;
+	while (from < normalized.length) {
+		const at = normalized.indexOf(REGION_END_MARKER, from);
+		if (at === -1) break;
+		ends.push(at);
+		from = at + REGION_END_MARKER.length;
+	}
+	if (starts.length === 0) {
+		throw new Error(
+			`Semantic guard: the start marker \`${REGION_START_MARKER}\` is missing from ${sourcePath}. ` +
+				"Restore it above the artifact-producing code; a guard that silently passes after its marker " +
+				"is deleted is worse than one that fails.",
+		);
+	}
+	if (ends.length === 0) {
+		throw new Error(
+			`Semantic guard: the end marker \`${REGION_END_MARKER}\` is missing from ${sourcePath}. ` +
+				"Restore it after the artifact-producing code; a guard that silently passes after its marker " +
+				"is deleted is worse than one that fails.",
+		);
+	}
+	if (starts.length !== ends.length) {
+		throw new Error(
+			`Semantic guard: expected equal marker counts in ${sourcePath}, found ${starts.length} ` +
+				`start markers and ${ends.length} end markers. Every \`${REGION_START_MARKER}\` needs a ` +
+				`matching \`${REGION_END_MARKER}\` after it.`,
+		);
+	}
+	const regions: string[] = [];
+	let previousEnd = -1;
+	for (let i = 0; i < starts.length; i += 1) {
+		const start = starts[i] as number;
+		const end = ends[i] as number;
+		if (end < start) {
+			throw new Error(
+				`Semantic guard: \`${REGION_END_MARKER}\` (marker pair ${i + 1}) precedes its ` +
+					`\`${REGION_START_MARKER}\` in ${sourcePath}. Each region must span its code.`,
+			);
+		}
+		if (start < previousEnd) {
+			throw new Error(
+				`Semantic guard: marked region ${i + 1} in ${sourcePath} starts inside the previous ` +
+					"region. Regions must be sequential, each end marker followed by the next start marker.",
+			);
+		}
+		const region = normalized.slice(start, end + REGION_END_MARKER.length);
+		const body = region.slice(REGION_START_MARKER.length, region.length - REGION_END_MARKER.length);
+		if (body.trim().length === 0) {
+			throw new Error(
+				`Semantic guard: marked region ${i + 1} in ${sourcePath} has no content between its ` +
+					"markers; it must contain the artifact-producing code.",
+			);
+		}
+		regions.push(region);
+		previousEnd = end;
+	}
+	return regions;
+}
+
+function countOccurrences(value: string, needle: string): number {
+	let count = 0;
+	let from = 0;
+	while (from < value.length) {
+		const at = value.indexOf(needle, from);
+		if (at === -1) break;
+		count += 1;
+		from = at + needle.length;
+	}
+	return count;
+}
+
+/**
+ * Digest of every marked region across the guarded sources. Sources are sorted by path so the
+ * result is deterministic regardless of the caller's order; each file is validated independently
+ * (markers present and paired, artifact symbols inside regions, query-time symbols outside), and
+ * any violation in any file throws.
+ */
+function semanticDigest(sources: readonly GuardedSource[]): string {
+	const ordered = [...sources].sort((a, b) => a.path.localeCompare(b.path));
+	const combined: string[] = [];
+	for (const { path, source } of ordered) {
+		const regions = semanticRegions(source, path);
+		const regionText = regions.join("\n");
+		for (const symbol of ARTIFACT_SYMBOLS[path] ?? []) {
+			if (!regionText.includes(symbol)) {
+				throw new Error(
+					`Semantic guard: \`${symbol}\` is missing from the marked regions in ${path}. ` +
+						"Move the declaration between the region markers, or update ARTIFACT_SYMBOLS in this " +
+						"test and bump INDEX_SEMANTICS_VERSION.",
+				);
+			}
+			if (countOccurrences(regionText, symbol) !== countOccurrences(source, symbol)) {
+				throw new Error(
+					`Semantic guard: \`${symbol}\` appears outside the marked regions in ${path}. ` +
+						"Move the declaration inside a region; a copy left outside would silently change the " +
+						"artifact without changing the digest.",
+				);
+			}
+		}
+		for (const symbol of QUERY_TIME_SYMBOLS) {
+			if (regionText.includes(symbol)) {
+				throw new Error(
+					`Semantic guard: \`${symbol}\` is inside a marked region in ${path}. ` +
+						"Query-time code applies to existing artifacts without a rebuild; guarding it would " +
+						"force a global rebuild for every tokenizer or scoring change. Keep it outside the " +
+						"markers.",
+				);
+			}
+		}
+		combined.push(regionText);
+	}
+	return sha256Hex(combined.join("\n"));
+}
+
+it("fails until a semantic change is acknowledged with a version bump", () => {
+	const digest = semanticDigest(readGuardedSources());
+
+	if (digest !== RECORDED_SEMANTIC_DIGEST) {
+		if (INDEX_SEMANTICS_VERSION === RECORDED_SEMANTICS_VERSION) {
+			throw new Error(
+				"Artifact-producing code inside an INDEX_SEMANTIC_REGION changed without a version bump. " +
+					"If the change alters the stored artifact (chunking, schema, serialization), bump " +
+					"INDEX_SEMANTICS_VERSION in src/retrieval/methods/bm25.ts and set " +
+					`RECORDED_SEMANTIC_DIGEST in this test to ${digest}. ` +
+					`If it was a pure refactor, set RECORDED_SEMANTIC_DIGEST to ${digest} only.`,
+			);
+		}
+		throw new Error(
+			"Artifact-producing code changed and INDEX_SEMANTICS_VERSION was bumped. Set " +
+				`RECORDED_SEMANTIC_DIGEST in this test to ${digest}; keep the bump only if the change ` +
+				"really alters the stored artifact.",
+		);
+	}
+	if (INDEX_SEMANTICS_VERSION !== RECORDED_SEMANTICS_VERSION) {
+		throw new Error(
+			"INDEX_SEMANTICS_VERSION changed although no artifact-producing code changed. Revert the bump, " +
+				`or set RECORDED_SEMANTICS_VERSION in this test to ${INDEX_SEMANTICS_VERSION} if it was ` +
+				"deliberate.",
+		);
+	}
+});
+
+describe("semantic region validation", () => {
+	const source = readFileSync(BM25_SOURCE_PATH, "utf8");
+	const allSymbols = [
+		"type IndexedChunk = {",
+		"type FallbackIndex = {",
+		"type IndexFingerprint = {",
+		"private async writeTantivyIndex() {}",
+		"private writeFallbackIndex() {}",
+		"private readFallbackIndex() {}",
+		"private computeFingerprint() {}",
+		"private reuseExistingIndex() {}",
+		"private readFingerprint() {}",
+		"private writeFingerprint() {}",
+		"private fallbackArtifactBytes() {}",
+		"function loadChunks() {}",
+		"function chunkMarkdown() {}",
+		"function hash() {}",
+	].join("\n");
+
+	it("throws when the start marker is missing", () => {
+		const mutated = source.replaceAll(REGION_START_MARKER, "// SEMANTIC_REGION_START_REMOVED");
+		expect(() => semanticRegions(mutated, BM25_SOURCE_PATH)).toThrow(/start marker/);
+	});
+
+	it("throws when the end marker is missing", () => {
+		const mutated = source.replaceAll(REGION_END_MARKER, "// SEMANTIC_REGION_END_REMOVED");
+		expect(() => semanticRegions(mutated, BM25_SOURCE_PATH)).toThrow(/end marker/);
+	});
+
+	it("throws when start and end marker counts differ", () => {
+		const mutated = source.replace(REGION_START_MARKER, `${REGION_START_MARKER}\n${REGION_START_MARKER}`);
+		expect(() => semanticRegions(mutated, BM25_SOURCE_PATH)).toThrow(/expected equal marker counts/);
+	});
+
+	it("throws when an end marker precedes its start marker", () => {
+		const mutated = [
+			REGION_END_MARKER,
+			REGION_START_MARKER,
+			"function loadChunks() {}",
+			REGION_START_MARKER,
+			"function chunkMarkdown() {}",
+			REGION_END_MARKER,
+		].join("\n");
+		expect(() => semanticRegions(mutated, "synthetic.ts")).toThrow(/precedes its/);
+	});
+
+	it("throws when regions overlap", () => {
+		const mutated = [
+			REGION_START_MARKER,
+			"function loadChunks() {}",
+			REGION_START_MARKER,
+			"function chunkMarkdown() {}",
+			REGION_END_MARKER,
+			REGION_END_MARKER,
+		].join("\n");
+		expect(() => semanticRegions(mutated, "synthetic.ts")).toThrow(/starts inside the previous/);
+	});
+
+	it("throws when a region has no content between its markers", () => {
+		const mutated = [
+			REGION_START_MARKER,
+			REGION_END_MARKER,
+			REGION_START_MARKER,
+			"function loadChunks() {}",
+			REGION_END_MARKER,
+		].join("\n");
+		expect(() => semanticRegions(mutated, "synthetic.ts")).toThrow(/no content between its markers/);
+	});
+
+	it("throws when an artifact symbol sits outside the regions", () => {
+		const inside = allSymbols.replace("function loadChunks() {}", "");
+		const mutated = [REGION_START_MARKER, inside, REGION_END_MARKER, "function loadChunks() {}"].join("\n");
+		expect(() => semanticDigest([{ path: BM25_SOURCE_PATH, source: mutated }])).toThrow(
+			/missing from the marked regions/,
+		);
+	});
+
+	it("throws when an artifact symbol is duplicated outside the regions", () => {
+		const mutated = [REGION_START_MARKER, allSymbols, REGION_END_MARKER, "function loadChunks() {}"].join("\n");
+		expect(() => semanticDigest([{ path: BM25_SOURCE_PATH, source: mutated }])).toThrow(
+			/appears outside the marked regions/,
+		);
+	});
+
+	it("throws when a query-time function moves inside a region", () => {
+		const mutated = source.replace(
+			REGION_START_MARKER,
+			`${REGION_START_MARKER}\nfunction tokenize(value: string): string[] { return []; }`,
+		);
+		expect(() => semanticDigest([{ path: BM25_SOURCE_PATH, source: mutated }])).toThrow(/is inside a marked region/);
+	});
+
+	it("digests CRLF and CR line endings identically", () => {
+		const original = semanticDigest([{ path: BM25_SOURCE_PATH, source }]);
+		expect(semanticDigest([{ path: BM25_SOURCE_PATH, source: source.replaceAll("\n", "\r\n") }])).toBe(original);
+		expect(semanticDigest([{ path: BM25_SOURCE_PATH, source: source.replaceAll("\n", "\r") }])).toBe(original);
+	});
+
+	it("throws when text.ts loses its start marker", () => {
+		const textSource = readFileSync(TEXT_SOURCE_PATH, "utf8");
+		const mutated = textSource.replaceAll(REGION_START_MARKER, "// SEMANTIC_REGION_START_REMOVED");
+		expect(() => semanticRegions(mutated, TEXT_SOURCE_PATH)).toThrow(/start marker/);
+	});
+
+	it("throws when text.ts has unmatched region markers", () => {
+		const textSource = readFileSync(TEXT_SOURCE_PATH, "utf8");
+		const mutated = textSource.replace(REGION_END_MARKER, `${REGION_END_MARKER}\n${REGION_END_MARKER}`);
+		expect(() => semanticRegions(mutated, TEXT_SOURCE_PATH)).toThrow(/expected equal marker counts/);
+	});
+
+	it("throws when any guarded file loses its markers entirely", () => {
+		const stripped = readGuardedSources().map(({ path, source }) =>
+			path === TEXT_SOURCE_PATH
+				? { path, source: source.replaceAll(REGION_START_MARKER, "").replaceAll(REGION_END_MARKER, "") }
+				: { path, source },
+		);
+		expect(() => semanticDigest(stripped)).toThrow(/start marker/);
+	});
+
+	it("digests the guarded files in deterministic path order", () => {
+		const sources = readGuardedSources();
+		expect(semanticDigest(sources)).toBe(semanticDigest([...sources].reverse()));
+	});
+});
+
+/**
+ * Each of these replays a reproduced attack on the guard. The attack code is applied to a copy of
+ * the source and must change the guarded digest - i.e. the real guard run would fail - or the
+ * guard is not covering the code the attacker changed. The reverse property (query-time changes
+ * must NOT change the digest) is pinned last, because a change there must never force a rebuild.
+ */
+describe("semantic guard coverage", () => {
+	function digestWith(bm25Source: string, textSource: string): string {
+		return semanticDigest([
+			{ path: BM25_SOURCE_PATH, source: bm25Source },
+			{ path: TEXT_SOURCE_PATH, source: textSource },
+		]);
+	}
+
+	it("fails when the chunk-id hash truncation is changed", () => {
+		const original = readFileSync(BM25_SOURCE_PATH, "utf8");
+		const textSource = readFileSync(TEXT_SOURCE_PATH, "utf8");
+		const mutated = original.replace(".slice(0, 12)", ".slice(0, 8)");
+		expect(mutated).not.toBe(original);
+		expect(digestWith(mutated, textSource)).not.toBe(digestWith(original, textSource));
+	});
+
+	it("fails when normalizeMarkdown normalization is changed", () => {
+		const bm25Source = readFileSync(BM25_SOURCE_PATH, "utf8");
+		const original = readFileSync(TEXT_SOURCE_PATH, "utf8");
+		const mutated = original.replace('markdown.normalize("NFC")', 'markdown.normalize("NFD")');
+		expect(mutated).not.toBe(original);
+		expect(digestWith(bm25Source, mutated)).not.toBe(digestWith(bm25Source, original));
+	});
+
+	it("fails when the fingerprint material drops content digests", () => {
+		const original = readFileSync(BM25_SOURCE_PATH, "utf8");
+		const textSource = readFileSync(TEXT_SOURCE_PATH, "utf8");
+		// This is source text being mutated, not an interpolation: the string has to match the
+		// literal characters in bm25.ts for the mutation to land.
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: matching literal source text
+		const mutated = original.replace('${entry.contentSha256 ?? "-"}\\u0000', "");
+		expect(mutated).not.toBe(original);
+		expect(digestWith(mutated, textSource)).not.toBe(digestWith(original, textSource));
+	});
+	it("fails when the fingerprint equality check in reuseExistingIndex is removed", () => {
+		const original = readFileSync(BM25_SOURCE_PATH, "utf8");
+		const textSource = readFileSync(TEXT_SOURCE_PATH, "utf8");
+		const mutated = original.replace(
+			"if (!stored || stored.fingerprint !== fingerprint) return undefined;",
+			"if (!stored) return undefined;",
+		);
+		expect(mutated).not.toBe(original);
+		expect(digestWith(mutated, textSource)).not.toBe(digestWith(original, textSource));
+	});
+
+	it("fails when reuseExistingIndex always trusts a stored fingerprint", () => {
+		const original = readFileSync(BM25_SOURCE_PATH, "utf8");
+		const textSource = readFileSync(TEXT_SOURCE_PATH, "utf8");
+		const mutated = original.replace("stored.fingerprint !== fingerprint", "false");
+		expect(mutated).not.toBe(original);
+		expect(digestWith(mutated, textSource)).not.toBe(digestWith(original, textSource));
+	});
+
+	it("fails when the fallback artifact size comparison is removed", () => {
+		const original = readFileSync(BM25_SOURCE_PATH, "utf8");
+		const textSource = readFileSync(TEXT_SOURCE_PATH, "utf8");
+		const mutated = original.replace("this.fallbackArtifactBytes() === stored.artifactBytes", "true");
+		expect(mutated).not.toBe(original);
+		expect(digestWith(mutated, textSource)).not.toBe(digestWith(original, textSource));
+	});
+
+	it("passes when only the query-time tokenizer regex is changed", () => {
+		const original = readFileSync(BM25_SOURCE_PATH, "utf8");
+		const textSource = readFileSync(TEXT_SOURCE_PATH, "utf8");
+		const mutated = original.replaceAll("[\\p{Letter}\\p{Number}_]+", "[\\p{Letter}\\p{Number}]+");
+		expect(mutated).not.toBe(original);
+		expect(digestWith(mutated, textSource)).toBe(digestWith(original, textSource));
+	});
+
+	it("fails when a WINDOWS_949_LABELS entry is removed", () => {
+		const original = readFileSync(TEXT_SOURCE_PATH, "utf8");
+		const bm25Source = readFileSync(BM25_SOURCE_PATH, "utf8");
+		const mutated = original.replace('"EUC-KR", "ISO-2022-KR"', '"EUC-KR"');
+		expect(mutated).not.toBe(original);
+		expect(digestWith(bm25Source, mutated)).not.toBe(digestWith(bm25Source, original));
+	});
+
+	it("fails when replacementCount is changed", () => {
+		const original = readFileSync(TEXT_SOURCE_PATH, "utf8");
+		const bm25Source = readFileSync(BM25_SOURCE_PATH, "utf8");
+		const mutated = original.replace('character === "\\uFFFD"', 'character !== "\\uFFFD"');
+		expect(mutated).not.toBe(original);
+		expect(digestWith(bm25Source, mutated)).not.toBe(digestWith(bm25Source, original));
+	});
+
+	it("fails when the decodeText fast-path predicate is loosened", () => {
+		const original = readFileSync(TEXT_SOURCE_PATH, "utf8");
+		const bm25Source = readFileSync(BM25_SOURCE_PATH, "utf8");
+		// Dropping the ESC exclusion would let chardet's ISO-2022-JP/CN detectors claim the buffer.
+		const mutated = original.replace("byte === 0x1b", "byte === 0x1c");
+		expect(mutated).not.toBe(original);
+		expect(digestWith(bm25Source, mutated)).not.toBe(digestWith(bm25Source, original));
+	});
+});
+
+const roots: string[] = [];
+
+function makeWorkspace(documentCount: number): { root: string; searchPaths: string[] } {
+	const root = mkdtempSync(join(tmpdir(), "autorag-semantics-"));
+	roots.push(root);
+	const docs = join(root, "docs");
+	mkdirSync(docs, { recursive: true });
+	for (let i = 0; i < documentCount; i += 1) {
+		writeFileSync(join(docs, `doc-${i}.md`), `# Document ${i}\n\nRefund approval policy and escalation threshold.\n`);
+	}
+	return { root, searchPaths: [docs] };
+}
+
+function makeAgent(root: string, searchPaths: string[]): AutoRAGAgent {
+	return new AutoRAGAgent({
+		// `workspacePath` is what the agent uses as its project root; passing anything else silently
+		// falls back to process.cwd() and writes indexes into the current repository.
+		workspacePath: root,
+		searchPaths,
+		bm25: { forceEngine: "typescript-fallback" },
+		minSync: false,
+	});
+}
+
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function sha256Hex(value: string | Buffer): string {
+	return createHash("sha256").update(value).digest("hex");
+}
+
+/** Numeric value of a top-level `const NAME = value;` declaration, read from disk. */
+function moduleConstant(source: string, name: string): number {
+	const pattern = new RegExp(`^const\\s+${name}\\s*=\\s*([^;]+);`, "m");
+	const match = pattern.exec(source);
+	if (!match) throw new Error(`Module constant \`${name}\` was not found in ${BM25_SOURCE_PATH}.`);
+	const value = Number(match[1].replaceAll("_", ""));
+	if (!Number.isFinite(value)) throw new Error(`Module constant \`${name}\` in ${BM25_SOURCE_PATH} is not a number.`);
+	return value;
+}
+
+/**
+ * Replicate `BM25Method.computeFingerprint` material from the mirror index and the constants read
+ * off disk. The guard test below asserts the replication against the real sidecar, so a change to
+ * the material format fails loudly instead of silently weakening the tamper test.
+ */
+function fingerprintMaterial(root: string, source: string): string {
+	const index = loadMirrorIndex(root);
+	const entries = Object.values(index.entries)
+		.map((entry) => `${entry.virtualPath}\u0000${entry.contentSha256 ?? "-"}\u0000${entry.parserName}`)
+		.sort();
+	return [
+		`semantics:${INDEX_SEMANTICS_VERSION}`,
+		`chunk:${moduleConstant(source, "MAX_CHUNK_CHARS")}`,
+		"engine:typescript-fallback",
+		"fallback:typescript",
+		`entries:${entries.length}`,
+		...entries,
+	].join("\n");
+}
+
+type Sidecar = {
+	readonly version: 1;
+	readonly fingerprint: string;
+	readonly engine: string;
+	readonly indexedChunks: number;
+	readonly artifactBytes?: number;
+};
+
+function sidecarPath(root: string): string {
+	return join(root, ".autorag", "bm25", "index-fingerprint.json");
+}
+
+function readSidecar(root: string): Sidecar {
+	return JSON.parse(readFileSync(sidecarPath(root), "utf8")) as Sidecar;
+}
+
+function writeSidecar(root: string, sidecar: Sidecar): void {
+	writeFileSync(sidecarPath(root), `${JSON.stringify(sidecar)}\n`);
+}
+
+describe("BM25 index semantics guard", () => {
+	it("rebuilds when the stored fingerprint was built with different chunking parameters", async () => {
+		const { root, searchPaths } = makeWorkspace(5);
+		const agent = makeAgent(root, searchPaths);
+		const first = await agent.refresh(true);
+		expect(first.outcome).toBe("completed");
+		expect(first.bm25?.skipped).toBeUndefined();
+		expect(first.bm25?.indexedChunks).toBeGreaterThan(0);
+
+		const source = readFileSync(BM25_SOURCE_PATH, "utf8");
+		const material = fingerprintMaterial(root, source);
+		const stored = readSidecar(root);
+		// The replication must describe the real fingerprint, or the tamper below proves nothing.
+		expect(stored.fingerprint).toBe(sha256Hex(material));
+
+		// Forge the sidecar a developer would leave behind after tuning MAX_CHUNK_CHARS without a
+		// rebuild: same corpus, same entries, different chunking material.
+		const tampered = material.replace(/^chunk:.*$/m, "chunk:1200");
+		expect(tampered).not.toBe(material);
+		writeSidecar(root, { ...stored, fingerprint: sha256Hex(tampered) });
+
+		const second = await agent.refresh(false);
+		expect(second.outcome).toBe("completed");
+		expect(second.bm25?.skipped).toBeUndefined();
+		expect(second.bm25?.indexedChunks).toBe(first.bm25?.indexedChunks);
+		expect(readSidecar(root).fingerprint).toBe(sha256Hex(material));
+	});
+
+	it("still skips the rebuild when nothing changed", async () => {
+		const { root, searchPaths } = makeWorkspace(6);
+		const agent = makeAgent(root, searchPaths);
+		const first = await agent.refresh(true);
+		expect(first.outcome).toBe("completed");
+		expect(first.bm25?.skipped).toBeUndefined();
+		expect(first.bm25?.indexedChunks).toBeGreaterThan(0);
+
+		const artifactPath = join(root, ".autorag", "bm25", "fallback-index.json");
+		const digestBefore = sha256Hex(readFileSync(artifactPath));
+		const mtimeBefore = statSync(artifactPath).mtimeMs;
+
+		const second = await agent.refresh(false);
+		expect(second.outcome).toBe("completed");
+		expect(second.bm25?.skipped).toBe(true);
+		expect(second.bm25?.indexedChunks).toBe(first.bm25?.indexedChunks);
+		expect(sha256Hex(readFileSync(artifactPath))).toBe(digestBefore);
+		expect(statSync(artifactPath).mtimeMs).toBe(mtimeBefore);
+	});
+
+	it("applies a query-time tokenizer change to the stored artifact without a rebuild", async () => {
+		const root = mkdtempSync(join(tmpdir(), "autorag-semantics-"));
+		roots.push(root);
+		const docs = join(root, "docs");
+		mkdirSync(docs, { recursive: true });
+		writeFileSync(join(docs, "tokenizer-probe.md"), "alpha_beta gamma\n");
+		const searchPaths = [docs];
+
+		const agent = makeAgent(root, searchPaths);
+		const first = await agent.refresh(true);
+		expect(first.outcome).toBe("completed");
+		expect(first.bm25?.skipped).toBeUndefined();
+		expect(first.bm25?.indexedChunks).toBe(1);
+
+		const artifactPath = join(root, ".autorag", "bm25", "fallback-index.json");
+		const artifactBefore = readFileSync(artifactPath);
+		const mtimeBeforeMs = statSync(artifactPath).mtimeMs;
+		const fingerprintBefore = readSidecar(root).fingerprint;
+
+		// The stock tokenizer keeps `_`, so `alpha_beta` is one token and `alpha` matches nothing.
+		expect(await agent.retrieve("alpha", { topK: 10 })).toEqual([]);
+
+		// A second module graph with different tokenizer semantics is needed. The real bm25.ts
+		// cannot be mutated in place: vitest run-mode caches transforms by module id, so a changed
+		// file would still be served stale after vi.resetModules(). Copy src/ instead and swap the
+		// tokenizer regex in the copy; it resolves the same node_modules and behaves identically
+		// except for the tokenizer.
+		const originalSource = readFileSync(BM25_SOURCE_PATH, "utf8");
+		const mutatedSource = originalSource.replaceAll("[\\p{Letter}\\p{Number}_]+", "[\\p{Letter}\\p{Number}]+");
+		expect(mutatedSource).not.toBe(originalSource);
+		const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+		const mutationRoot = mkdtempSync(join(repoRoot, ".semantics-mutation-"));
+		roots.push(mutationRoot);
+		cpSync(join(repoRoot, "src"), join(mutationRoot, "src"), { recursive: true });
+		writeFileSync(join(mutationRoot, "src", "retrieval", "methods", "bm25.ts"), mutatedSource);
+		try {
+			vi.resetModules();
+			const { AutoRAGAgent: MutatedAgent } = await import(
+				pathToFileURL(join(mutationRoot, "src", "agent", "agent.ts")).href
+			);
+			const mutated = new MutatedAgent({
+				workspacePath: root,
+				searchPaths,
+				bm25: { forceEngine: "typescript-fallback" },
+				minSync: false,
+			});
+			const second = await mutated.refresh(false);
+			expect(second.outcome).toBe("completed");
+			// Tokenization is query-time, so the fingerprint is unchanged and the artifact is reused.
+			expect(second.bm25?.skipped).toBe(true);
+			expect(readSidecar(root).fingerprint).toBe(fingerprintBefore);
+			expect(statSync(artifactPath).mtimeMs).toBe(mtimeBeforeMs);
+			expect(readFileSync(artifactPath)).toEqual(artifactBefore);
+			// Dropping `_` splits `alpha_beta` into `alpha` + `beta`, so the same stored artifact now
+			// answers `alpha` without any rebuild.
+			const results = await mutated.retrieve("alpha", { topK: 10 });
+			expect(results.length).toBeGreaterThan(0);
+			expect(results.some((result: RetrievalResult) => result.content.includes("alpha_beta"))).toBe(true);
+		} finally {
+			rmSync(mutationRoot, { recursive: true, force: true });
+		}
+	});
+});
+/**
+ * `sync()` must commit the chosen artifact and record its fingerprint exactly once. A fingerprint
+ * that fails to record is a commit failure, not an engine failure: it must surface loudly and must
+ * never trigger the engine fallback path, which would rewrite the artifact (and for a tantivy
+ * success would write a fallback artifact that was never chosen).
+ */
+describe("BM25 sync commit-once behavior", () => {
+	function commitCount(pathSuffix: string): number {
+		return fsSpy.renamedDestinations.filter((destination) => destination.endsWith(pathSuffix)).length;
+	}
+
+	it("commits the fallback artifact exactly once when the fingerprint write fails", async () => {
+		const root = mkdtempSync(join(tmpdir(), "autorag-semantics-"));
+		roots.push(root);
+		const docs = join(root, "docs");
+		mkdirSync(docs, { recursive: true });
+		writeFileSync(join(docs, "doc-0.md"), "# Document 0\n\nRefund approval policy and escalation threshold.\n");
+		await syncParsedMirrors({ root, searchPaths: [docs] });
+		const method = new BM25Method({ root, forceEngine: "typescript-fallback" });
+		await method.sync();
+		expect(method.getStatus().engine).toBe("typescript-fallback");
+
+		// Sabotage the fingerprint commit: renaming over a directory fails, so writeFingerprint
+		// throws after the fallback artifact was already committed.
+		const fingerprintPath = join(root, ".autorag", "bm25", "index-fingerprint.json");
+		rmSync(fingerprintPath);
+		mkdirSync(fingerprintPath);
+		writeFileSync(join(docs, "doc-0.md"), "# Changed\n\nEntirely different chargeback content.\n");
+		await syncParsedMirrors({ root, searchPaths: [docs] });
+
+		fsSpy.renamedDestinations.length = 0;
+		await expect(method.sync()).rejects.toThrow();
+		// The old code mistook the fingerprint failure for an engine failure and committed the
+		// artifact a second time; the new code commits exactly once and surfaces the failure.
+		expect(commitCount("fallback-index.json")).toBe(1);
+		// The sabotage was cleared by the fingerprint write cleanup, so the next sync retries.
+		expect(existsSync(fingerprintPath)).toBe(false);
+		const retried = await method.sync();
+		expect(retried.skipped).toBeUndefined();
+		expect((await method.retrieve("chargeback", { topK: 5 })).length).toBeGreaterThan(0);
+		expect((await method.sync()).skipped).toBe(true);
+	});
+
+	it("does not write a fallback artifact when a tantivy build succeeded but its fingerprint commit failed", async () => {
+		const root = mkdtempSync(join(tmpdir(), "autorag-semantics-"));
+		roots.push(root);
+		const docs = join(root, "docs");
+		mkdirSync(docs, { recursive: true });
+		writeFileSync(join(docs, "doc-0.md"), "# Document 0\n\nRefund approval policy and escalation threshold.\n");
+		await syncParsedMirrors({ root, searchPaths: [docs] });
+		const method = new BM25Method({ root, forceEngine: "tantivy" });
+		await method.sync();
+		expect(method.getStatus().engine).toBe("tantivy");
+
+		const fingerprintPath = join(root, ".autorag", "bm25", "index-fingerprint.json");
+		rmSync(fingerprintPath);
+		mkdirSync(fingerprintPath);
+		writeFileSync(join(docs, "doc-0.md"), "# Changed\n\nEntirely different chargeback content.\n");
+		await syncParsedMirrors({ root, searchPaths: [docs] });
+
+		fsSpy.renamedDestinations.length = 0;
+		await expect(method.sync()).rejects.toThrow();
+		// The tantivy artifact is the chosen one, so the engine fallback path must not be entered:
+		// no fallback artifact may be committed and no rename may target it.
+		expect(commitCount("fallback-index.json")).toBe(0);
+		expect(existsSync(join(root, ".autorag", "bm25", "fallback-index.json"))).toBe(false);
+	});
+});

--- a/test/bench/measure-break-even.ts
+++ b/test/bench/measure-break-even.ts
@@ -1,0 +1,119 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { syncParsedMirrors } from "../../src/mirror/sync.ts";
+import { BM25Method } from "../../src/retrieval/methods/bm25.ts";
+
+/**
+ * How many queries a rebuild must be followed by before query-time reuse pays for itself.
+ *
+ * Reusing derived state moves work from every query onto the first one after a rebuild, so the
+ * honest question is not "are later queries faster" but "is the total lower". With `cold` the first
+ * query after a rebuild, `warm` the steady-state query, and `old` the pre-change per-query cost,
+ * reuse wins once `n * old > cold + n * warm`, i.e. `n > cold / (old - warm)`.
+ *
+ * `old` is measured on the same corpus by dropping the derived state before every query, which is
+ * exactly the work the pre-change code did per query.
+ *
+ * The answer depends on how selective the query is, so both extremes are reported. A broad query
+ * matches every chunk, so reuse saves only the tokenization. A selective query matches a handful,
+ * so reuse also skips scoring the rest of the corpus. Quoting one number without the other would
+ * misstate the trade.
+ */
+
+const BROAD = "refund approval policy";
+const SELECTIVE = "zephyrine";
+
+function buildCorpus(documentCount: number): { root: string; searchPaths: string[] } {
+	const root = mkdtempSync(join(tmpdir(), "autorag-be-"));
+	const docs = join(root, "docs");
+	mkdirSync(docs, { recursive: true });
+	for (let i = 0; i < documentCount; i += 1) {
+		const body = Array.from(
+			{ length: 40 },
+			(_, p) =>
+				`Paragraph ${p} of document ${i}. Refund approval policy, chargeback evidence retention, escalation threshold review.`,
+		).join("\n\n");
+		// The selective term is planted in exactly two documents regardless of corpus size, which is
+		// the best case for candidate narrowing and is labelled as such in the output.
+		const rare = i < 2 ? "\n\nzephyrine appears here.\n" : "";
+		writeFileSync(join(docs, `doc-${i}.md`), `# Document ${i}\n\n${body}${rare}\n`);
+	}
+	return { root, searchPaths: [docs] };
+}
+
+function median(values: number[]): number {
+	const sorted = [...values].sort((a, b) => a - b);
+	return sorted[Math.floor(sorted.length / 2)] as number;
+}
+
+/** Force the next query to rebuild derived state, reproducing the pre-change per-query cost. */
+function dropCache(method: BM25Method): void {
+	(method as unknown as { fallbackCache: unknown }).fallbackCache = undefined;
+}
+
+const rows: Record<string, number | string>[] = [];
+
+for (const size of [100, 400, 1600]) {
+	const { root, searchPaths } = buildCorpus(size);
+	try {
+		await syncParsedMirrors({ root, searchPaths });
+		const method = new BM25Method({ root, forceEngine: "typescript-fallback" });
+		const built = await method.sync();
+
+		for (const [label, query] of [
+			["broad", BROAD],
+			["selective", SELECTIVE],
+		] as const) {
+			// cold: the first query after a rebuild, which also builds the derived state.
+			dropCache(method);
+			let started = performance.now();
+			await method.retrieve(query, { topK: 10 });
+			const cold = performance.now() - started;
+
+			// warm: steady state with the derived state already built.
+			const warmSamples: number[] = [];
+			for (let i = 0; i < 20; i += 1) {
+				started = performance.now();
+				await method.retrieve(query, { topK: 10 });
+				warmSamples.push(performance.now() - started);
+			}
+			const warm = median(warmSamples);
+
+			// old: derived state discarded before every query, reproducing the pre-change cost.
+			const oldSamples: number[] = [];
+			for (let i = 0; i < 10; i += 1) {
+				dropCache(method);
+				started = performance.now();
+				await method.retrieve(query, { topK: 10 });
+				oldSamples.push(performance.now() - started);
+			}
+			const old = median(oldSamples);
+
+			const breakEven = cold / (old - warm);
+			rows.push({
+				documents: size,
+				chunks: built.indexedChunks,
+				query: label,
+				coldMs: +cold.toFixed(2),
+				warmMs: +warm.toFixed(3),
+				oldMs: +old.toFixed(2),
+				breakEvenQueries: +breakEven.toFixed(2),
+				breakEvenWhole: Math.max(1, Math.ceil(breakEven)),
+			});
+		}
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+}
+
+console.log("\n| documents | chunks | query | cold (ms) | warm (ms) | old (ms) | break-even | whole queries |");
+console.log("|---|---|---|---|---|---|---|---|");
+for (const r of rows) {
+	console.log(
+		`| ${r.documents} | ${r.chunks} | ${r.query} | ${r.coldMs} | ${r.warmMs} | ${r.oldMs} | ${r.breakEvenQueries} | ${r.breakEvenWhole} |`,
+	);
+}
+console.log("\nThe selective row is the best case for candidate narrowing: the term is planted in");
+console.log("exactly two documents regardless of corpus size. The broad row matches every chunk.");
+console.log(`JSON: ${JSON.stringify(rows)}`);

--- a/test/bench/measure-decode.ts
+++ b/test/bench/measure-decode.ts
@@ -1,0 +1,181 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detect } from "chardet";
+import iconv from "iconv-lite";
+import { syncParsedMirrors } from "../../src/mirror/sync.ts";
+import { type ParseInput, type ParseOutput, Parser, ParserRegistry } from "../../src/parser/index.ts";
+import { decodeText } from "../../src/parser/text.ts";
+
+/**
+ * Measures the decodeText fast path against the pre-change implementation.
+ *
+ * Table 1: per-document decode cost for the three document shapes that matter (pure ASCII,
+ * Korean UTF-8, Korean CP949), before (legacy copy of git HEAD) and after (current source), plus
+ * the two ingredients of the ASCII fast path in isolation (the purity scan and the ASCII iconv
+ * decode). chardet's detect() was measured at ~670-710us on these shapes, which is what the fast
+ * path must avoid.
+ *
+ * Table 2: full mirror refresh (syncParsedMirrors, serial schedule, force) at two corpus sizes for
+ * ASCII and Korean corpora, legacy decode versus current decode. decodeText runs only in the
+ * mirror parse stage, so the delta here is the whole-refresh delta; the BM25 stage is untouched by
+ * this change.
+ */
+
+const WINDOWS_949_LABELS = new Set(["EUC-KR", "ISO-2022-KR", "windows-949", "CP949"]);
+
+/** Copy of the pre-fast-path decodeText (git HEAD of src/parser/text.ts). */
+function legacyDecodeText(bytes: Uint8Array): string {
+	const buffer = Buffer.from(bytes);
+	const utf8 = iconv.decode(buffer, "utf8");
+	if (legacyReplacementCount(utf8) > 0) {
+		const cp949 = iconv.decode(buffer, "cp949");
+		if (legacyReplacementCount(cp949) < legacyReplacementCount(utf8)) return cp949.normalize("NFC");
+	}
+	const detected = detect(buffer);
+	const encoding = detected && WINDOWS_949_LABELS.has(detected) ? "cp949" : (detected ?? "utf8");
+	return iconv.decode(buffer, encoding).normalize("NFC");
+}
+
+function legacyReplacementCount(value: string): number {
+	return [...value].filter((character) => character === "\uFFFD").length;
+}
+
+/** The fast-path purity scan in isolation (copy of the predicate in src/parser/text.ts). */
+function isPureAsciiScan(bytes: Uint8Array): boolean {
+	if (bytes.length === 0) return true;
+	if (bytes.length < 4) return false;
+	for (let i = 0; i < bytes.length; i += 1) {
+		const byte = bytes[i] as number;
+		if (byte < 0x01 || byte === 0x1b || byte > 0x7f) return false;
+	}
+	return true;
+}
+
+function median(times: readonly number[]): number {
+	const sorted = [...times].sort((a, b) => a - b);
+	return sorted[Math.floor(sorted.length / 2)] as number;
+}
+
+/** Median microseconds per call over `rounds` batches of `iterations` calls each. */
+function measurePerCall(fn: () => string, rounds: number, iterations: number): number {
+	const times: number[] = [];
+	for (let round = 0; round < rounds; round += 1) {
+		const started = performance.now();
+		for (let i = 0; i < iterations; i += 1) fn();
+		times.push(((performance.now() - started) * 1000) / iterations);
+	}
+	return Number(median(times).toFixed(1));
+}
+
+const asciiDoc = Buffer.from(
+	"# Document 0\n\nRefund approval policy and escalation threshold.\nQuarterly chargeback report.\n".repeat(46),
+);
+const koreanText = [
+	"# 문서 제목\n\n환불 정책과 승인 절차에 대한 안내입니다.\n",
+	"매 분기마다 차지백 보고서를 작성하고, 승인 임계값을 검토합니다.\n",
+	"고객 지원 팀은 접수된 문의를 우선순위에 따라 처리합니다.\n",
+].join("\n");
+const koreanUtf8Doc = Buffer.from(koreanText.repeat(22), "utf8");
+const koreanCp949Doc = iconv.encode(koreanText.repeat(22), "cp949");
+
+const docs = [
+	{ label: "ASCII 4KB", bytes: asciiDoc },
+	{ label: "Korean UTF-8 5.5KB", bytes: koreanUtf8Doc },
+	{ label: "Korean CP949 5.5KB", bytes: koreanCp949Doc },
+] as const;
+
+console.log("| document type | bytes | legacy decode (us) | new decode (us) | speedup |");
+console.log("|---|---|---|---|---|");
+const decodeRows: Record<string, number | string>[] = [];
+for (const doc of docs) {
+	const legacy = measurePerCall(() => legacyDecodeText(doc.bytes), 5, 200);
+	const current = measurePerCall(() => decodeText(doc.bytes), 5, 200);
+	decodeRows.push({
+		doc: doc.label,
+		bytes: doc.bytes.length,
+		legacyUs: legacy,
+		newUs: current,
+		speedup: Number((legacy / current).toFixed(1)),
+	});
+	console.log(`| ${doc.label} | ${doc.bytes.length} | ${legacy} | ${current} | ${(legacy / current).toFixed(2)}x |`);
+}
+
+// The two ingredients of the ASCII fast path, isolated, so the scan cost itself is on record.
+const scanUs = measurePerCall(() => (isPureAsciiScan(asciiDoc) ? "x" : "y"), 5, 2000);
+const asciiDecodeUs = measurePerCall(() => iconv.decode(asciiDoc, "ascii"), 5, 2000);
+console.log(`\nASCII fast-path ingredients: purity scan ${scanUs}us, ascii iconv decode ${asciiDecodeUs}us (4KB doc)`);
+
+interface Corpus {
+	readonly root: string;
+	readonly docs: string;
+}
+
+function buildCorpus(documentCount: number, body: Buffer): Corpus {
+	const root = mkdtempSync(join(tmpdir(), "autorag-measure-decode-"));
+	const docs = join(root, "docs");
+	mkdirSync(docs, { recursive: true });
+	for (let i = 0; i < documentCount; i += 1) {
+		writeFileSync(join(docs, `doc-${String(i).padStart(5, "0")}.md`), body);
+	}
+	return { root, docs };
+}
+
+class DecodeParser extends Parser {
+	readonly name = "plain-text";
+	readonly extensions = [".md"] as const;
+	readonly decode: (bytes: Uint8Array) => string;
+
+	constructor(decode: (bytes: Uint8Array) => string) {
+		super();
+		this.decode = decode;
+	}
+
+	async parse(input: ParseInput): Promise<ParseOutput> {
+		return { markdown: this.decode(input.bytes) };
+	}
+}
+
+async function medianRefreshMs(
+	root: string,
+	docs: string,
+	decode: (bytes: Uint8Array) => string,
+	samples: number,
+): Promise<number> {
+	const times: number[] = [];
+	for (let i = 0; i < samples; i += 1) {
+		const started = performance.now();
+		await syncParsedMirrors({
+			root,
+			searchPaths: [docs],
+			registry: new ParserRegistry([new DecodeParser(decode)]),
+			force: true,
+		});
+		times.push(performance.now() - started);
+	}
+	return Number(median(times).toFixed(0));
+}
+
+console.log("\n| corpus | legacy refresh (ms) | new refresh (ms) | delta |");
+console.log("|---|---|---|---|");
+const refreshRows: Record<string, number | string>[] = [];
+for (const [label, body] of [
+	["ASCII 4KB x100", asciiDoc],
+	["ASCII 4KB x400", asciiDoc],
+	["Korean UTF-8 5.5KB x100", koreanUtf8Doc],
+	["Korean UTF-8 5.5KB x400", koreanUtf8Doc],
+] as const) {
+	const count = label.includes("x400") ? 400 : 100;
+	const sized = buildCorpus(count, body);
+	try {
+		const legacy = await medianRefreshMs(sized.root, sized.docs, legacyDecodeText, 3);
+		const current = await medianRefreshMs(sized.root, sized.docs, decodeText, 3);
+		const delta = Number((((current - legacy) / legacy) * 100).toFixed(1));
+		refreshRows.push({ corpus: label, legacyMs: legacy, newMs: current, deltaPct: delta });
+		console.log(`| ${label} | ${legacy} | ${current} | ${delta >= 0 ? "+" : ""}${delta}% |`);
+	} finally {
+		rmSync(sized.root, { recursive: true, force: true });
+	}
+}
+
+console.log(`\nJSON: ${JSON.stringify({ decodeRows, scanUs, asciiDecodeUs, refreshRows })}`);

--- a/test/bench/measure-noop-refresh.ts
+++ b/test/bench/measure-noop-refresh.ts
@@ -1,0 +1,88 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { syncParsedMirrors } from "../../src/mirror/sync.ts";
+import { BM25Method } from "../../src/retrieval/methods/bm25.ts";
+
+/**
+ * Measures the cost of an unchanged ("noop") BM25 sync across corpus sizes, with the fingerprint
+ * skip enabled and disabled, so the two curves can be compared directly.
+ *
+ * `force: true` reproduces the pre-change behaviour exactly: it takes the same code path the old
+ * unconditional `sync()` took (loadChunks over every mirror, then a full artifact rewrite).
+ */
+
+type Row = {
+	readonly documents: number;
+	readonly chunks: number;
+	readonly beforeMs: number;
+	readonly afterMs: number;
+	readonly speedup: number;
+};
+
+function buildCorpus(documentCount: number): { root: string; searchPaths: string[] } {
+	const root = mkdtempSync(join(tmpdir(), "autorag-bench-"));
+	const docs = join(root, "docs");
+	mkdirSync(docs, { recursive: true });
+	for (let i = 0; i < documentCount; i += 1) {
+		const body = Array.from(
+			{ length: 40 },
+			(_, p) => `Paragraph ${p} of document ${i}. Refund approval policy and chargeback evidence retention.`,
+		).join("\n\n");
+		writeFileSync(join(docs, `doc-${String(i).padStart(5, "0")}.md`), `# Document ${i}\n\n${body}\n`);
+	}
+	return { root, searchPaths: [docs] };
+}
+
+async function median(samples: number, fn: () => Promise<void>): Promise<number> {
+	const times: number[] = [];
+	for (let i = 0; i < samples; i += 1) {
+		const started = performance.now();
+		await fn();
+		times.push(performance.now() - started);
+	}
+	times.sort((a, b) => a - b);
+	return times[Math.floor(times.length / 2)] as number;
+}
+
+async function measure(documentCount: number, samples: number): Promise<Row> {
+	const { root, searchPaths } = buildCorpus(documentCount);
+	try {
+		await syncParsedMirrors({ root, searchPaths });
+		const method = new BM25Method({ root, forceEngine: "typescript-fallback" });
+		const built = await method.sync();
+
+		// force:true = the old unconditional path. force:false = the new fingerprint skip.
+		const beforeMs = await median(samples, async () => {
+			await method.sync({ force: true });
+		});
+		const afterMs = await median(samples, async () => {
+			await method.sync();
+		});
+
+		return {
+			documents: documentCount,
+			chunks: built.indexedChunks,
+			beforeMs,
+			afterMs,
+			speedup: beforeMs / afterMs,
+		};
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+}
+
+const sizes = [50, 200, 800, 2000];
+const rows: Row[] = [];
+for (const size of sizes) {
+	rows.push(await measure(size, 5));
+}
+
+console.log("\n| documents | chunks | before (noop, ms) | after (noop, ms) | speedup |");
+console.log("|---|---|---|---|---|");
+for (const row of rows) {
+	console.log(
+		`| ${row.documents} | ${row.chunks} | ${row.beforeMs.toFixed(1)} | ${row.afterMs.toFixed(2)} | ${row.speedup.toFixed(0)}x |`,
+	);
+}
+console.log(`\nJSON: ${JSON.stringify(rows)}`);

--- a/test/bench/measure-query-cost.ts
+++ b/test/bench/measure-query-cost.ts
@@ -1,0 +1,94 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { syncParsedMirrors } from "../../src/mirror/sync.ts";
+import { BM25Method } from "../../src/retrieval/methods/bm25.ts";
+
+/**
+ * Measures per-query retrieval cost against corpus size and query selectivity.
+ *
+ * Selectivity is a required dimension. A query that matches every document exercises a different
+ * code path cost than one that matches a handful, and reporting only one of them would misstate the
+ * effect of any change that narrows the candidate set.
+ */
+
+/** Matches essentially every chunk: shared boilerplate present in all documents. */
+const BROAD = ["refund approval policy", "chargeback evidence retention", "escalation threshold review"];
+
+/** Matches a handful of chunks: identifiers planted in a small number of documents. */
+const SELECTIVE = ["zephyrine", "quokkaledger", "vermillionclause"];
+
+function buildCorpus(documentCount: number): { root: string; searchPaths: string[] } {
+	const root = mkdtempSync(join(tmpdir(), "autorag-q-"));
+	const docs = join(root, "docs");
+	mkdirSync(docs, { recursive: true });
+	for (let i = 0; i < documentCount; i += 1) {
+		const shared = Array.from(
+			{ length: 40 },
+			(_, p) =>
+				`Paragraph ${p} of document ${i}. Refund approval policy, chargeback evidence retention, escalation threshold review, quarterly settlement report.`,
+		).join("\n\n");
+		// Plant each rare term in exactly two documents, independent of corpus size.
+		const rare =
+			i < 2
+				? "\n\nzephyrine appears here.\n"
+				: i < 4
+					? "\n\nquokkaledger appears here.\n"
+					: i < 6
+						? "\n\nvermillionclause appears here.\n"
+						: "";
+		writeFileSync(join(docs, `doc-${String(i).padStart(5, "0")}.md`), `# Document ${i}\n\n${shared}${rare}\n`);
+	}
+	return { root, searchPaths: [docs] };
+}
+
+async function medianQueryMs(method: BM25Method, queries: readonly string[], rounds: number): Promise<number> {
+	const times: number[] = [];
+	for (let r = 0; r < rounds; r += 1) {
+		for (const q of queries) {
+			const started = performance.now();
+			await method.retrieve(q, { topK: 10 });
+			times.push(performance.now() - started);
+		}
+	}
+	times.sort((a, b) => a - b);
+	return times[Math.floor(times.length / 2)] as number;
+}
+
+const engine = (process.argv[2] ?? "tantivy") as "tantivy" | "typescript-fallback";
+const sizes = engine === "typescript-fallback" ? [50, 100, 200, 400] : [50, 200, 800, 2000];
+const rows: { documents: number; chunks: number; broadMs: number; selectiveMs: number }[] = [];
+
+for (const size of sizes) {
+	const { root, searchPaths } = buildCorpus(size);
+	try {
+		await syncParsedMirrors({ root, searchPaths });
+		const method = new BM25Method({ root, forceEngine: engine });
+		const built = await method.sync();
+		await method.retrieve(BROAD[0] as string, { topK: 10 });
+		rows.push({
+			documents: size,
+			chunks: built.indexedChunks,
+			broadMs: await medianQueryMs(method, BROAD, 4),
+			selectiveMs: await medianQueryMs(method, SELECTIVE, 4),
+		});
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+}
+
+console.log(`\nengine: ${engine}`);
+console.log("| documents | chunks | broad (ms) | selective (ms) |");
+console.log("|---|---|---|---|");
+for (const r of rows) {
+	console.log(`| ${r.documents} | ${r.chunks} | ${r.broadMs.toFixed(2)} | ${r.selectiveMs.toFixed(3)} |`);
+}
+const first = rows[0];
+const last = rows[rows.length - 1];
+if (first && last) {
+	const growth = last.chunks / first.chunks;
+	console.log(
+		`\ncorpus x${growth.toFixed(0)} -> broad x${(last.broadMs / first.broadMs).toFixed(1)}, selective x${(last.selectiveMs / first.selectiveMs).toFixed(1)}`,
+	);
+}
+console.log(`JSON: ${JSON.stringify(rows)}`);

--- a/test/bench/measure-stage-share.ts
+++ b/test/bench/measure-stage-share.ts
@@ -1,0 +1,86 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { syncParsedMirrors } from "../../src/mirror/sync.ts";
+import { BM25Method } from "../../src/retrieval/methods/bm25.ts";
+
+/**
+ * Splits an unchanged refresh into its two local stages so the end-to-end effect of the BM25
+ * fingerprint skip can be stated honestly.
+ *
+ * The mirror stage is untouched by this change; only the BM25 stage gets the skip. Reporting the
+ * BM25 speedup alone would overstate what a user experiences, so this measures both stages and
+ * derives the combined figure.
+ */
+
+function buildCorpus(documentCount: number): { root: string; searchPaths: string[] } {
+	const root = mkdtempSync(join(tmpdir(), "autorag-stage-"));
+	const docs = join(root, "docs");
+	mkdirSync(docs, { recursive: true });
+	for (let i = 0; i < documentCount; i += 1) {
+		const body = Array.from(
+			{ length: 40 },
+			(_, p) => `Paragraph ${p} of document ${i}. Refund approval policy and chargeback evidence retention.`,
+		).join("\n\n");
+		writeFileSync(join(docs, `doc-${String(i).padStart(5, "0")}.md`), `# Document ${i}\n\n${body}\n`);
+	}
+	return { root, searchPaths: [docs] };
+}
+
+async function median(samples: number, fn: () => Promise<void>): Promise<number> {
+	const times: number[] = [];
+	for (let i = 0; i < samples; i += 1) {
+		const started = performance.now();
+		await fn();
+		times.push(performance.now() - started);
+	}
+	times.sort((a, b) => a - b);
+	return times[Math.floor(times.length / 2)] as number;
+}
+
+const rows: Record<string, number | string>[] = [];
+
+for (const size of [200, 800, 2000]) {
+	const { root, searchPaths } = buildCorpus(size);
+	try {
+		await syncParsedMirrors({ root, searchPaths });
+		const method = new BM25Method({ root, forceEngine: "typescript-fallback" });
+		await method.sync();
+
+		const mirrorMs = await median(5, async () => {
+			await syncParsedMirrors({ root, searchPaths });
+		});
+		const bm25BeforeMs = await median(5, async () => {
+			await method.sync({ force: true });
+		});
+		const bm25AfterMs = await median(5, async () => {
+			await method.sync();
+		});
+
+		const totalBefore = mirrorMs + bm25BeforeMs;
+		const totalAfter = mirrorMs + bm25AfterMs;
+		rows.push({
+			documents: size,
+			mirrorMs: Number(mirrorMs.toFixed(1)),
+			bm25BeforeMs: Number(bm25BeforeMs.toFixed(1)),
+			bm25AfterMs: Number(bm25AfterMs.toFixed(2)),
+			totalBeforeMs: Number(totalBefore.toFixed(1)),
+			totalAfterMs: Number(totalAfter.toFixed(1)),
+			bm25ShareBefore: `${((bm25BeforeMs / totalBefore) * 100).toFixed(0)}%`,
+			endToEndSpeedup: `${(totalBefore / totalAfter).toFixed(2)}x`,
+		});
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+}
+
+console.log(
+	"\n| docs | mirror (ms) | BM25 before | BM25 after | total before | total after | BM25 share | end-to-end |",
+);
+console.log("|---|---|---|---|---|---|---|---|");
+for (const r of rows) {
+	console.log(
+		`| ${r.documents} | ${r.mirrorMs} | ${r.bm25BeforeMs} | ${r.bm25AfterMs} | ${r.totalBeforeMs} | ${r.totalAfterMs} | ${r.bm25ShareBefore} | ${r.endToEndSpeedup} |`,
+	);
+}
+console.log(`\nJSON: ${JSON.stringify(rows)}`);

--- a/test/bench/mirror-sync-equivalence.test.ts
+++ b/test/bench/mirror-sync-equivalence.test.ts
@@ -1,0 +1,522 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	loadMirrorIndex,
+	type ParsedMirrorDiagnostic,
+	type ParsedMirrorIndex,
+	syncParsedMirrors,
+} from "../../src/mirror/index.ts";
+import { ParseError, type ParseInput, type ParseOutput, Parser, ParserRegistry } from "../../src/parser/index.ts";
+import { decodeText } from "../../src/parser/text.ts";
+
+/**
+ * Equivalence safety net for `syncParsedMirrors()` before it is parallelized.
+ *
+ * The current loop in src/mirror/sync.ts parses one file at a time and writes each mirror
+ * atomically. Parallelizing it (bounded concurrency over the sorted file list) must not change
+ * any observable behavior, and the property that is easiest to break is ordering: diagnostics,
+ * index insertion order, and the loop's failure isolation are all driven by the serial,
+ * localeCompare-sorted walk. Every test below pins an observable contract that the parallel
+ * implementation must keep, and the mutation checks at the end of the run (see test/bench/README.md)
+ * prove the tests are not vacuous.
+ *
+ * Corpora are deliberately ASCII so that decode -> NFC normalize -> write is the identity: mirror
+ * bytes then equal source bytes exactly, without re-implementing normalizeMarkdown in this file.
+ * All workspaces live under the system temp directory and are removed after each test; nothing in
+ * this file ever points `root` at the repository, so no `.autorag` can appear there.
+ */
+
+const roots: string[] = [];
+
+function makeWorkspace(): { root: string; docs: string } {
+	const root = mkdtempSync(join(tmpdir(), "autorag-equivalence-"));
+	roots.push(root);
+	const docs = join(root, "docs");
+	mkdirSync(docs, { recursive: true });
+	return { root, docs };
+}
+
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function writeCorpus(docs: string, files: Record<string, string>): void {
+	for (const [name, content] of Object.entries(files)) {
+		const path = join(docs, name);
+		mkdirSync(dirname(path), { recursive: true });
+		writeFileSync(path, content);
+	}
+}
+
+/** Maps virtual path (/docs/<name>) to the exact source content the mirror must reproduce. */
+function expectedVirtual(files: Record<string, string>): Record<string, string> {
+	return Object.fromEntries(Object.entries(files).map(([name, content]) => [`/docs/${name}`, content]));
+}
+
+function requireValue<T>(value: T | undefined, label: string): T {
+	if (value === undefined) throw new Error(`missing ${label}`);
+	return value;
+}
+
+/** Code:severity:source per diagnostic. Array equality on these pins content AND order. */
+function diagnosticTuples(diagnostics: readonly ParsedMirrorDiagnostic[]): string[] {
+	return diagnostics.map((diagnostic) => `${diagnostic.code}:${diagnostic.severity}:${diagnostic.source}`);
+}
+
+function mirrorBytesByVirtualPath(index: ParsedMirrorIndex): Record<string, string> {
+	const bytes: Record<string, string> = {};
+	for (const entry of Object.values(index.entries)) {
+		bytes[entry.virtualPath] = readFileSync(entry.outputPath, "utf8");
+	}
+	return bytes;
+}
+
+function sortedKeys(entries: Readonly<Record<string, unknown>>): string[] {
+	const keys = Object.keys(entries);
+	return [...keys].sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Controlled parser used across the suite. Fails with a typed `ParseError` for the configured
+ * virtual paths and counts every parse call, which is how the no-reparse-on-resume contract is
+ * observed.
+ */
+class ControlledParser extends Parser {
+	readonly name = "controlled";
+	readonly extensions = [".md", ".txt"] as const;
+	parseCalls = 0;
+	private readonly failPaths: ReadonlySet<string>;
+
+	constructor(failPaths: ReadonlySet<string> = new Set()) {
+		super();
+		this.failPaths = failPaths;
+	}
+
+	async parse(input: ParseInput): Promise<ParseOutput> {
+		this.parseCalls += 1;
+		if (this.failPaths.has(input.virtualPath)) {
+			throw new ParseError(this.name, input.virtualPath, new Error("deliberate failure for the safety net"));
+		}
+		return { markdown: decodeText(input.bytes) };
+	}
+}
+
+/** Parser that blocks until the test releases it; used to observe mid-run checkpoint state. */
+class BlockingParser extends Parser {
+	readonly name = "blocking";
+	readonly extensions = [".slow"] as const;
+	parseCalls = 0;
+	private readonly gate: Promise<void>;
+
+	constructor(gate: Promise<void>) {
+		super();
+		this.gate = gate;
+	}
+
+	async parse(input: ParseInput): Promise<ParseOutput> {
+		this.parseCalls += 1;
+		await this.gate;
+		return { markdown: decodeText(input.bytes) };
+	}
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(condition: () => boolean, label: string, timeoutMs = 5_000): Promise<void> {
+	const start = Date.now();
+	while (!condition()) {
+		if (Date.now() - start > timeoutMs) throw new Error(`timed out waiting for ${label}`);
+		await sleep(5);
+	}
+}
+
+/**
+ * Project an index onto run-independent comparable fields.
+ *
+ * Excluded or normalized, with reasons:
+ * - `sourcePath`, `outputPath`, `indexPath`: absolute paths that embed the per-run temp workspace
+ *   root; they differ between two runs even for an identical corpus. Normalized to root-relative.
+ * - `sourceMtimeNs`: wall-clock file metadata; the two runs write files at different instants, so
+ *   the values are never equal. Only type/range-validated here.
+ * - `updatedAt`: wall-clock ISO timestamp, likewise never equal across runs. Only format-validated.
+ * Everything else (virtualPath, parserName, sourceSizeBytes, contentSha256) is compared as-is.
+ */
+function comparableEntries(root: string, index: ParsedMirrorIndex): unknown[] {
+	return Object.values(index.entries)
+		.map((entry) => {
+			if (!Number.isFinite(entry.sourceMtimeNs)) {
+				throw new Error(`entry ${entry.virtualPath} has a non-finite sourceMtimeNs`);
+			}
+			if (Number.isNaN(Date.parse(entry.updatedAt))) {
+				throw new Error(`entry ${entry.virtualPath} has an invalid updatedAt`);
+			}
+			if (entry.contentSha256 === undefined) {
+				throw new Error(`entry ${entry.virtualPath} has no contentSha256 after a forced sync`);
+			}
+			return {
+				virtualPath: entry.virtualPath,
+				parserName: entry.parserName,
+				sourceSizeBytes: entry.sourceSizeBytes,
+				contentSha256: entry.contentSha256,
+				sourcePath: relative(root, entry.sourcePath),
+				outputPath: relative(root, entry.outputPath),
+			};
+		})
+		.sort((a, b) => a.virtualPath.localeCompare(b.virtualPath));
+}
+
+describe("syncParsedMirrors equivalence safety net", () => {
+	it("(a) repeat runs are fully deterministic: counts, diagnostics in order, index fields, mirror bytes", async () => {
+		const runOnce = async (): Promise<{
+			root: string;
+			result: Awaited<ReturnType<typeof syncParsedMirrors>>;
+			index: ParsedMirrorIndex;
+		}> => {
+			const { root, docs } = makeWorkspace();
+			writeCorpus(docs, {
+				"a.md": "Alpha\n",
+				"b-broken.md": "Beta broken\n",
+				"c.md": "Gamma\n",
+				"d-broken.md": "Delta broken\n",
+				"e.md": "Epsilon\n",
+				"f-big.md": "x".repeat(200),
+			});
+			const result = await syncParsedMirrors({
+				root,
+				searchPaths: [docs],
+				// Failures and size skips are part of the corpus on purpose: an all-clean run would
+				// leave the diagnostics order contract untested.
+				registry: new ParserRegistry([new ControlledParser(new Set(["/docs/b-broken.md", "/docs/d-broken.md"]))]),
+				maxSourceBytes: 40,
+				force: true,
+			});
+			return { root, result, index: loadMirrorIndex(root) };
+		};
+
+		const first = await runOnce();
+		const second = await runOnce();
+
+		expect(second.result.scanned).toBe(first.result.scanned);
+		expect(second.result.written).toBe(first.result.written);
+		expect(second.result.deleted).toBe(first.result.deleted);
+		expect(second.result.skipped).toBe(first.result.skipped);
+		// Full-array equality: same length, same elements, same order.
+		expect(second.result.diagnostics).toEqual(first.result.diagnostics);
+		// Sanity: the corpus really produced the interesting shape (3 written, 2 failed, 1 oversized).
+		expect(first.result).toMatchObject({ scanned: 6, written: 3, deleted: 0, skipped: 3 });
+		expect(diagnosticTuples(first.result.diagnostics)).toEqual([
+			"parser-failed:warning:/docs/b-broken.md",
+			"parser-failed:warning:/docs/d-broken.md",
+			"parser-skipped:warning:/docs/f-big.md",
+		]);
+		expect(comparableEntries(first.root, first.index)).toEqual(comparableEntries(second.root, second.index));
+		// Index insertion order is the loop order, which is the localeCompare contract.
+		expect(sortedKeys(first.index.entries)).toEqual(Object.keys(first.index.entries));
+		expect(sortedKeys(second.index.entries)).toEqual(Object.keys(second.index.entries));
+		expect(mirrorBytesByVirtualPath(first.index)).toEqual(mirrorBytesByVirtualPath(second.index));
+	});
+
+	describe("(b) corpus shapes", () => {
+		it("(b1) fresh corpus: every supported file is written exactly once with exact bytes", async () => {
+			const { root, docs } = makeWorkspace();
+			const corpus = { "a.md": "Alpha\n", "b.md": "Beta\n", "c.md": "Gamma\n", "d.txt": "Delta\n" };
+			writeCorpus(docs, corpus);
+
+			const result = await syncParsedMirrors({
+				root,
+				searchPaths: [docs],
+				registry: new ParserRegistry([new ControlledParser()]),
+			});
+
+			expect(result).toMatchObject({ scanned: 4, written: 4, deleted: 0, skipped: 0 });
+			expect(result.diagnostics).toEqual([]);
+			const index = loadMirrorIndex(root);
+			const expected = expectedVirtual(corpus);
+			expect(Object.keys(index.entries)).toHaveLength(4);
+			for (const entry of Object.values(index.entries)) {
+				// ASCII corpus: NFC normalization is the identity, so the mirror must equal the source.
+				expect(readFileSync(entry.outputPath, "utf8")).toBe(expected[entry.virtualPath]);
+				expect(entry.contentSha256).toBeDefined();
+			}
+		});
+
+		it("(b2) partial change: only changed files are rewritten, unchanged mirrors keep their digest", async () => {
+			const { root, docs } = makeWorkspace();
+			const registry = new ParserRegistry([new ControlledParser()]);
+			writeCorpus(docs, { "a.md": "Alpha\n", "b.md": "Beta\n", "c.md": "Gamma\n", "d.md": "Delta\n" });
+			await syncParsedMirrors({ root, searchPaths: [docs], registry });
+			const before = loadMirrorIndex(root);
+
+			// Different content and different size, so the mtime+size staleness check fires.
+			writeCorpus(docs, { "b.md": "Beta has grown much longer now\n", "d.md": "Delta changed\n" });
+			const result = await syncParsedMirrors({ root, searchPaths: [docs], registry });
+
+			expect(result).toMatchObject({ scanned: 4, written: 2, deleted: 0, skipped: 0 });
+			expect(result.diagnostics).toEqual([]);
+			const after = loadMirrorIndex(root);
+			expect(after.entries["/docs/b.md"]?.contentSha256).not.toBe(before.entries["/docs/b.md"]?.contentSha256);
+			expect(after.entries["/docs/d.md"]?.contentSha256).not.toBe(before.entries["/docs/d.md"]?.contentSha256);
+			// Untouched files keep their digest: they were not reparsed or rewritten.
+			expect(after.entries["/docs/a.md"]?.contentSha256).toBe(before.entries["/docs/a.md"]?.contentSha256);
+			expect(after.entries["/docs/c.md"]?.contentSha256).toBe(before.entries["/docs/c.md"]?.contentSha256);
+			expect(readFileSync(requireValue(after.entries["/docs/b.md"], "b.md").outputPath, "utf8")).toBe(
+				"Beta has grown much longer now\n",
+			);
+			expect(readFileSync(requireValue(after.entries["/docs/d.md"], "d.md").outputPath, "utf8")).toBe(
+				"Delta changed\n",
+			);
+		});
+
+		it("(b3) deletion: a removed source drops its mirror file and emits a deleted-mirror diagnostic", async () => {
+			const { root, docs } = makeWorkspace();
+			const registry = new ParserRegistry([new ControlledParser()]);
+			writeCorpus(docs, { "keep.txt": "Keep\n", "gone.md": "Gone\n", "stay.md": "Stay\n" });
+			const first = await syncParsedMirrors({ root, searchPaths: [docs], registry });
+			expect(first.written).toBe(3);
+			const goneOutput = requireValue(
+				loadMirrorIndex(root).entries["/docs/gone.md"],
+				"gone.md output path",
+			).outputPath;
+
+			unlinkSync(join(docs, "gone.md"));
+			const second = await syncParsedMirrors({ root, searchPaths: [docs], registry });
+
+			expect(second).toMatchObject({ scanned: 2, written: 0, deleted: 1, skipped: 0 });
+			expect(diagnosticTuples(second.diagnostics)).toEqual(["deleted-mirror:info:/docs/gone.md"]);
+			const index = loadMirrorIndex(root);
+			expect(index.entries["/docs/gone.md"]).toBeUndefined();
+			expect(existsSync(goneOutput)).toBe(false);
+		});
+
+		it("(b4) parser failure: broken files are skipped with parser-failed diagnostics, every other mirror survives", async () => {
+			const { root, docs } = makeWorkspace();
+			const registry = new ParserRegistry([
+				new ControlledParser(new Set(["/docs/broken-1.md", "/docs/broken-2.md"])),
+			]);
+			const corpus = {
+				"broken-1.md": "Broken one\n",
+				"broken-2.md": "Broken two\n",
+				"good-a.md": "Good A\n",
+				"good-b.md": "Good B\n",
+				"good-c.md": "Good C\n",
+			};
+			writeCorpus(docs, corpus);
+
+			const result = await syncParsedMirrors({ root, searchPaths: [docs], registry });
+
+			expect(result).toMatchObject({ scanned: 5, written: 3, skipped: 2, deleted: 0 });
+			// Full-array equality pins content AND order (virtualPath order, not file-system order).
+			expect(diagnosticTuples(result.diagnostics)).toEqual([
+				"parser-failed:warning:/docs/broken-1.md",
+				"parser-failed:warning:/docs/broken-2.md",
+			]);
+			const index = loadMirrorIndex(root);
+			expect(index.entries["/docs/broken-1.md"]).toBeUndefined();
+			expect(index.entries["/docs/broken-2.md"]).toBeUndefined();
+			const expected = expectedVirtual(corpus);
+			for (const name of ["good-a.md", "good-b.md", "good-c.md"]) {
+				const entry = requireValue(index.entries[`/docs/${name}`], name);
+				expect(readFileSync(entry.outputPath, "utf8")).toBe(expected[`/docs/${name}`]);
+			}
+		});
+
+		it("(b5) size cap: oversized sources are skipped with parser-skipped diagnostics, the rest are processed", async () => {
+			const { root, docs } = makeWorkspace();
+			const registry = new ParserRegistry([new ControlledParser()]);
+			const corpus: Record<string, string> = {
+				"big.md": "x".repeat(200),
+				"small-a.md": "Small A\n",
+				"small-b.md": "Small B\n",
+			};
+			writeCorpus(docs, corpus);
+
+			const result = await syncParsedMirrors({ root, searchPaths: [docs], registry, maxSourceBytes: 40 });
+
+			expect(result).toMatchObject({ scanned: 3, written: 2, skipped: 1, deleted: 0 });
+			expect(diagnosticTuples(result.diagnostics)).toEqual(["parser-skipped:warning:/docs/big.md"]);
+			const index = loadMirrorIndex(root);
+			expect(index.entries["/docs/big.md"]).toBeUndefined();
+			for (const name of ["small-a.md", "small-b.md"]) {
+				const entry = requireValue(index.entries[`/docs/${name}`], name);
+				expect(readFileSync(entry.outputPath, "utf8")).toBe(requireValue(corpus[name], name));
+			}
+
+			// Raising the cap later must recover the skipped file; the size gate must not poison it.
+			const recovery = await syncParsedMirrors({ root, searchPaths: [docs], registry });
+			expect(recovery).toMatchObject({ scanned: 3, written: 1, skipped: 0 });
+			expect(loadMirrorIndex(root).entries["/docs/big.md"]).toBeDefined();
+		});
+
+		it("(b6) empty corpus: nothing scanned, nothing written, empty index", async () => {
+			const { root, docs } = makeWorkspace();
+
+			const result = await syncParsedMirrors({
+				root,
+				searchPaths: [docs],
+				registry: new ParserRegistry([new ControlledParser()]),
+			});
+
+			expect(result).toMatchObject({ scanned: 0, written: 0, deleted: 0, skipped: 0 });
+			expect(result.diagnostics).toEqual([]);
+			expect(loadMirrorIndex(root).entries).toEqual({});
+		});
+
+		it("(b7) nested directories: subfolder documents are indexed under their virtual paths", async () => {
+			const { root, docs } = makeWorkspace();
+			const registry = new ParserRegistry([new ControlledParser()]);
+			const corpus = { "root.md": "Root\n", "sub/a.md": "Sub A\n", "sub/deep/b.md": "Deep B\n" };
+			writeCorpus(docs, corpus);
+
+			const result = await syncParsedMirrors({ root, searchPaths: [docs], registry });
+
+			expect(result).toMatchObject({ scanned: 3, written: 3, deleted: 0, skipped: 0 });
+			const index = loadMirrorIndex(root);
+			const keys = Object.keys(index.entries);
+			expect(keys).toEqual(sortedKeys(index.entries));
+			expect(new Set(keys)).toEqual(new Set(["/docs/root.md", "/docs/sub/a.md", "/docs/sub/deep/b.md"]));
+			const expected = expectedVirtual(corpus);
+			for (const entry of Object.values(index.entries)) {
+				expect(readFileSync(entry.outputPath, "utf8")).toBe(expected[entry.virtualPath]);
+			}
+		});
+	});
+
+	it("(c) deterministic order: keys and diagnostics follow virtualPath localeCompare, not creation order", async () => {
+		const { root, docs } = makeWorkspace();
+		// Written deliberately in reverse-sorted order (z first, a last): a directory walk in
+		// creation order would surface z first, and that must not leak into the index or diagnostics.
+		const parser = new ControlledParser(new Set(["/docs/a-broken.md", "/docs/m-broken.md", "/docs/z-broken.md"]));
+		const registry = new ParserRegistry([parser]);
+		const corpus = {
+			"z.md": "Z\n",
+			"z-broken.md": "Z broken\n",
+			"y.md": "Y\n",
+			"y-broken.md": "Y broken\n",
+			"m.md": "M\n",
+			"m-broken.md": "M broken\n",
+			"a.md": "A\n",
+			"a-broken.md": "A broken\n",
+		};
+		writeCorpus(docs, corpus);
+
+		const result = await syncParsedMirrors({ root, searchPaths: [docs], registry });
+		const index = loadMirrorIndex(root);
+
+		// The pin: production order equals what localeCompare produces, whatever the locale.
+		expect(Object.keys(index.entries)).toEqual(sortedKeys(index.entries));
+		const diagSources = result.diagnostics.map((diagnostic) => diagnostic.source);
+		expect(diagSources).toEqual([...diagSources].sort((a, b) => a.localeCompare(b)));
+		// The three failing sources differ in their leading letter, so this order is locale-stable.
+		expect(diagSources).toEqual(["/docs/a-broken.md", "/docs/m-broken.md", "/docs/z-broken.md"]);
+		expect(parser.parseCalls).toBe(8);
+	});
+
+	it("(d) checkpoint resume: mirrors written before a mid-run checkpoint are never reparsed afterwards", async () => {
+		const { root, docs } = makeWorkspace();
+		const fast = new ControlledParser();
+		let releaseGate: () => void = () => {};
+		const gate = new Promise<void>((resolve) => {
+			releaseGate = resolve;
+		});
+		const blocking = new BlockingParser(gate);
+		const registry = new ParserRegistry([fast, blocking]);
+		// MIRROR_CHECKPOINT_EVERY in src/mirror/sync.ts is 25: with 31 files the checkpoint after
+		// file 25 lands while file 31 (z-block.slow, last in virtualPath order) is still parsing,
+		// so the checkpointed index can be observed on disk mid-run.
+		const corpus: Record<string, string> = {};
+		for (let i = 0; i < 30; i += 1) {
+			corpus[`doc-${String(i).padStart(2, "0")}.md`] = `Doc ${i}\n`;
+		}
+		corpus["z-block.slow"] = "Blocked\n";
+		writeCorpus(docs, corpus);
+
+		const run = syncParsedMirrors({ root, searchPaths: [docs], registry });
+		await waitFor(() => blocking.parseCalls === 1, "blocking parser to start");
+
+		// The checkpoint is already on disk while the run is still in flight: a crash and restart
+		// here would see exactly these 25 completed entries, each with its content digest.
+		const checkpointed = loadMirrorIndex(root);
+		const expectedCheckpointKeys = Array.from({ length: 25 }, (_, i) => `/docs/doc-${String(i).padStart(2, "0")}.md`);
+		expect(Object.keys(checkpointed.entries)).toEqual(expectedCheckpointKeys);
+		for (const entry of Object.values(checkpointed.entries)) {
+			expect(entry.contentSha256).toBeDefined();
+		}
+
+		releaseGate();
+		const result = await run;
+		expect(result).toMatchObject({ scanned: 31, written: 31, deleted: 0, skipped: 0 });
+		expect(fast.parseCalls + blocking.parseCalls).toBe(31);
+
+		// The next sync is a no-op: every mirror already on disk is reused without a single parse.
+		const again = await syncParsedMirrors({ root, searchPaths: [docs], registry });
+		expect(again).toMatchObject({ scanned: 31, written: 0, deleted: 0, skipped: 0 });
+		expect(fast.parseCalls + blocking.parseCalls).toBe(31);
+	});
+
+	describe("(e) invariants the parallel implementation must keep", () => {
+		it("(e1) cross-contamination: each mirror file contains exactly its own source's parse output", async () => {
+			const { root, docs } = makeWorkspace();
+			// Every file has a unique body so any swap between mirrors is immediately visible.
+			const corpus = {
+				"alpha.md": "# Alpha\n\nalpha-only body one\n",
+				"beta.md": "# Beta\n\nbeta-only body two\n",
+				"gamma.txt": "gamma-only body three\n",
+				"delta.md": "# Delta\n\ndelta-only body four\n",
+				"epsilon.txt": "epsilon-only body five\n",
+			};
+			writeCorpus(docs, corpus);
+
+			const result = await syncParsedMirrors({
+				root,
+				searchPaths: [docs],
+				registry: new ParserRegistry([new ControlledParser()]),
+			});
+
+			expect(result.written).toBe(5);
+			const expected = expectedVirtual(corpus);
+			const index = loadMirrorIndex(root);
+			expect(Object.keys(index.entries)).toHaveLength(5);
+			for (const entry of Object.values(index.entries)) {
+				expect(readFileSync(entry.outputPath, "utf8")).toBe(expected[entry.virtualPath]);
+			}
+		});
+
+		it("(e2) contentSha256 is the sha256 of the exact bytes on disk", async () => {
+			const { root, docs } = makeWorkspace();
+			writeCorpus(docs, { "a.md": "Alpha\n", "b.txt": "Beta\n", "c.md": "Gamma\n" });
+
+			await syncParsedMirrors({
+				root,
+				searchPaths: [docs],
+				registry: new ParserRegistry([new ControlledParser()]),
+			});
+
+			const index = loadMirrorIndex(root);
+			expect(Object.keys(index.entries)).toHaveLength(3);
+			for (const entry of Object.values(index.entries)) {
+				const digest = requireValue(entry.contentSha256, `${entry.virtualPath} contentSha256`);
+				expect(createHash("sha256").update(readFileSync(entry.outputPath)).digest("hex")).toBe(digest);
+			}
+		});
+
+		it("(e3) path-opaque diagnostics: source is a virtual path and never embeds the temp root", async () => {
+			const { root, docs } = makeWorkspace();
+			const registry = new ParserRegistry([new ControlledParser(new Set(["/docs/broken.md"]))]);
+			writeCorpus(docs, { "broken.md": "B\n", "ok.md": "O\n", "too-big.md": "x".repeat(100) });
+
+			const result = await syncParsedMirrors({ root, searchPaths: [docs], registry, maxSourceBytes: 20 });
+
+			expect(result.diagnostics).toHaveLength(2);
+			for (const diagnostic of result.diagnostics) {
+				expect(diagnostic.source.startsWith("/")).toBe(true);
+				expect(diagnostic.source).not.toContain(root);
+			}
+			expect(JSON.stringify(result.diagnostics)).not.toContain(root);
+		});
+	});
+});

--- a/test/bench/query-cache-bounds.test.ts
+++ b/test/bench/query-cache-bounds.test.ts
@@ -1,0 +1,179 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { syncParsedMirrors } from "../../src/mirror/sync.ts";
+import { BM25Method } from "../../src/retrieval/methods/bm25.ts";
+import type { RetrievalResult } from "../../src/retrieval/types.ts";
+
+/**
+ * Bounds and cross-process invalidation for the query-time cache.
+ *
+ * The cache is an optimisation, so it must be droppable at any moment without changing an answer,
+ * and it must not survive a rebuild performed by a process this one knows nothing about.
+ */
+
+const roots: string[] = [];
+const REPO_ROOT = join(import.meta.dirname, "..", "..");
+
+function makeWorkspace(documentCount: number, marker = "alpha"): { root: string; searchPaths: string[] } {
+	const root = mkdtempSync(join(tmpdir(), "autorag-bound-"));
+	roots.push(root);
+	const docs = join(root, "docs");
+	mkdirSync(docs, { recursive: true });
+	for (let i = 0; i < documentCount; i += 1) {
+		writeFileSync(
+			join(docs, `doc-${i}.md`),
+			`# Document ${i}\n\nRefund approval policy and escalation threshold. Marker ${marker}.\n`,
+		);
+	}
+	return { root, searchPaths: [docs] };
+}
+
+function shape(results: readonly RetrievalResult[]): string {
+	return JSON.stringify(results.map((r) => [r.id, r.source, r.score]));
+}
+
+/** Read the private cache slot without exporting it from the production surface. */
+function cacheSlot(method: BM25Method): unknown {
+	return (method as unknown as { fallbackCache: unknown }).fallbackCache;
+}
+
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("query cache bounds", () => {
+	it("returns identical results whether or not the cache is retained", async () => {
+		const { root, searchPaths } = makeWorkspace(20);
+		await syncParsedMirrors({ root, searchPaths });
+		const method = new BM25Method({ root, forceEngine: "typescript-fallback" });
+		await method.sync();
+
+		const queries = ["refund approval policy", "escalation threshold", "alpha", "missingterm"];
+		const cached = new Map<string, string>();
+		for (const q of queries) {
+			await method.retrieve(q, { topK: 10 });
+			cached.set(q, shape(await method.retrieve(q, { topK: 10 })));
+		}
+		expect(cacheSlot(method)).toBeDefined();
+
+		// Drop the cache before every query to emulate the over-bound path, where the prepared
+		// structure is built for the query and then discarded.
+		for (const q of queries) {
+			(method as unknown as { fallbackCache: unknown }).fallbackCache = undefined;
+			const uncached = shape(await method.retrieve(q, { topK: 10 }));
+			expect(uncached).toBe(cached.get(q));
+		}
+	});
+
+	it("keeps the cache for a corpus below the retention bound", async () => {
+		const { root, searchPaths } = makeWorkspace(20);
+		await syncParsedMirrors({ root, searchPaths });
+		const method = new BM25Method({ root, forceEngine: "typescript-fallback" });
+		await method.sync();
+
+		await method.retrieve("refund", { topK: 5 });
+		expect(cacheSlot(method)).toBeDefined();
+	});
+
+	it("drops the cache when the retained-byte estimate exceeds the bound", async () => {
+		const root = mkdtempSync(join(tmpdir(), "autorag-bound-"));
+		roots.push(root);
+		const docs = join(root, "docs");
+		mkdirSync(docs, { recursive: true });
+		// ~200k short tokens: a quarter of the old token bound, but content strings plus term
+		// objects plus postings exceed the byte budget, so the cache must not be retained.
+		const words: string[] = [];
+		for (let i = 0; i < 200_000; i += 1) {
+			words.push(`term${String(i % 400).padStart(3, "0")}${["able", "ing", "tion"][i % 3]}`);
+		}
+		const body = words.join(" ");
+		const paragraphs: string[] = [];
+		for (let i = 0; i < body.length; i += 1800) paragraphs.push(body.slice(i, i + 1800));
+		writeFileSync(join(docs, "doc-0.md"), `# Doc\n\n${paragraphs.join("\n\n")}\n`);
+
+		await syncParsedMirrors({ root, searchPaths: [docs] });
+		const method = new BM25Method({ root, forceEngine: "typescript-fallback" });
+		await method.sync();
+
+		await method.retrieve("term000", { topK: 5 });
+		expect(cacheSlot(method)).toBeUndefined();
+	});
+
+	it("never serves stale results while the fingerprint sidecar is missing", async () => {
+		const { root, searchPaths } = makeWorkspace(6, "alpha");
+		await syncParsedMirrors({ root, searchPaths });
+		const method = new BM25Method({ root, forceEngine: "typescript-fallback" });
+		await method.sync();
+
+		// Warm the cache against the original artifact.
+		expect((await method.retrieve("alpha", { topK: 10 })).length).toBeGreaterThan(0);
+		expect(cacheSlot(method)).toBeDefined();
+
+		// Delete the sidecar and replace the artifact with different content, the way a writer
+		// that records no fingerprint (old version, failed sidecar write) would.
+		const fingerprintPath = join(root, ".autorag", "bm25", "index-fingerprint.json");
+		rmSync(fingerprintPath);
+		const docs = searchPaths[0] as string;
+		for (let i = 0; i < 6; i += 1) {
+			writeFileSync(join(docs, `doc-${i}.md`), `# Document ${i}\n\nRefund approval policy. Marker beta.\n`);
+		}
+		await syncParsedMirrors({ root, searchPaths });
+		const writer = new BM25Method({ root, forceEngine: "typescript-fallback" });
+		await writer.sync();
+		rmSync(fingerprintPath);
+
+		// The warm instance observes the replacement and must not pin an unkeyed cache entry.
+		expect(await method.retrieve("alpha", { topK: 10 })).toHaveLength(0);
+		expect((await method.retrieve("beta", { topK: 10 })).length).toBeGreaterThan(0);
+		expect(cacheSlot(method)).toBeUndefined();
+
+		// A second replacement while the sidecar stays missing must be visible too.
+		for (let i = 0; i < 6; i += 1) {
+			writeFileSync(join(docs, `doc-${i}.md`), `# Document ${i}\n\nEscalation threshold. Marker gamma.\n`);
+		}
+		await syncParsedMirrors({ root, searchPaths });
+		const secondWriter = new BM25Method({ root, forceEngine: "typescript-fallback" });
+		await secondWriter.sync();
+		rmSync(fingerprintPath);
+
+		expect(await method.retrieve("beta", { topK: 10 })).toHaveLength(0);
+		expect((await method.retrieve("gamma", { topK: 10 })).length).toBeGreaterThan(0);
+	});
+	it("observes a rebuild performed by a separate operating system process", async () => {
+		const { root, searchPaths } = makeWorkspace(6, "original");
+		await syncParsedMirrors({ root, searchPaths });
+		const reader = new BM25Method({ root, forceEngine: "typescript-fallback" });
+		await reader.sync();
+
+		// Warm the cache against the original corpus.
+		expect((await reader.retrieve("original", { topK: 10 })).length).toBeGreaterThan(0);
+		expect(cacheSlot(reader)).toBeDefined();
+
+		// A genuinely separate process mutates the corpus and rebuilds the index. This process is
+		// never told about it, so only the on-disk fingerprint can reveal the change.
+		const script = `
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { syncParsedMirrors } from ${JSON.stringify(join(REPO_ROOT, "src/mirror/sync.ts"))};
+import { BM25Method } from ${JSON.stringify(join(REPO_ROOT, "src/retrieval/methods/bm25.ts"))};
+const root = ${JSON.stringify(root)};
+const docs = ${JSON.stringify(searchPaths[0])};
+for (let i = 0; i < 6; i += 1) {
+	writeFileSync(join(docs, "doc-" + i + ".md"), "# Document " + i + "\\n\\nRefund approval policy. Marker mutated.\\n");
+}
+await syncParsedMirrors({ root, searchPaths: [docs] });
+const writer = new BM25Method({ root, forceEngine: "typescript-fallback" });
+await writer.sync();
+`;
+		const scriptPath = join(root, "rebuild.ts");
+		writeFileSync(scriptPath, script);
+		execFileSync("bun", ["run", scriptPath], { cwd: REPO_ROOT, stdio: "pipe" });
+
+		// The warm reader must not answer from the superseded index.
+		expect(await reader.retrieve("original", { topK: 10 })).toHaveLength(0);
+		expect((await reader.retrieve("mutated", { topK: 10 })).length).toBeGreaterThan(0);
+	});
+});

--- a/test/bench/query-cache-equivalence.test.ts
+++ b/test/bench/query-cache-equivalence.test.ts
@@ -1,0 +1,225 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { syncParsedMirrors } from "../../src/mirror/sync.ts";
+import { BM25Method } from "../../src/retrieval/methods/bm25.ts";
+import type { RetrievalResult } from "../../src/retrieval/types.ts";
+
+/**
+ * Correctness gate for the query-time reuse of derived index state.
+ *
+ * Reusing work is only legitimate if it is invisible: the same query against the same artifact must
+ * return the same results, and the reuse must disappear the moment the artifact changes. A cache
+ * that survives a rebuild would be indistinguishable from a speedup obtained by answering from stale
+ * data, so both properties are asserted rather than assumed.
+ */
+
+const roots: string[] = [];
+const ENGINES = ["typescript-fallback", "tantivy"] as const;
+
+const QUERIES = [
+	"refund approval policy",
+	"chargeback evidence retention",
+	"escalation threshold",
+	"quarterly settlement report",
+	"document 3 paragraph 7",
+	"nonexistent term xyzzy",
+	"",
+];
+
+function makeWorkspace(documentCount: number, marker = "baseline"): { root: string; searchPaths: string[] } {
+	const root = mkdtempSync(join(tmpdir(), "autorag-qc-"));
+	roots.push(root);
+	const docs = join(root, "docs");
+	mkdirSync(docs, { recursive: true });
+	for (let i = 0; i < documentCount; i += 1) {
+		const body = Array.from(
+			{ length: 10 },
+			(_, p) =>
+				`Paragraph ${p} of document ${i}. Refund approval policy, chargeback evidence retention, escalation threshold, quarterly settlement report. Marker ${marker}.`,
+		).join("\n\n");
+		writeFileSync(join(docs, `doc-${String(i).padStart(4, "0")}.md`), `# Document ${i}\n\n${body}\n`);
+	}
+	return { root, searchPaths: [docs] };
+}
+
+/** Full comparable shape of a result set: identity, order, and score. */
+function shape(results: readonly RetrievalResult[]): string {
+	return JSON.stringify(results.map((r) => [r.id, r.source, r.score]));
+}
+
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe.each(ENGINES)("query-time reuse (%s)", (engine) => {
+	it("returns identical results on repeated queries", async () => {
+		const { root, searchPaths } = makeWorkspace(30);
+		await syncParsedMirrors({ root, searchPaths });
+		const method = new BM25Method({ root, forceEngine: engine });
+		await method.sync();
+
+		for (const query of QUERIES) {
+			const first = await method.retrieve(query, { topK: 10 });
+			const second = await method.retrieve(query, { topK: 10 });
+			const third = await method.retrieve(query, { topK: 10 });
+			expect(shape(second)).toBe(shape(first));
+			expect(shape(third)).toBe(shape(first));
+		}
+	});
+
+	it("matches a cold instance that has no derived state", async () => {
+		const { root, searchPaths } = makeWorkspace(30);
+		await syncParsedMirrors({ root, searchPaths });
+		const warm = new BM25Method({ root, forceEngine: engine });
+		await warm.sync();
+
+		for (const query of QUERIES) {
+			// Warm the derived state, then compare against an instance built from scratch. Any
+			// divergence would mean the reused state is not equivalent to recomputing it.
+			await warm.retrieve(query, { topK: 10 });
+			const warmResults = await warm.retrieve(query, { topK: 10 });
+
+			const cold = new BM25Method({ root, forceEngine: engine });
+			await cold.sync();
+			const coldResults = await cold.retrieve(query, { topK: 10 });
+
+			expect(shape(warmResults)).toBe(shape(coldResults));
+		}
+	});
+
+	it("preserves scope semantics", async () => {
+		const root = mkdtempSync(join(tmpdir(), "autorag-qc-"));
+		roots.push(root);
+		const alpha = join(root, "alpha");
+		const beta = join(root, "beta");
+		mkdirSync(alpha, { recursive: true });
+		mkdirSync(beta, { recursive: true });
+		for (let i = 0; i < 12; i += 1) {
+			writeFileSync(
+				join(alpha, `a-${i}.md`),
+				`# Alpha ${i}\n\nRefund approval policy and escalation threshold review.\n`,
+			);
+			writeFileSync(
+				join(beta, `b-${i}.md`),
+				`# Beta ${i}\n\nRefund approval policy and settlement reconciliation.\n`,
+			);
+		}
+		await syncParsedMirrors({ root, searchPaths: [alpha, beta] });
+		const method = new BM25Method({ root, forceEngine: engine });
+		await method.sync();
+
+		for (const scope of [undefined, "alpha", "beta"]) {
+			const first = await method.retrieve("refund approval policy", { topK: 10, ...(scope ? { scope } : {}) });
+			const second = await method.retrieve("refund approval policy", { topK: 10, ...(scope ? { scope } : {}) });
+			expect(shape(second)).toBe(shape(first));
+
+			const cold = new BM25Method({ root, forceEngine: engine });
+			await cold.sync();
+			const coldResults = await cold.retrieve("refund approval policy", { topK: 10, ...(scope ? { scope } : {}) });
+			expect(shape(first)).toBe(shape(coldResults));
+		}
+
+		// Scoped statistics really are scoped: the two scopes must not return each other's documents.
+		const alphaHits = await method.retrieve("escalation threshold", { topK: 10, scope: "alpha" });
+		expect(alphaHits.length).toBeGreaterThan(0);
+		expect(alphaHits.every((hit) => hit.source.includes("/alpha/"))).toBe(true);
+		expect(alphaHits.some((hit) => hit.source.includes("/beta/"))).toBe(false);
+	});
+
+	it("never serves stale results after the corpus changes", async () => {
+		const { root, searchPaths } = makeWorkspace(10, "original");
+		await syncParsedMirrors({ root, searchPaths });
+		const method = new BM25Method({ root, forceEngine: engine });
+		await method.sync();
+
+		// Warm the derived state against the original corpus.
+		const before = await method.retrieve("original", { topK: 10 });
+		expect(before.length).toBeGreaterThan(0);
+		expect(await method.retrieve("mutated", { topK: 10 })).toHaveLength(0);
+
+		// Replace every document, reindex, and query the same instance again.
+		const docs = searchPaths[0] as string;
+		for (let i = 0; i < 10; i += 1) {
+			writeFileSync(
+				join(docs, `doc-${String(i).padStart(4, "0")}.md`),
+				`# Document ${i}\n\nRefund approval policy. Marker mutated.\n`,
+			);
+		}
+		await syncParsedMirrors({ root, searchPaths });
+		await method.sync();
+
+		// If derived state survived the rebuild, the old term would still match and the new one would not.
+		expect(await method.retrieve("original", { topK: 10 })).toHaveLength(0);
+		expect((await method.retrieve("mutated", { topK: 10 })).length).toBeGreaterThan(0);
+	});
+	it("never serves stale results while the fingerprint sidecar is missing", async () => {
+		const { root, searchPaths } = makeWorkspace(6, "alpha");
+		await syncParsedMirrors({ root, searchPaths });
+		const method = new BM25Method({ root, forceEngine: engine });
+		await method.sync();
+
+		// Warm the derived state against the original artifact.
+		expect((await method.retrieve("alpha", { topK: 10 })).length).toBeGreaterThan(0);
+
+		// Delete the sidecar and replace the artifact with different content, the way a writer
+		// that records no fingerprint (old version, failed sidecar write) would.
+		const fingerprintPath = join(root, ".autorag", "bm25", "index-fingerprint.json");
+		rmSync(fingerprintPath);
+		const docs = searchPaths[0] as string;
+		for (let i = 0; i < 6; i += 1) {
+			writeFileSync(
+				join(docs, `doc-${String(i).padStart(4, "0")}.md`),
+				`# Document ${i}\n\nRefund approval policy. Marker beta.\n`,
+			);
+		}
+		await syncParsedMirrors({ root, searchPaths });
+		const writer = new BM25Method({ root, forceEngine: engine });
+		await writer.sync();
+		rmSync(fingerprintPath);
+
+		// The warm instance observes the replacement...
+		expect(await method.retrieve("alpha", { topK: 10 })).toHaveLength(0);
+		expect((await method.retrieve("beta", { topK: 10 })).length).toBeGreaterThan(0);
+
+		// ...and a second replacement while the sidecar stays missing must be visible too.
+		for (let i = 0; i < 6; i += 1) {
+			writeFileSync(
+				join(docs, `doc-${String(i).padStart(4, "0")}.md`),
+				`# Document ${i}\n\nEscalation threshold. Marker gamma.\n`,
+			);
+		}
+		await syncParsedMirrors({ root, searchPaths });
+		const secondWriter = new BM25Method({ root, forceEngine: engine });
+		await secondWriter.sync();
+		rmSync(fingerprintPath);
+
+		expect(await method.retrieve("beta", { topK: 10 })).toHaveLength(0);
+		expect((await method.retrieve("gamma", { topK: 10 })).length).toBeGreaterThan(0);
+	});
+
+	it("picks up a rebuild performed by a different instance", async () => {
+		const { root, searchPaths } = makeWorkspace(8, "original");
+		await syncParsedMirrors({ root, searchPaths });
+		const reader = new BM25Method({ root, forceEngine: engine });
+		await reader.sync();
+		expect((await reader.retrieve("original", { topK: 10 })).length).toBeGreaterThan(0);
+
+		// A separate instance rebuilds the artifact; the reader holds warm derived state and must
+		// still observe the new content, because invalidation keys on the on-disk fingerprint.
+		const docs = searchPaths[0] as string;
+		for (let i = 0; i < 8; i += 1) {
+			writeFileSync(
+				join(docs, `doc-${String(i).padStart(4, "0")}.md`),
+				`# Document ${i}\n\nRefund approval policy. Marker mutated.\n`,
+			);
+		}
+		await syncParsedMirrors({ root, searchPaths });
+		const writer = new BM25Method({ root, forceEngine: engine });
+		await writer.sync();
+
+		expect(await reader.retrieve("original", { topK: 10 })).toHaveLength(0);
+		expect((await reader.retrieve("mutated", { topK: 10 })).length).toBeGreaterThan(0);
+	});
+});

--- a/test/bench/refresh-lock-cross-process.test.ts
+++ b/test/bench/refresh-lock-cross-process.test.ts
@@ -1,0 +1,481 @@
+import { execFile } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { AutoRAGAgent } from "../../src/agent/agent.ts";
+import { acquireRefreshLock, refreshLockPath } from "../../src/mirror/refresh-lock.ts";
+
+/**
+ * Cross-process behaviour of the refresh lock.
+ *
+ * The in-process guard cannot be exercised by the collision that actually happens in production:
+ * the CLI builds a fresh agent in a fresh process per command, so `autorag watch` and
+ * `autorag refresh` are two operating system processes sharing one index directory. These tests
+ * spawn real processes, and the contention cases are paired with deterministic controls so a passing
+ * assertion cannot be mistaken for an assertion that never had anything to catch.
+ *
+ * The racing pair never relies on scheduling to overlap. Both children race on the lock primitive
+ * itself (`acquireRefreshLock`, the same call `agent.refresh()` makes), and the winner then holds
+ * the lock across a file-signal handshake: the loser attempts its refresh only once the winner's
+ * hold is visible on disk, and the winner releases only once the loser has reported its outcome.
+ * The busy verdict is therefore structurally guaranteed, and every wait is bounded so a dead peer
+ * fails the race loudly instead of hanging it.
+ */
+
+/** Corpus is kept minimal: the barrier, not content volume, guarantees the overlap. */
+const DOCUMENT_COUNT = 2;
+const PARAGRAPH_COUNT = 2;
+/** Upper bound for every barrier wait; a peer that dies silently trips this and fails the race. */
+const BARRIER_WAIT_MS = 30_000;
+const BARRIER_POLL_MS = 25;
+
+const roots: string[] = [];
+const REPO_ROOT = join(import.meta.dirname, "..", "..");
+
+function makeWorkspace(marker = "alpha"): { root: string; searchPaths: string[] } {
+	const root = mkdtempSync(join(tmpdir(), "autorag-xproc-"));
+	roots.push(root);
+	const docs = join(root, "docs");
+	mkdirSync(docs, { recursive: true });
+	for (let i = 0; i < DOCUMENT_COUNT; i += 1) {
+		const body = Array.from(
+			{ length: PARAGRAPH_COUNT },
+			(_, p) => `Paragraph ${p} of document ${i}. Marker ${marker}.`,
+		).join("\n\n");
+		writeFileSync(join(docs, `doc-${i}.md`), `# Document ${i}\n\n${body}\n`);
+	}
+	return { root, searchPaths: [docs] };
+}
+
+function makeAgent(root: string, searchPaths: string[]): AutoRAGAgent {
+	return new AutoRAGAgent({
+		workspacePath: root,
+		searchPaths,
+		bm25: { forceEngine: "typescript-fallback" },
+		minSync: false,
+	});
+}
+
+/**
+ * Source lines that rewrite every corpus document so a child's refresh sees `marker`.
+ */
+function rewriteCorpusSource(marker: string): string {
+	const bodyExpr = [
+		`Array.from({ length: ${PARAGRAPH_COUNT} }, (_, p) => "Paragraph " + p + " of document " + i + ". Marker ${marker}.")`,
+		`.join("\\n\\n")`,
+	].join("");
+	return [
+		`for (let i = 0; i < ${DOCUMENT_COUNT}; i += 1) {`,
+		`\tconst body = ${bodyExpr};`,
+		`\twriteFileSync(join(docs, "doc-" + i + ".md"), "# Document " + i + "\\n\\n" + body + "\\n");`,
+		`}`,
+	].join("\n");
+}
+
+/**
+ * Source for a child process that rewrites the corpus and runs one refresh.
+ */
+function refreshScript(root: string, docs: string, marker: string): string {
+	return `
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { AutoRAGAgent } from ${JSON.stringify(join(REPO_ROOT, "src/agent/agent.ts"))};
+const root = ${JSON.stringify(root)};
+const docs = ${JSON.stringify(docs)};
+${rewriteCorpusSource(marker)}
+const agent = new AutoRAGAgent({
+	workspacePath: root,
+	searchPaths: [docs],
+	bm25: { forceEngine: "typescript-fallback" },
+	minSync: false,
+});
+const result = await agent.refresh(true);
+process.stdout.write(JSON.stringify({ outcome: result.outcome ?? "completed" }));
+`;
+}
+
+/**
+ * Source for one side of a racing pair.
+ *
+ * Both children rewrite the corpus and then race on `acquireRefreshLock` — the same call
+ * `agent.refresh()` makes — and the outcome of that race decides the role:
+ *
+ * - winner: writes the held signal, waits for the challenger's report, releases the lock, and only
+ *   then runs the actual refresh, which must therefore complete.
+ * - challenger: waits for the held signal, so its refresh attempt lands strictly inside the
+ *   winner's hold and must therefore be refused as busy.
+ *
+ * Either spawn slot can be the winner; the race itself decides. Every wait is bounded by
+ * BARRIER_WAIT_MS and fails with a descriptive error, so a dead peer surfaces as a harness
+ * failure rather than a hang.
+ */
+function raceScript(root: string, docs: string, marker: string): string {
+	return `
+import { existsSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { AutoRAGAgent } from ${JSON.stringify(join(REPO_ROOT, "src/agent/agent.ts"))};
+import { acquireRefreshLock } from ${JSON.stringify(join(REPO_ROOT, "src/mirror/refresh-lock.ts"))};
+const root = ${JSON.stringify(root)};
+const docs = ${JSON.stringify(docs)};
+const heldSignal = join(root, "barrier-held");
+const triedSignal = join(root, "barrier-tried");
+${rewriteCorpusSource(marker)}
+async function waitForSignal(path, what) {
+	const deadline = Date.now() + ${BARRIER_WAIT_MS};
+	while (!existsSync(path)) {
+		if (Date.now() > deadline) {
+			throw new Error("race barrier timeout: " + what + " never appeared at " + path + " within ${BARRIER_WAIT_MS}ms");
+		}
+		await new Promise((resolve) => setTimeout(resolve, ${BARRIER_POLL_MS}));
+	}
+}
+function makeAgent() {
+	return new AutoRAGAgent({
+		workspacePath: root,
+		searchPaths: [docs],
+		bm25: { forceEngine: "typescript-fallback" },
+		minSync: false,
+	});
+}
+const lock = acquireRefreshLock(root);
+if (lock) {
+	writeFileSync(heldSignal, "held");
+	await waitForSignal(triedSignal, "the challenger's report");
+	lock.release();
+	const result = await makeAgent().refresh(true);
+	process.stdout.write(JSON.stringify({ role: "winner", outcome: result.outcome ?? "completed" }));
+} else {
+	await waitForSignal(heldSignal, "the winner's hold signal");
+	const result = await makeAgent().refresh(true);
+	writeFileSync(triedSignal, "tried");
+	process.stdout.write(JSON.stringify({ role: "challenger", outcome: result.outcome ?? "completed" }));
+}
+`;
+}
+
+interface ChildResult {
+	/** Present only for the racing script, which decides roles by the lock race. */
+	readonly role?: "winner" | "challenger";
+	readonly outcome: string;
+}
+
+/**
+ * Start a child process without blocking on it.
+ *
+ * A synchronous spawn would run the children one after another, which is not a race at all and
+ * would make the contention assertions vacuous. A non-zero exit rejects with the child's stderr so
+ * a barrier timeout fails the test with its message instead of a bare exit code.
+ */
+function startChild(root: string, script: string): Promise<ChildResult> {
+	const path = join(root, `child-${Math.random().toString(36).slice(2)}.ts`);
+	writeFileSync(path, script);
+	return new Promise((resolve, reject) => {
+		execFile("bun", ["run", path], { cwd: REPO_ROOT, encoding: "utf8" }, (error, stdout) => {
+			if (error) {
+				const stderr = typeof error.stderr === "string" && error.stderr.length > 0 ? `\n${error.stderr}` : "";
+				reject(new Error(`race child failed: ${error.message}${stderr}`));
+			} else {
+				resolve(JSON.parse(stdout) as ChildResult);
+			}
+		});
+	});
+}
+
+/** Run one round of two racing refreshes and report what the winner and the challenger did. */
+async function raceOnce(marker: string): Promise<{ winner: string; challenger: string }> {
+	const { root, searchPaths } = makeWorkspace("seed");
+	const docs = searchPaths[0] as string;
+	const outcomes = await Promise.all([
+		startChild(root, raceScript(root, docs, marker)),
+		startChild(root, raceScript(root, docs, marker)),
+	]);
+	const winner = outcomes.find((outcome) => outcome.role === "winner");
+	const challenger = outcomes.find((outcome) => outcome.role === "challenger");
+	if (winner === undefined || challenger === undefined) {
+		throw new Error(`race harness: expected one winner and one challenger, got ${JSON.stringify(outcomes)}`);
+	}
+	return { winner: winner.outcome, challenger: challenger.outcome };
+}
+
+function artifactMatchesMarker(root: string, marker: string): boolean {
+	const artifact = join(root, ".autorag", "bm25", "fallback-index.json");
+	if (!existsSync(artifact)) return false;
+	return readFileSync(artifact, "utf8").includes(marker);
+}
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Source for a child that runs the real CLI (`main` from `src/cli/index.ts`) against a workspace
+ * whose config lives in a temp home. The exit code and rendered output are the assertions, so the
+ * child must not swallow either.
+ */
+function cliChildScript(root: string, docs: string, args: readonly string[]): string {
+	return `
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { main } from ${JSON.stringify(join(REPO_ROOT, "src/cli/index.ts"))};
+const root = ${JSON.stringify(root)};
+const home = join(root, "home");
+process.env.HOME = home;
+process.env.AUTORAG_HOME = join(home, ".autorag");
+mkdirSync(process.env.AUTORAG_HOME, { recursive: true });
+writeFileSync(join(process.env.AUTORAG_HOME, "config.json"), JSON.stringify({
+	searchPaths: [${JSON.stringify(docs)}],
+	workspacePath: root,
+	memoryPath: join(root, "memory.json"),
+	bm25: { forceEngine: "typescript-fallback" },
+	minSync: false,
+}, null, 2));
+process.chdir(root);
+const code = await main(${JSON.stringify([...args])});
+process.exit(code);
+`;
+}
+
+interface CliChildResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+/**
+ * Run a CLI child that may legitimately exit non-zero. Unlike `startChild` (whose children must
+ * always succeed, so a non-zero exit rejects the race), these children are the commands under
+ * test: the exit code is the assertion.
+ */
+function startCliChild(root: string, script: string): Promise<CliChildResult> {
+	const path = join(root, `cli-child-${Math.random().toString(36).slice(2)}.ts`);
+	writeFileSync(path, script);
+	return new Promise((resolve) => {
+		execFile("bun", ["run", path], { cwd: REPO_ROOT, encoding: "utf8" }, (error, stdout, stderr) => {
+			resolve({
+				code: error ? (typeof error.code === "number" ? error.code : 1) : 0,
+				stdout,
+				stderr,
+			});
+		});
+	});
+}
+
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("refresh lock across processes", () => {
+	it("refuses a second caller while another holds the lock", async () => {
+		const { root, searchPaths } = makeWorkspace();
+		const agent = makeAgent(root, searchPaths);
+
+		const held = acquireRefreshLock(root);
+		expect(held).toBeDefined();
+
+		const refused = await agent.refresh(true);
+		expect(refused.outcome).toBe("busy");
+		expect(refused.bm25).toBeUndefined();
+		expect(refused.written).toBe(0);
+
+		held?.release();
+
+		// Once released, the same agent proceeds normally.
+		const completed = await agent.refresh(true);
+		expect(completed.outcome).toBe("completed");
+	});
+
+	it("does not honour a lock whose owner process is gone", async () => {
+		const { root, searchPaths } = makeWorkspace();
+		const agent = makeAgent(root, searchPaths);
+
+		// A pid that cannot be running, with a marker old enough to be reapable.
+		const lockDir = refreshLockPath(root);
+		mkdirSync(lockDir, { recursive: true });
+		const marker = join(lockDir, "owner-abandoned.json");
+		writeFileSync(
+			marker,
+			`${JSON.stringify({ token: "abandoned", pid: 2 ** 30, createdAt: Date.now() - 60 * 60 * 1000 })}\n`,
+		);
+		const old = new Date(Date.now() - 60 * 60 * 1000);
+		const fs = await import("node:fs");
+		fs.utimesSync(marker, old, old);
+
+		const result = await agent.refresh(true);
+		expect(result.outcome).toBe("completed");
+	});
+
+	it("honours a lock whose owner process is alive", async () => {
+		const { root, searchPaths } = makeWorkspace();
+		const agent = makeAgent(root, searchPaths);
+
+		const lockDir = refreshLockPath(root);
+		mkdirSync(lockDir, { recursive: true });
+		// This process is alive by definition, so the record must be honoured however old it looks.
+		writeFileSync(
+			join(lockDir, "owner-live.json"),
+			`${JSON.stringify({ token: "live", pid: process.pid, createdAt: Date.now() - 60 * 60 * 1000 })}\n`,
+		);
+
+		const result = await agent.refresh(true);
+		expect(result.outcome).toBe("busy");
+	});
+
+	it("lets exactly one of two racing processes do the work", async () => {
+		// Overlap is guaranteed by the handshake in `raceScript`, not by scheduling luck: the
+		// winner holds the lock until the challenger has attempted a refresh, so one completion
+		// and one refusal are the only reachable outcome. Two rounds so either spawn slot gets a
+		// chance to be the winner.
+		for (let round = 0; round < 2; round += 1) {
+			const outcome = await raceOnce(`round${round}`);
+			expect(outcome).toEqual({ winner: "completed", challenger: "busy" });
+		}
+	}, 120_000);
+
+	it("control: a child is busy while the lock is held and completes once it is released", async () => {
+		// The race test above asserts exactly one completion, which is only meaningful if the
+		// "busy" outcome is caused by the lock and not by the harness. This control removes every
+		// other variable: the parent takes the lock before the child starts and keeps holding it
+		// until the child has exited, so the refusal cannot come from scheduling; the same script
+		// and workspace then complete after the release, so the refusal cannot come from the
+		// harness either.
+		const { root, searchPaths } = makeWorkspace();
+		const script = refreshScript(root, searchPaths[0] as string, "ctl-held");
+
+		const held = acquireRefreshLock(root);
+		expect(held).toBeDefined();
+		expect((await startChild(root, script)).outcome).toBe("busy");
+
+		held?.release();
+		expect((await startChild(root, script)).outcome).toBe("completed");
+	}, 120_000);
+
+	it("control: two children in separate workspaces both complete", async () => {
+		// The race test rejects two completions. This control proves that outcome is reachable
+		// with the same harness: two children with no shared lock directory cannot contend, so
+		// both must complete however their execution interleaves. A harness that could only ever
+		// count one completion would fail here and make the race assertion vacuous.
+		const first = makeWorkspace("ctl-a");
+		const second = makeWorkspace("ctl-b");
+		const outcomes = await Promise.all([
+			startChild(first.root, refreshScript(first.root, first.searchPaths[0] as string, "ctl-a")),
+			startChild(second.root, refreshScript(second.root, second.searchPaths[0] as string, "ctl-b")),
+		]);
+		expect(outcomes.map((outcome) => outcome.outcome)).toEqual(["completed", "completed"]);
+	}, 120_000);
+
+	it("leaves an artifact that matches the corpus after racing processes", async () => {
+		// The seed corpus carries a different marker, so the final artifact can only match if the
+		// winner's refresh indexed the post-race corpus and no interleaving corrupted it.
+		const { root, searchPaths } = makeWorkspace("seed");
+		const docs = searchPaths[0] as string;
+		const marker = "mark0";
+
+		await Promise.all([
+			startChild(root, raceScript(root, docs, marker)),
+			startChild(root, raceScript(root, docs, marker)),
+		]);
+
+		// Settle with one uncontended refresh, then the artifact must carry the current marker.
+		const agent = makeAgent(root, searchPaths);
+		await agent.refresh(false);
+		expect(artifactMatchesMarker(root, marker)).toBe(true);
+	}, 120_000);
+	it("an explicit CLI refresh exits 1 and reports busy while the lock is held", async () => {
+		// Red-team scenario 1: `autorag refresh` refused by a held lock must not exit 0 as if the
+		// index had been updated. The parent holds the lock before the child starts, so the refusal
+		// is structural, not scheduling.
+		const { root, searchPaths } = makeWorkspace();
+		const docs = searchPaths[0] as string;
+
+		const held = acquireRefreshLock(root);
+		expect(held).toBeDefined();
+
+		const child = await startCliChild(root, cliChildScript(root, docs, ["refresh", "--json"]));
+
+		expect(child.code).toBe(1);
+		const envelope = JSON.parse(child.stdout) as Record<string, unknown>;
+		expect(envelope.outcome).toBe("busy");
+		expect(envelope.ok).toBe(false);
+		expect(envelope.counts).toEqual({ scanned: 0, written: 0, deleted: 0, skipped: 0 });
+
+		held?.release();
+	});
+
+	it("fails with a clear error, not busy, when a regular file sits at the lock path, and leaves it untouched", async () => {
+		// Red-team scenario 2: a regular file forged to look like a live lock owner. The old
+		// behaviour read it as contention forever (permanent silent DoS with exit 0) or, once
+		// stale-looking, silently unlinked the user's file via the legacy-file reaper. It must now
+		// fail loudly with a fixable message and never touch the file.
+		const { root, searchPaths } = makeWorkspace();
+		const docs = searchPaths[0] as string;
+
+		const lockFile = refreshLockPath(root);
+		mkdirSync(join(root, ".autorag"), { recursive: true });
+		const forged = `${JSON.stringify({ token: "forged", pid: process.pid, createdAt: Date.now() })}\n`;
+		writeFileSync(lockFile, forged);
+
+		const child = await startCliChild(root, cliChildScript(root, docs, ["refresh", "--json"]));
+
+		expect(child.code).toBe(1);
+		expect(child.stdout).not.toContain("busy");
+		expect(child.stderr).toContain("not a lock directory");
+		expect(child.stderr).toContain(".autorag/refresh.lock");
+		expect(readFileSync(lockFile, "utf8")).toBe(forged);
+	});
+
+	it("index rebuild holds the lock across deletion and re-indexing", async () => {
+		// Red-team scenario 3: `index rebuild` deleted the indexes, released the lock, and a
+		// concurrent refresh then made the re-indexing busy — exit 0 with the indexes gone. The
+		// rebuild must be one transaction: the parent watches the deletion happen (proof the
+		// rebuild started) and then asserts the lock stays held until the child exits. A free lock
+		// at any point inside that window is the silent data-loss bug.
+		const root = mkdtempSync(join(tmpdir(), "autorag-rebuild-"));
+		roots.push(root);
+		const docs = join(root, "docs");
+		mkdirSync(docs, { recursive: true });
+		// Large enough that the re-indexing after the deletion outlasts the parent's probes.
+		for (let i = 0; i < 300; i += 1) {
+			writeFileSync(
+				join(docs, `doc-${i}.md`),
+				`# Document ${i}\n\n${Array.from({ length: 3 }, (_, p) => `Paragraph ${p} of rebuild document ${i}.`).join("\n\n")}\n`,
+			);
+		}
+		const bm25Dir = join(root, ".autorag", "bm25");
+		mkdirSync(bm25Dir, { recursive: true });
+		writeFileSync(join(bm25Dir, "stale-index.json"), "{}");
+
+		const child = startCliChild(root, cliChildScript(root, docs, ["index", "rebuild", "--yes", "--json"]));
+
+		// The deletion is the proof that the rebuild has started.
+		const deleteDeadline = Date.now() + BARRIER_WAIT_MS;
+		while (existsSync(bm25Dir)) {
+			if (Date.now() > deleteDeadline) throw new Error("rebuild never removed the bm25 index dir");
+			await sleep(BARRIER_POLL_MS);
+		}
+
+		// From the deletion until the child exits the lock must never be acquirable.
+		const heldDeadline = Date.now() + BARRIER_WAIT_MS;
+		let observedHeld = false;
+		while (!observedHeld && Date.now() < heldDeadline) {
+			const probe = acquireRefreshLock(root);
+			if (probe === undefined) {
+				observedHeld = true;
+			} else {
+				probe.release();
+				await sleep(BARRIER_POLL_MS);
+			}
+		}
+		if (!observedHeld) {
+			throw new Error("rebuild lock became acquirable before the rebuild finished");
+		}
+
+		const result = await child;
+		expect(result.code).toBe(0);
+
+		// The lock is free again and the indexes were actually rebuilt.
+		const after = acquireRefreshLock(root);
+		expect(after).toBeDefined();
+		after?.release();
+		expect(existsSync(join(bm25Dir, "fallback-index.json"))).toBe(true);
+	}, 120_000);
+});

--- a/test/bench/refresh-lock.test.ts
+++ b/test/bench/refresh-lock.test.ts
@@ -1,0 +1,165 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { AutoRAGAgent } from "../../src/agent/agent.ts";
+
+/**
+ * Transaction guarantees for `refresh()`.
+ *
+ * The fingerprint skip makes interleaved refreshes dangerous: if one run commits the BM25 artifact
+ * while another commits the fingerprint, the fingerprint can end up describing a newer mirror than
+ * the artifact it points at, and the next refresh then matches the fingerprint and keeps the stale
+ * artifact without any error. These tests pin the guarantees that make that impossible.
+ */
+
+const roots: string[] = [];
+
+function makeWorkspace(documentCount: number, marker = "alpha"): { root: string; searchPaths: string[] } {
+	const root = mkdtempSync(join(tmpdir(), "autorag-lock-"));
+	roots.push(root);
+	const docs = join(root, "docs");
+	mkdirSync(docs, { recursive: true });
+	for (let i = 0; i < documentCount; i += 1) {
+		writeFileSync(join(docs, `doc-${i}.md`), `# Document ${i}\n\nRefund approval policy. Marker ${marker}.\n`);
+	}
+	return { root, searchPaths: [docs] };
+}
+
+function makeAgent(root: string, searchPaths: string[]): AutoRAGAgent {
+	return new AutoRAGAgent({
+		// `workspacePath` is what the agent uses as its project root; passing anything else silently
+		// falls back to process.cwd() and writes indexes into the current repository.
+		workspacePath: root,
+		searchPaths,
+		bm25: { forceEngine: "typescript-fallback" },
+		minSync: false,
+	});
+}
+
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("refresh transaction lock", () => {
+	it("runs the pipeline once for concurrent calls with the same parameters", async () => {
+		const { root, searchPaths } = makeWorkspace(6);
+		const agent = makeAgent(root, searchPaths);
+
+		// Count actual index builds by watching how often the parsed stage does work.
+		let builds = 0;
+		const original = agent.syncParsedMirrors.bind(agent);
+		(agent as unknown as { syncParsedMirrors: typeof agent.syncParsedMirrors }).syncParsedMirrors = async (
+			force?: boolean,
+		) => {
+			builds += 1;
+			return original(force);
+		};
+
+		const [first, second] = await Promise.all([agent.refresh(true), agent.refresh(true)]);
+
+		expect(builds).toBe(1);
+		expect(first.outcome).toBe("completed");
+		expect(second.outcome).toBe("completed");
+	});
+
+	it("gives joined callers the identical result object", async () => {
+		const { root, searchPaths } = makeWorkspace(4);
+		const agent = makeAgent(root, searchPaths);
+
+		const [first, second] = await Promise.all([agent.refresh(true), agent.refresh(true)]);
+
+		// Same run, so the same object: not merely equal values.
+		expect(second).toBe(first);
+	});
+
+	it("refuses a concurrent call with different parameters and runs no downstream stage", async () => {
+		const { root, searchPaths } = makeWorkspace(6);
+		const agent = makeAgent(root, searchPaths);
+
+		// Different `force` produces a different lock key, so the second call must be refused.
+		const running = agent.refresh(true);
+		const refused = await agent.refresh(false);
+
+		expect(refused.outcome).toBe("busy");
+		expect(refused.bm25).toBeUndefined();
+		expect(refused.minsync).toBeUndefined();
+		expect(refused.datasources).toEqual([]);
+		expect(refused.scanned).toBe(0);
+		expect(refused.written).toBe(0);
+		expect(refused.diagnostics).toEqual([]);
+
+		const completed = await running;
+		expect(completed.outcome).toBe("completed");
+	});
+
+	it("keeps artifact and fingerprint consistent under repeated interleaving attempts", async () => {
+		const { root, searchPaths } = makeWorkspace(5, "original");
+		const agent = makeAgent(root, searchPaths);
+		await agent.refresh(true);
+
+		const fingerprintPath = join(root, ".autorag", "bm25", "index-fingerprint.json");
+		const artifactPath = join(root, ".autorag", "bm25", "fallback-index.json");
+
+		// Twenty rounds of racing refreshes against a mutating corpus. After each round the stored
+		// fingerprint must describe the artifact that is actually on disk, which is checked by
+		// asking for a fresh refresh and confirming it does not skip a stale artifact: the indexed
+		// content must always contain the marker currently in the corpus.
+		for (let round = 0; round < 20; round += 1) {
+			const marker = `round${round}`;
+			for (let i = 0; i < 5; i += 1) {
+				writeFileSync(
+					join(searchPaths[0] as string, `doc-${i}.md`),
+					`# Document ${i}\n\nRefund approval policy. Marker ${marker}.\n`,
+				);
+			}
+			await Promise.all([agent.refresh(false), agent.refresh(false), agent.refresh(true)]);
+
+			// Settle any refusal by running one uncontended refresh.
+			await agent.refresh(false);
+
+			const artifact = readFileSync(artifactPath, "utf8");
+			expect(artifact).toContain(marker);
+			// A fingerprint must exist for the artifact that is present.
+			expect(() => readFileSync(fingerprintPath, "utf8")).not.toThrow();
+
+			const hits = await agent.searchAllDocuments(marker, { topK: 5 });
+			expect(hits.results.length).toBeGreaterThan(0);
+		}
+	});
+
+	it("releases the lock when a refresh throws", async () => {
+		const { root, searchPaths } = makeWorkspace(3);
+		const agent = makeAgent(root, searchPaths);
+
+		const original = agent.syncParsedMirrors.bind(agent);
+		let shouldFail = true;
+		(agent as unknown as { syncParsedMirrors: typeof agent.syncParsedMirrors }).syncParsedMirrors = async (
+			force?: boolean,
+		) => {
+			if (shouldFail) {
+				shouldFail = false;
+				throw new Error("injected failure");
+			}
+			return original(force);
+		};
+
+		await expect(agent.refresh(true)).rejects.toThrow("injected failure");
+
+		// The lock must not be wedged by the rejection.
+		const after = await agent.refresh(true);
+		expect(after.outcome).toBe("completed");
+	});
+
+	it("still serves a sequential refresh normally", async () => {
+		const { root, searchPaths } = makeWorkspace(4);
+		const agent = makeAgent(root, searchPaths);
+
+		const first = await agent.refresh(true);
+		const second = await agent.refresh(false);
+
+		expect(first.outcome).toBe("completed");
+		expect(second.outcome).toBe("completed");
+		expect(second.bm25?.skipped).toBe(true);
+	});
+});

--- a/test/bench/reset-lock.test.ts
+++ b/test/bench/reset-lock.test.ts
@@ -1,0 +1,159 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { runIndex } from "../../src/cli/commands/index.ts";
+import type { CommandContext } from "../../src/cli/commands/types.ts";
+import { MINSYNC_SUBDIR } from "../../src/minsync/paths.ts";
+import { AUTORAG_DIR, PARSED_MIRROR_SUBDIR } from "../../src/mirror/paths.ts";
+import { acquireRefreshLock, refreshLockPath } from "../../src/mirror/refresh-lock.ts";
+import { BM25_SUBDIR } from "../../src/retrieval/methods/bm25.ts";
+
+/**
+ * `index reset` deletes whole index subtrees. Two properties have to hold, and they are separate
+ * claims that are easy to conflate:
+ *
+ *   1. Reset must not run while a refresh holds the lock, or it deletes artifacts out from under a
+ *      writer that will then commit a fingerprint describing files that no longer exist.
+ *   2. The lock must survive reset. This is a placement property, not a mutual-exclusion property:
+ *      a lock stored inside a directory reset removes would be destroyed by the operation it is
+ *      supposed to exclude, so a third process would find the lock "free" while a refresh runs.
+ *
+ * Property 2 is the one that silently regresses if the lock path is ever moved back under an index
+ * directory, so it is asserted directly against the old placement as a control.
+ */
+
+const roots: string[] = [];
+
+function makeWorkspace(): string {
+	const root = mkdtempSync(join(tmpdir(), "autorag-resetlock-"));
+	roots.push(root);
+	const docs = join(root, "docs");
+	mkdirSync(docs, { recursive: true });
+	writeFileSync(join(docs, "a.md"), "# alpha\n\nsome indexable prose about alpha and beta.\n");
+	// Pre-create the index dirs with a sentinel so we can prove removal actually happened.
+	for (const subdir of [PARSED_MIRROR_SUBDIR, BM25_SUBDIR, MINSYNC_SUBDIR]) {
+		const dir = join(root, subdir);
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(join(dir, "sentinel.txt"), "present");
+	}
+	return root;
+}
+
+function makeContext(root: string, positionals: string[]): { ctx: CommandContext; out: string[]; err: string[] } {
+	const out: string[] = [];
+	const err: string[] = [];
+	const ctx: CommandContext = {
+		positionals,
+		flags: { yes: true, workspace: root },
+		json: false,
+		debug: false,
+		cwd: root,
+		stdout: (line) => out.push(line),
+		stderr: (line) => err.push(line),
+	};
+	return { ctx, out, err };
+}
+
+function sentinels(root: string): boolean[] {
+	return [PARSED_MIRROR_SUBDIR, BM25_SUBDIR, MINSYNC_SUBDIR].map((subdir) =>
+		existsSync(join(root, subdir, "sentinel.txt")),
+	);
+}
+
+afterAll(() => {
+	for (const root of roots) rmSync(root, { recursive: true, force: true });
+});
+
+describe("index reset participates in the refresh lock", () => {
+	it("refuses to delete anything while the refresh lock is held", async () => {
+		const root = makeWorkspace();
+		const held = acquireRefreshLock(root);
+		expect(held).toBeDefined();
+
+		const { ctx, err } = makeContext(root, ["reset"]);
+		const code = await runIndex(ctx);
+
+		expect(code).toBe(1);
+		expect(err.join("\n")).toContain("already running");
+		// The decisive assertion: refusal means nothing was removed, not merely that a message printed.
+		expect(sentinels(root)).toEqual([true, true, true]);
+
+		held?.release();
+	});
+
+	it("proceeds once the lock is released, and removes every target", async () => {
+		const root = makeWorkspace();
+		const held = acquireRefreshLock(root);
+		held?.release();
+
+		const { ctx } = makeContext(root, ["reset"]);
+		const code = await runIndex(ctx);
+
+		expect(code).toBe(0);
+		expect(sentinels(root)).toEqual([false, false, false]);
+	});
+
+	it("releases the lock after a reset so a later refresh is not permanently blocked", async () => {
+		const root = makeWorkspace();
+		const { ctx } = makeContext(root, ["reset"]);
+		expect(await runIndex(ctx)).toBe(0);
+
+		// If reset leaked the lock, this acquire would come back undefined.
+		const after = acquireRefreshLock(root);
+		expect(after).toBeDefined();
+		after?.release();
+	});
+
+	it("keeps the lock file outside every directory reset deletes", async () => {
+		const root = makeWorkspace();
+		const lockPath = refreshLockPath(root);
+
+		// Control: the previous placement was inside the parsed mirror, which reset removes. Assert
+		// that placement really would have been destroyed, so the property below is not vacuous.
+		const oldPlacement = join(root, PARSED_MIRROR_SUBDIR, "refresh.lock");
+		mkdirSync(oldPlacement, { recursive: true });
+
+		const { ctx } = makeContext(root, ["reset"]);
+		expect(await runIndex(ctx)).toBe(0);
+
+		expect(existsSync(oldPlacement)).toBe(false);
+		// The real lock path lives directly under `.autorag`, which reset preserves.
+		expect(lockPath.startsWith(join(root, AUTORAG_DIR))).toBe(true);
+		expect(lockPath.startsWith(join(root, PARSED_MIRROR_SUBDIR))).toBe(false);
+		expect(lockPath.startsWith(join(root, BM25_SUBDIR))).toBe(false);
+		expect(lockPath.startsWith(join(root, MINSYNC_SUBDIR))).toBe(false);
+	});
+
+	it("holds the lock across the deletion, not merely before it", async () => {
+		const root = makeWorkspace();
+		// Acquire, run reset in a way that must fail, then confirm a fresh acquire still works: this
+		// pins that the lock is scoped to the removal and cleaned up on the refusal path too.
+		const held = acquireRefreshLock(root);
+		const { ctx } = makeContext(root, ["reset"]);
+		expect(await runIndex(ctx)).toBe(1);
+		held?.release();
+
+		const reacquired = acquireRefreshLock(root);
+		expect(reacquired).toBeDefined();
+		reacquired?.release();
+		expect(sentinels(root)).toEqual([true, true, true]);
+	});
+	it("refuses to delete anything for rebuild while the refresh lock is held", async () => {
+		// Rebuild shares the reset refusal: if the lock is taken before the command starts, nothing
+		// may be deleted and the command must fail loudly — a rebuild that deletes and then reports
+		// busy (or success with no index) is silent data loss.
+		const root = makeWorkspace();
+		const held = acquireRefreshLock(root);
+		expect(held).toBeDefined();
+
+		const { ctx, err } = makeContext(root, ["rebuild"]);
+		const code = await runIndex(ctx);
+
+		expect(code).toBe(1);
+		expect(err.join("\n")).toContain("already running");
+		expect(sentinels(root)).toEqual([true, true, true]);
+
+		held?.release();
+	});
+});

--- a/test/cli/commands.watch.test.ts
+++ b/test/cli/commands.watch.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { CommandContext } from "../../src/cli/commands/types.ts";
 import { runWatch } from "../../src/cli/commands/watch.ts";
+import { acquireRefreshLock } from "../../src/mirror/refresh-lock.ts";
 
 let root: string;
 let docs: string;
@@ -63,5 +64,23 @@ describe("runWatch (cli)", () => {
 		expect(payload.ok === true || typeof payload.written === "number" || payload.parsed !== undefined || true).toBe(
 			true,
 		);
+	});
+	it("watch --once treats a busy tick as backpressure and still exits 0", async () => {
+		// Watch ticks are periodic sync: a busy tick is normal backpressure, not a failure. Unlike
+		// an explicit `autorag refresh`, the exit code must stay 0; the envelope still reports the
+		// refusal honestly.
+		writeConfig();
+		const held = acquireRefreshLock(root);
+		expect(held).toBeDefined();
+
+		const out: string[] = [];
+		const code = await runWatch(makeCtx({ stdout: (line) => out.push(line) }));
+
+		expect(code).toBe(0);
+		const payload = JSON.parse(out[0]) as Record<string, unknown>;
+		expect(payload.outcome).toBe("busy");
+		expect(payload.ok).toBe(false);
+
+		held?.release();
 	});
 });

--- a/test/cli/output.test.ts
+++ b/test/cli/output.test.ts
@@ -160,6 +160,47 @@ describe("renderSearch", () => {
 	});
 });
 
+describe("renderRefresh busy outcome", () => {
+	/** A refresh that was refused because another process held the lock: no work was done. */
+	function busyResult() {
+		return {
+			scanned: 0,
+			written: 0,
+			deleted: 0,
+			skipped: 0,
+			indexPath: "/tmp/does-not-matter/.autorag/parsed",
+			diagnostics: [],
+			datasources: [],
+			outcome: "busy" as const,
+		};
+	}
+
+	it("human output says busy instead of ok", () => {
+		const out = renderRefresh(busyResult(), {});
+		expect(out).toContain("refresh: busy");
+		expect(out).not.toContain("refresh: ok");
+		// Zero counters must not be presented as a successful no-op run.
+		expect(out).not.toContain("scanned=0");
+	});
+
+	it("json output carries the busy outcome", () => {
+		const parsed = JSON.parse(renderRefresh(busyResult(), { json: true })) as Record<string, unknown>;
+		expect(parsed.outcome).toBe("busy");
+	});
+	it("json output reports ok:false for a busy outcome", () => {
+		const parsed = JSON.parse(renderRefresh(busyResult(), { json: true })) as Record<string, unknown>;
+		expect(parsed.ok).toBe(false);
+		expect(parsed.outcome).toBe("busy");
+	});
+
+	it("a completed refresh carries no outcome field and still reads as ok", () => {
+		const out = renderRefresh(cannedRefreshResult(), {});
+		expect(out).toContain("refresh: ok");
+		const parsed = JSON.parse(renderRefresh(cannedRefreshResult(), { json: true })) as Record<string, unknown>;
+		expect(parsed.outcome).toBeUndefined();
+	});
+});
+
 describe("renderRefresh path opacity", () => {
 	it("human output contains no indexPath, no fake absolute path, and no .autorag/bm25", () => {
 		const out = renderRefresh(cannedRefreshResult(), {});

--- a/test/parser/decode-text.test.ts
+++ b/test/parser/decode-text.test.ts
@@ -1,0 +1,279 @@
+import { detect } from "chardet";
+import iconv from "iconv-lite";
+import { describe, expect, it, vi } from "vitest";
+import { decodeText } from "../../src/parser/text.ts";
+
+/**
+ * Equivalence safety net for the decodeText fast path.
+ *
+ * `decodeText` produces the text stored in the mirror, so the fast path (skip chardet for
+ * pure-ASCII bytes) is only legal if it reproduces the pre-change implementation byte for byte.
+ * The pre-change implementation is copied below verbatim (git HEAD of src/parser/text.ts) and
+ * every test compares the two as black boxes, including their failure behavior: an input that
+ * made the old implementation throw must still throw.
+ *
+ * chardet is mocked at module level so one test can prove the fast path really skips `detect()`
+ * (a throwing detect leaves pure-ASCII decodeText unharmed) while every other test runs the real
+ * detector through the same indirection.
+ */
+
+const detectImpl = vi.hoisted(() => ({
+	current: null as null | ((bytes: Uint8Array) => string | null),
+}));
+
+vi.mock("chardet", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("chardet")>();
+	return {
+		...actual,
+		detect: (bytes: Uint8Array) => (detectImpl.current ?? actual.detect)(bytes),
+	};
+});
+
+const WINDOWS_949_LABELS = new Set(["EUC-KR", "ISO-2022-KR", "windows-949", "CP949"]);
+
+/** Verbatim copy of the pre-fast-path decodeText from git HEAD of src/parser/text.ts. */
+function referenceDecodeText(bytes: Uint8Array): string {
+	const buffer = Buffer.from(bytes);
+	const utf8 = iconv.decode(buffer, "utf8");
+	if (referenceReplacementCount(utf8) > 0) {
+		const cp949 = iconv.decode(buffer, "cp949");
+		if (referenceReplacementCount(cp949) < referenceReplacementCount(utf8)) return cp949.normalize("NFC");
+	}
+	const detected = detect(buffer);
+	const encoding = detected && WINDOWS_949_LABELS.has(detected) ? "cp949" : (detected ?? "utf8");
+	return iconv.decode(buffer, encoding).normalize("NFC");
+}
+
+function referenceReplacementCount(value: string): number {
+	return [...value].filter((character) => character === "\uFFFD").length;
+}
+
+type Outcome = { readonly kind: "ok"; readonly value: string } | { readonly kind: "throw"; readonly message: string };
+
+function outcomeOf(decode: (bytes: Uint8Array) => string, bytes: Uint8Array): Outcome {
+	try {
+		return { kind: "ok", value: decode(bytes) };
+	} catch (error) {
+		return { kind: "throw", message: error instanceof Error ? error.message : String(error) };
+	}
+}
+
+function assertSameOutcome(bytes: Uint8Array): void {
+	expect(outcomeOf(decodeText, bytes)).toEqual(outcomeOf(referenceDecodeText, bytes));
+}
+
+describe("decodeText fast path equivalence", () => {
+	it("keeps pure ASCII byte-identical to the pre-change implementation", () => {
+		const cases = [
+			Buffer.from("hello world"),
+			Buffer.from("hello world\nthis is a test\n"),
+			Buffer.from("# Document 0\n\nRefund approval policy and escalation threshold.\n"),
+			Buffer.from("a\tb\tc\r\nd"),
+			Buffer.from("0123456789 !@#$%^&*()_+-=[]{}|;':\",./<>?`~"),
+			Buffer.from(new Uint8Array(Array.from({ length: 127 }, (_, i) => i + 1))), // every byte 0x01-0x7F
+			Buffer.from("ends without newline"),
+			Buffer.from("\n\n\n"),
+			Buffer.from("line1\r\nline2\r\nline3"),
+		];
+		for (const bytes of cases) assertSameOutcome(bytes);
+	});
+
+	it("keeps ESC-containing ASCII on the legacy path, throw included", () => {
+		const cases = [
+			Buffer.from("ESC \x1b$B test\n"),
+			Buffer.from("\x1b$B"),
+			Buffer.from("\x1b$B\x1b(Bplain"),
+			Buffer.from("\x1b$C ESC \x1b$B mixed"),
+		];
+		for (const bytes of cases) assertSameOutcome(bytes);
+		// A full ISO-2022-JP escape sequence made the old implementation throw (iconv-lite cannot
+		// decode ISO-2022-JP); the fast path must not silently change that into a clean string.
+		expect(outcomeOf(referenceDecodeText, Buffer.from("ESC \x1b$B test\n")).kind).toBe("throw");
+		expect(outcomeOf(referenceDecodeText, Buffer.from("\x1b$B")).kind).toBe("throw");
+		// A 2-byte ESC prefix is too short for the ISO-2022-JP detector; UTF-32LE claims the
+		// buffer and iconv drops the incomplete unit, so the legacy output is "".
+		expect(outcomeOf(referenceDecodeText, Buffer.from("\x1b$"))).toEqual({ kind: "ok", value: "" });
+	});
+
+	it("keeps Korean UTF-8 identical", () => {
+		assertSameOutcome(Buffer.from("한글 테스트 문서입니다\n안녕하세요, 세계!\n", "utf8"));
+		assertSameOutcome(Buffer.from("가나다라마바사아자차카타파하", "utf8"));
+	});
+
+	it("keeps the CP949 fallback path alive", () => {
+		// CP949 bytes for "한글" and a longer legacy-encoded paragraph.
+		assertSameOutcome(Buffer.from([0xc7, 0xd1, 0xb1, 0xdb]));
+		const cp949 = iconv.encode("한글 문서입니다. 오늘은 화요일입니다.", "cp949");
+		assertSameOutcome(cp949);
+	});
+
+	it("keeps UTF-8 BOM input identical", () => {
+		assertSameOutcome(Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from("hello world\n")]));
+		assertSameOutcome(Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from("한글 BOM 문서\n", "utf8")]));
+		assertSameOutcome(Buffer.from([0xef, 0xbb, 0xbf]));
+	});
+
+	it("keeps the empty buffer identical", () => {
+		assertSameOutcome(new Uint8Array(0));
+	});
+
+	it("keeps invalid byte sequences identical", () => {
+		const cases = [
+			new Uint8Array([0x80]),
+			new Uint8Array([0xc3]), // truncated two-byte sequence
+			new Uint8Array([0xe2, 0x82]), // truncated three-byte sequence
+			new Uint8Array([0xf0, 0x9f, 0x92]), // truncated four-byte sequence
+			new Uint8Array([0xff, 0xff, 0xff]),
+			new Uint8Array([0xc3, 0x28]), // invalid continuation
+			new Uint8Array([0x61, 0xc3, 0x28]), // valid byte then an invalid sequence
+			new Uint8Array([0xfe, 0x80, 0x80, 0x80]),
+		];
+		for (const bytes of cases) assertSameOutcome(bytes);
+	});
+
+	it("keeps NFC-normalizing input identical (combining characters)", () => {
+		// Decomposed Hangul and a decomposed Latin letter: NFC must actually fire in both paths.
+		assertSameOutcome(Buffer.from("한글", "utf8"));
+		assertSameOutcome(Buffer.from("e\u0301", "utf8"));
+		assertSameOutcome(Buffer.from("cafe\u0301 \u1100\u1161", "utf8"));
+	});
+
+	it("keeps null-byte input identical", () => {
+		const cases = [
+			new Uint8Array([0x61, 0x00, 0x62]),
+			new Uint8Array([0x61, 0x00, 0x62, 0x00]),
+			Buffer.concat([Buffer.from("한", "utf8"), new Uint8Array([0x00]), Buffer.from("글", "utf8")]),
+			new Uint8Array([0x00]),
+			new Uint8Array([0x00, 0x00, 0x00, 0x00]),
+		];
+		for (const bytes of cases) assertSameOutcome(bytes);
+	});
+});
+
+/** Deterministic PRNG (mulberry32) so property failures reproduce exactly. */
+function mulberry32(seed: number): () => number {
+	let state = seed;
+	return () => {
+		state = (state + 0x6d2b79f5) | 0;
+		let t = Math.imul(state ^ (state >>> 15), 1 | state);
+		t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+type ByteGenerator = (random: () => number, length: number) => Uint8Array;
+
+function randomBytes(random: () => number, length: number, pick: (random: () => number) => number): Uint8Array {
+	const bytes = new Uint8Array(length);
+	for (let i = 0; i < length; i += 1) bytes[i] = pick(random);
+	return bytes;
+}
+
+/** Every byte in 0x01-0x7F, ESC included, so the fast path boundary is exercised. */
+function asciiBytes(random: () => number, length: number): Uint8Array {
+	return randomBytes(random, length, () => 1 + Math.floor(random() * 127));
+}
+
+/** Mostly ASCII, with a sprinkle of nulls and high bytes crossing into legacy-path territory. */
+function mixedBytes(random: () => number, length: number): Uint8Array {
+	return randomBytes(random, length, () => {
+		const roll = random();
+		if (roll < 0.8) return 1 + Math.floor(random() * 127);
+		if (roll < 0.9) return 0;
+		return 128 + Math.floor(random() * 128);
+	});
+}
+
+/** Uniform 0x00-0xFF, the adversarial corner: arbitrary binary data. */
+function uniformBytes(random: () => number, length: number): Uint8Array {
+	return randomBytes(random, length, () => Math.floor(random() * 256));
+}
+
+/**
+ * Biased toward valid UTF-8 text (Korean, Latin-1 accents, CJK) with occasional invalid bytes,
+ * approximating real-world markdown corpora in several scripts.
+ */
+function utf8ishBytes(random: () => number, length: number): Uint8Array {
+	const fragments = ["한", "글", "문", "서", "é", "ü", "ñ", "日", "中", "Ж", "α", " ", "\n", "\t", "a", "9", "."];
+	const parts: Uint8Array[] = [];
+	let produced = 0;
+	while (produced < length) {
+		if (random() < 0.12) {
+			// A raw invalid byte: a lone high byte or a forbidden lead (0xC0-0xC1, 0xF5-0xFF).
+			const invalid = new Uint8Array([
+				random() < 0.5 ? 0x80 + Math.floor(random() * 64) : 0xc0 + Math.floor(random() * 2),
+			]);
+			parts.push(invalid);
+			produced += 1;
+		} else {
+			const fragment = Buffer.from(fragments[Math.floor(random() * fragments.length)] ?? "a", "utf8");
+			parts.push(fragment);
+			produced += fragment.length;
+		}
+	}
+	return Buffer.concat(parts).subarray(0, length);
+}
+
+function exerciseProperty(seed: number, count: number, generate: ByteGenerator, label: string): void {
+	const random = mulberry32(seed);
+	let fastPathHits = 0;
+	for (let i = 0; i < count; i += 1) {
+		const length = Math.floor(random() * 256);
+		const bytes = generate(random, length);
+		const fast = outcomeOf(decodeText, bytes);
+		const reference = outcomeOf(referenceDecodeText, bytes);
+		expect(fast, `${label} sample ${i}`).toEqual(reference);
+		if (fast.kind === "ok" && isFastPathEligible(bytes)) {
+			fastPathHits += 1;
+		}
+	}
+	// Every sample of this generator is fast-path eligible, so a batch that never takes the fast
+	// path means the predicate changed and the boundary moved out from under this test.
+	if (label === "ascii") {
+		expect(fastPathHits, `${label} must exercise the fast path`).toBeGreaterThan(0);
+	}
+}
+
+function isFastPathEligible(bytes: Uint8Array): boolean {
+	if (bytes.length === 0) return true;
+	if (bytes.length < 4) return false;
+	return bytes.every((byte) => byte >= 0x01 && byte <= 0x7f && byte !== 0x1b);
+}
+
+describe("decodeText fast path seeded property equivalence", () => {
+	it("matches the pre-change implementation on pure-ASCII buffers", () => {
+		exerciseProperty(0xa11ce, 400, asciiBytes, "ascii");
+	});
+
+	it("matches on mixed ASCII/null/high-byte buffers", () => {
+		exerciseProperty(0xbeef, 400, mixedBytes, "mixed");
+	});
+
+	it("matches on arbitrary 0x00-0xFF buffers", () => {
+		exerciseProperty(0xdead, 400, uniformBytes, "uniform");
+	});
+
+	it("matches on UTF-8-biased text buffers", () => {
+		exerciseProperty(0xf00d, 400, utf8ishBytes, "utf8ish");
+	});
+});
+
+describe("decodeText fast path observability", () => {
+	it("skips detect() for pure ASCII and still consults it otherwise", () => {
+		detectImpl.current = () => {
+			throw new Error("detect must not be called");
+		};
+		try {
+			// Pure ASCII without ESC: the fast path answers without chardet.
+			expect(decodeText(Buffer.from("pure ascii body\nline two\n"))).toBe("pure ascii body\nline two\n");
+			expect(decodeText(new Uint8Array(0))).toBe("");
+			// ESC routes to the legacy path, which calls detect() and must hit the throwing mock.
+			expect(() => decodeText(Buffer.from("\x1b$B"))).toThrow("detect must not be called");
+			// Any non-ASCII byte routes to the legacy path as well.
+			expect(() => decodeText(Buffer.from("한글", "utf8"))).toThrow("detect must not be called");
+			expect(() => decodeText(new Uint8Array([0x61, 0x00]))).toThrow("detect must not be called");
+		} finally {
+			detectImpl.current = null;
+		}
+	});
+});


### PR DESCRIPTION
## What

Three hot-path optimizations, measured against this branch's merge base with a separate checkout of `main` on the same machine.

| Corpus | `main` cold refresh | this branch | |
|---|---|---|---|
| 200 ASCII docs | 175 ms | **42 ms** | 4.2x |
| **200 Korean docs** | 199 ms | 200 ms | **1.0x — no gain** |

| Workload | `main` | this branch | |
|---|---|---|---|
| No-op refresh, 2,000 docs | 78 ms | 44 ms | 1.8x |
| Selective query, 1,200 chunks | 19.0 ms | 0.021 ms | |

The Korean row is the honest headline caveat: the parser fast path only applies to pure-ASCII sources, so a Korean-document corpus sees no cold-refresh gain. It still benefits from the index and query work (no-op refresh 2.0x). Given that this project targets Korean documents, please weigh that when scoping.

## Commits

Three independent changes, split so they can be reviewed or landed separately. **Happy to split into separate PRs on request** — the natural boundary is `parser` alone, and `fingerprint skip + lock` before `query cache` (the cache uses the fingerprint sidecar as its invalidation key).

1. **`perf(parser)`** — skip `chardet.detect()` for pure-ASCII buffers. Independent of the other two.
2. **`perf(retrieval)` fingerprint skip + cross-process lock** — a no-op refresh no longer rebuilds the BM25 index. The lock is not optional here: skipping is only sound if artifact and fingerprint commits cannot interleave across processes.
3. **`perf(retrieval)` query cache** — the fallback engine no longer re-tokenizes the corpus and linearly scans every chunk per query.

## Behavior changes

These are deliberate and observable. Please push back if you'd prefer different semantics.

- **`autorag refresh` refused because another refresh holds the lock now exits 1** (`ok:false`, `outcome:"busy"`) instead of exiting 0. Previously a refused refresh looked successful to anything checking only the exit code. This can break existing `set -e` CI or cron that treated contention as success; conversely, exit-code-based retry can now detect and back off.
- **`index reset` / `index rebuild` exit 1 when refused** for the same reason, and reset removes nothing in that case.
- **A non-directory file at `.autorag/refresh.lock` is now an explicit error**, not a "busy" result. Previously it silently made refresh and reset do nothing.
- `watch` is unaffected — busy is normal backpressure there and ticks still exit 0.

## Correctness

The parser change is the one that touches stored content, so it is argued rather than sampled: for a pure-ASCII buffer the set of encodings `chardet` can return is enumerable, and every member decodes `0x01-0x7F` identically. Sampling backs it up — a test keeps a copy of the previous implementation and compares both across boundary lengths, boundary byte values, BOM, NUL bytes, combining characters and pseudo-random buffers.

Because the fingerprint decides whether a stored artifact is trusted, the code that determines artifact meaning is pinned by source-region markers that a test digests: chunking, chunk id hashing, fallback persistence schema, tantivy schema construction, the fingerprint material itself, and mirror normalization. Changing any of them fails until `INDEX_SEMANTICS_VERSION` is bumped or the recorded digest is refreshed deliberately.

**This guard is a manual allowlist.** It does not discover new files or helpers on its own. If a future change puts artifact-shaping logic outside the marked regions, the guard will not notice.

Query-time code (`tokenize`, `bm25Score`, `k1`, `b`) is intentionally *outside* those regions. Changing the tokenizer changes query results immediately and correctly against the stored artifact — verified by a test that mutates it and observes the artifact mtime stay unchanged while results change. Guarding it would force needless global rebuilds.

## Known limitations

- **Korean corpora get no cold-refresh gain** (above). Widening the fast path to "any valid UTF-8" is *not* safe: the current code follows `chardet` even for valid UTF-8, so short or ambiguous inputs could decode differently. Doing it would be a semantics change requiring a version bump and migration.
- **`index rebuild` is concurrency-atomic but not rollback-atomic.** Delete and rebuild are covered by one lock, so no other refresh can interleave. But if parsing or building fails after the delete, the indexes stay removed and you must rerun.
- **`artifactBytes` only checks size.** A same-length tampered artifact passes. It is truncation detection, not integrity verification.
- **`auto` engine sticks to fallback** after one tantivy failure, because the engine is part of the fingerprint. Results stay correct but quality silently stays lower until `index rebuild`.
- **Cache retention is an empirical budget, not a hard cap.** It estimates bytes pinned by the fallback structure; it does not count allocator overhead and does not cover native tantivy handles.
- **Without a fingerprint sidecar the query cache is not held at all** — prepared state is rebuilt per query. That is deliberate (there is no cross-process invalidation key), and one normal refresh fixes it, but querying a large sidecar-less corpus is slow until then.
- **Parser and dependency upgrades still need `--force`.** An unchanged source with the same mtime/size is not re-mirrored, so a new parser or a `chardet`/`iconv-lite` upgrade does not re-parse existing documents.
- Stale lock reclaim cannot distinguish PID reuse; `mkdir` atomicity is unverified on NFS.

## Verification

`biome check` (252 files, 0 warnings), `tsc --noEmit`, and `bun run build` all pass.

`vitest run` reports 3 failures out of 1,365:

| File | Cause |
|---|---|
| `test/parser/parser.test.ts` | no Java runtime on this machine (PDF parser) |
| `test/agent/parser-mirror.test.ts` | same |
| `test/jikji/installer.test.ts` | load-dependent flake; **passes 10/10 in isolation** |

That last one is worth flagging separately: the suite is load-dependent regardless of this branch. Running `vitest run` on the unmodified merge base on this machine produced *more* failures (12 files / 15 tests) than this branch (10 files / 13 tests) in the same session. `vitest.config.ts` sets no pool or concurrency limits, so wall-clock-budgeted tests compete under load. Happy to open that as a separate issue.

Test count 1,249 → 1,365. New tests cover fingerprint skip, artifact integrity, semantics guard, mirror sync contracts, query cache equivalence and bounds, lock behavior in-process and across real OS processes, and decode equivalence.

## Not included

An earlier revision parallelized mirror parsing. It was reverted before this PR: measured gain was 1.01–1.10x on markdown (parsing is dominated by synchronous CPU, not I/O wait), and adversarial testing found a deadlock on a zero concurrency limit, unbounded fan-out on NaN, and a checkpoint/disk digest mismatch that could serve stale results indefinitely. It needs a deterministic commit-prefix design and real PDF/Office corpus measurements, so it belongs in its own change.
