### PR TITLE
perf(parser): skip encoding detection for pure ASCII sources (4.2x cold refresh)

### DIFF
--- a/src/parser/text.ts
+++ b/src/parser/text.ts
@@ -1,10 +1,24 @@
 import { detect } from "chardet";
 import iconv from "iconv-lite";
 
+// Text decoding and normalization applied to mirror content before BM25 chunking: the stored
+// artifact contains exactly the text produced here, so a change invalidates every stored index.
 const WINDOWS_949_LABELS = new Set(["EUC-KR", "ISO-2022-KR", "windows-949", "CP949"]);
 
 export function decodeText(bytes: Uint8Array): string {
 	const buffer = Buffer.from(bytes);
+	if (isPureAscii(bytes)) {
+		// Bytes 0x01-0x7F decode to the same code points under utf8, cp949, and every single-byte
+		// encoding chardet can name, and NFC normalization is the identity on them, so the result
+		// is fixed without consulting chardet. ESC (0x1B) is excluded: chardet can claim
+		// ISO-2022-JP/CN for buffers containing its escape sequences, which iconv-lite cannot
+		// decode, so those bytes must keep the legacy path. Buffers shorter than one 4-byte unit
+		// are excluded too: chardet's UTF-32LE heuristic can claim UTF-32LE for control-character
+		// and DEL bytes, and iconv-lite then drops the incomplete trailing unit, making the legacy
+		// output "". Pure printable ASCII decodes normally ("A"/"AB"/"ABC"), so excluding every
+		// sub-4-byte buffer is just the conservative choice and must keep the legacy path.
+		return iconv.decode(buffer, "ascii");
+	}
 	const utf8 = iconv.decode(buffer, "utf8");
 	if (replacementCount(utf8) > 0) {
 		const cp949 = iconv.decode(buffer, "cp949");
@@ -21,4 +35,14 @@ export function normalizeMarkdown(markdown: string): string {
 
 function replacementCount(value: string): number {
 	return [...value].filter((character) => character === "\uFFFD").length;
+}
+
+function isPureAscii(bytes: Uint8Array): boolean {
+	if (bytes.length === 0) return true;
+	if (bytes.length < 4) return false;
+	for (let i = 0; i < bytes.length; i += 1) {
+		const byte = bytes[i] as number;
+		if (byte < 0x01 || byte === 0x1b || byte > 0x7f) return false;
+	}
+	return true;
 }

--- a/test/bench/measure-decode.ts
+++ b/test/bench/measure-decode.ts
@@ -1,0 +1,181 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detect } from "chardet";
+import iconv from "iconv-lite";
+import { syncParsedMirrors } from "../../src/mirror/sync.ts";
+import { type ParseInput, type ParseOutput, Parser, ParserRegistry } from "../../src/parser/index.ts";
+import { decodeText } from "../../src/parser/text.ts";
+
+/**
+ * Measures the decodeText fast path against the pre-change implementation.
+ *
+ * Table 1: per-document decode cost for the three document shapes that matter (pure ASCII,
+ * Korean UTF-8, Korean CP949), before (legacy copy of git HEAD) and after (current source), plus
+ * the two ingredients of the ASCII fast path in isolation (the purity scan and the ASCII iconv
+ * decode). chardet's detect() was measured at ~670-710us on these shapes, which is what the fast
+ * path must avoid.
+ *
+ * Table 2: full mirror refresh (syncParsedMirrors, serial schedule, force) at two corpus sizes for
+ * ASCII and Korean corpora, legacy decode versus current decode. decodeText runs only in the
+ * mirror parse stage, so the delta here is the whole-refresh delta; the BM25 stage is untouched by
+ * this change.
+ */
+
+const WINDOWS_949_LABELS = new Set(["EUC-KR", "ISO-2022-KR", "windows-949", "CP949"]);
+
+/** Copy of the pre-fast-path decodeText (git HEAD of src/parser/text.ts). */
+function legacyDecodeText(bytes: Uint8Array): string {
+	const buffer = Buffer.from(bytes);
+	const utf8 = iconv.decode(buffer, "utf8");
+	if (legacyReplacementCount(utf8) > 0) {
+		const cp949 = iconv.decode(buffer, "cp949");
+		if (legacyReplacementCount(cp949) < legacyReplacementCount(utf8)) return cp949.normalize("NFC");
+	}
+	const detected = detect(buffer);
+	const encoding = detected && WINDOWS_949_LABELS.has(detected) ? "cp949" : (detected ?? "utf8");
+	return iconv.decode(buffer, encoding).normalize("NFC");
+}
+
+function legacyReplacementCount(value: string): number {
+	return [...value].filter((character) => character === "\uFFFD").length;
+}
+
+/** The fast-path purity scan in isolation (copy of the predicate in src/parser/text.ts). */
+function isPureAsciiScan(bytes: Uint8Array): boolean {
+	if (bytes.length === 0) return true;
+	if (bytes.length < 4) return false;
+	for (let i = 0; i < bytes.length; i += 1) {
+		const byte = bytes[i] as number;
+		if (byte < 0x01 || byte === 0x1b || byte > 0x7f) return false;
+	}
+	return true;
+}
+
+function median(times: readonly number[]): number {
+	const sorted = [...times].sort((a, b) => a - b);
+	return sorted[Math.floor(sorted.length / 2)] as number;
+}
+
+/** Median microseconds per call over `rounds` batches of `iterations` calls each. */
+function measurePerCall(fn: () => string, rounds: number, iterations: number): number {
+	const times: number[] = [];
+	for (let round = 0; round < rounds; round += 1) {
+		const started = performance.now();
+		for (let i = 0; i < iterations; i += 1) fn();
+		times.push(((performance.now() - started) * 1000) / iterations);
+	}
+	return Number(median(times).toFixed(1));
+}
+
+const asciiDoc = Buffer.from(
+	"# Document 0\n\nRefund approval policy and escalation threshold.\nQuarterly chargeback report.\n".repeat(46),
+);
+const koreanText = [
+	"# 문서 제목\n\n환불 정책과 승인 절차에 대한 안내입니다.\n",
+	"매 분기마다 차지백 보고서를 작성하고, 승인 임계값을 검토합니다.\n",
+	"고객 지원 팀은 접수된 문의를 우선순위에 따라 처리합니다.\n",
+].join("\n");
+const koreanUtf8Doc = Buffer.from(koreanText.repeat(22), "utf8");
+const koreanCp949Doc = iconv.encode(koreanText.repeat(22), "cp949");
+
+const docs = [
+	{ label: "ASCII 4KB", bytes: asciiDoc },
+	{ label: "Korean UTF-8 5.5KB", bytes: koreanUtf8Doc },
+	{ label: "Korean CP949 5.5KB", bytes: koreanCp949Doc },
+] as const;
+
+console.log("| document type | bytes | legacy decode (us) | new decode (us) | speedup |");
+console.log("|---|---|---|---|---|");
+const decodeRows: Record<string, number | string>[] = [];
+for (const doc of docs) {
+	const legacy = measurePerCall(() => legacyDecodeText(doc.bytes), 5, 200);
+	const current = measurePerCall(() => decodeText(doc.bytes), 5, 200);
+	decodeRows.push({
+		doc: doc.label,
+		bytes: doc.bytes.length,
+		legacyUs: legacy,
+		newUs: current,
+		speedup: Number((legacy / current).toFixed(1)),
+	});
+	console.log(`| ${doc.label} | ${doc.bytes.length} | ${legacy} | ${current} | ${(legacy / current).toFixed(2)}x |`);
+}
+
+// The two ingredients of the ASCII fast path, isolated, so the scan cost itself is on record.
+const scanUs = measurePerCall(() => (isPureAsciiScan(asciiDoc) ? "x" : "y"), 5, 2000);
+const asciiDecodeUs = measurePerCall(() => iconv.decode(asciiDoc, "ascii"), 5, 2000);
+console.log(`\nASCII fast-path ingredients: purity scan ${scanUs}us, ascii iconv decode ${asciiDecodeUs}us (4KB doc)`);
+
+interface Corpus {
+	readonly root: string;
+	readonly docs: string;
+}
+
+function buildCorpus(documentCount: number, body: Buffer): Corpus {
+	const root = mkdtempSync(join(tmpdir(), "autorag-measure-decode-"));
+	const docs = join(root, "docs");
+	mkdirSync(docs, { recursive: true });
+	for (let i = 0; i < documentCount; i += 1) {
+		writeFileSync(join(docs, `doc-${String(i).padStart(5, "0")}.md`), body);
+	}
+	return { root, docs };
+}
+
+class DecodeParser extends Parser {
+	readonly name = "plain-text";
+	readonly extensions = [".md"] as const;
+	readonly decode: (bytes: Uint8Array) => string;
+
+	constructor(decode: (bytes: Uint8Array) => string) {
+		super();
+		this.decode = decode;
+	}
+
+	async parse(input: ParseInput): Promise<ParseOutput> {
+		return { markdown: this.decode(input.bytes) };
+	}
+}
+
+async function medianRefreshMs(
+	root: string,
+	docs: string,
+	decode: (bytes: Uint8Array) => string,
+	samples: number,
+): Promise<number> {
+	const times: number[] = [];
+	for (let i = 0; i < samples; i += 1) {
+		const started = performance.now();
+		await syncParsedMirrors({
+			root,
+			searchPaths: [docs],
+			registry: new ParserRegistry([new DecodeParser(decode)]),
+			force: true,
+		});
+		times.push(performance.now() - started);
+	}
+	return Number(median(times).toFixed(0));
+}
+
+console.log("\n| corpus | legacy refresh (ms) | new refresh (ms) | delta |");
+console.log("|---|---|---|---|");
+const refreshRows: Record<string, number | string>[] = [];
+for (const [label, body] of [
+	["ASCII 4KB x100", asciiDoc],
+	["ASCII 4KB x400", asciiDoc],
+	["Korean UTF-8 5.5KB x100", koreanUtf8Doc],
+	["Korean UTF-8 5.5KB x400", koreanUtf8Doc],
+] as const) {
+	const count = label.includes("x400") ? 400 : 100;
+	const sized = buildCorpus(count, body);
+	try {
+		const legacy = await medianRefreshMs(sized.root, sized.docs, legacyDecodeText, 3);
+		const current = await medianRefreshMs(sized.root, sized.docs, decodeText, 3);
+		const delta = Number((((current - legacy) / legacy) * 100).toFixed(1));
+		refreshRows.push({ corpus: label, legacyMs: legacy, newMs: current, deltaPct: delta });
+		console.log(`| ${label} | ${legacy} | ${current} | ${delta >= 0 ? "+" : ""}${delta}% |`);
+	} finally {
+		rmSync(sized.root, { recursive: true, force: true });
+	}
+}
+
+console.log(`\nJSON: ${JSON.stringify({ decodeRows, scanUs, asciiDecodeUs, refreshRows })}`);

--- a/test/parser/decode-text.test.ts
+++ b/test/parser/decode-text.test.ts
@@ -1,0 +1,279 @@
+import { detect } from "chardet";
+import iconv from "iconv-lite";
+import { describe, expect, it, vi } from "vitest";
+import { decodeText } from "../../src/parser/text.ts";
+
+/**
+ * Equivalence safety net for the decodeText fast path.
+ *
+ * `decodeText` produces the text stored in the mirror, so the fast path (skip chardet for
+ * pure-ASCII bytes) is only legal if it reproduces the pre-change implementation byte for byte.
+ * The pre-change implementation is copied below verbatim (git HEAD of src/parser/text.ts) and
+ * every test compares the two as black boxes, including their failure behavior: an input that
+ * made the old implementation throw must still throw.
+ *
+ * chardet is mocked at module level so one test can prove the fast path really skips `detect()`
+ * (a throwing detect leaves pure-ASCII decodeText unharmed) while every other test runs the real
+ * detector through the same indirection.
+ */
+
+const detectImpl = vi.hoisted(() => ({
+	current: null as null | ((bytes: Uint8Array) => string | null),
+}));
+
+vi.mock("chardet", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("chardet")>();
+	return {
+		...actual,
+		detect: (bytes: Uint8Array) => (detectImpl.current ?? actual.detect)(bytes),
+	};
+});
+
+const WINDOWS_949_LABELS = new Set(["EUC-KR", "ISO-2022-KR", "windows-949", "CP949"]);
+
+/** Verbatim copy of the pre-fast-path decodeText from git HEAD of src/parser/text.ts. */
+function referenceDecodeText(bytes: Uint8Array): string {
+	const buffer = Buffer.from(bytes);
+	const utf8 = iconv.decode(buffer, "utf8");
+	if (referenceReplacementCount(utf8) > 0) {
+		const cp949 = iconv.decode(buffer, "cp949");
+		if (referenceReplacementCount(cp949) < referenceReplacementCount(utf8)) return cp949.normalize("NFC");
+	}
+	const detected = detect(buffer);
+	const encoding = detected && WINDOWS_949_LABELS.has(detected) ? "cp949" : (detected ?? "utf8");
+	return iconv.decode(buffer, encoding).normalize("NFC");
+}
+
+function referenceReplacementCount(value: string): number {
+	return [...value].filter((character) => character === "\uFFFD").length;
+}
+
+type Outcome = { readonly kind: "ok"; readonly value: string } | { readonly kind: "throw"; readonly message: string };
+
+function outcomeOf(decode: (bytes: Uint8Array) => string, bytes: Uint8Array): Outcome {
+	try {
+		return { kind: "ok", value: decode(bytes) };
+	} catch (error) {
+		return { kind: "throw", message: error instanceof Error ? error.message : String(error) };
+	}
+}
+
+function assertSameOutcome(bytes: Uint8Array): void {
+	expect(outcomeOf(decodeText, bytes)).toEqual(outcomeOf(referenceDecodeText, bytes));
+}
+
+describe("decodeText fast path equivalence", () => {
+	it("keeps pure ASCII byte-identical to the pre-change implementation", () => {
+		const cases = [
+			Buffer.from("hello world"),
+			Buffer.from("hello world\nthis is a test\n"),
+			Buffer.from("# Document 0\n\nRefund approval policy and escalation threshold.\n"),
+			Buffer.from("a\tb\tc\r\nd"),
+			Buffer.from("0123456789 !@#$%^&*()_+-=[]{}|;':\",./<>?`~"),
+			Buffer.from(new Uint8Array(Array.from({ length: 127 }, (_, i) => i + 1))), // every byte 0x01-0x7F
+			Buffer.from("ends without newline"),
+			Buffer.from("\n\n\n"),
+			Buffer.from("line1\r\nline2\r\nline3"),
+		];
+		for (const bytes of cases) assertSameOutcome(bytes);
+	});
+
+	it("keeps ESC-containing ASCII on the legacy path, throw included", () => {
+		const cases = [
+			Buffer.from("ESC \x1b$B test\n"),
+			Buffer.from("\x1b$B"),
+			Buffer.from("\x1b$B\x1b(Bplain"),
+			Buffer.from("\x1b$C ESC \x1b$B mixed"),
+		];
+		for (const bytes of cases) assertSameOutcome(bytes);
+		// A full ISO-2022-JP escape sequence made the old implementation throw (iconv-lite cannot
+		// decode ISO-2022-JP); the fast path must not silently change that into a clean string.
+		expect(outcomeOf(referenceDecodeText, Buffer.from("ESC \x1b$B test\n")).kind).toBe("throw");
+		expect(outcomeOf(referenceDecodeText, Buffer.from("\x1b$B")).kind).toBe("throw");
+		// A 2-byte ESC prefix is too short for the ISO-2022-JP detector; UTF-32LE claims the
+		// buffer and iconv drops the incomplete unit, so the legacy output is "".
+		expect(outcomeOf(referenceDecodeText, Buffer.from("\x1b$"))).toEqual({ kind: "ok", value: "" });
+	});
+
+	it("keeps Korean UTF-8 identical", () => {
+		assertSameOutcome(Buffer.from("한글 테스트 문서입니다\n안녕하세요, 세계!\n", "utf8"));
+		assertSameOutcome(Buffer.from("가나다라마바사아자차카타파하", "utf8"));
+	});
+
+	it("keeps the CP949 fallback path alive", () => {
+		// CP949 bytes for "한글" and a longer legacy-encoded paragraph.
+		assertSameOutcome(Buffer.from([0xc7, 0xd1, 0xb1, 0xdb]));
+		const cp949 = iconv.encode("한글 문서입니다. 오늘은 화요일입니다.", "cp949");
+		assertSameOutcome(cp949);
+	});
+
+	it("keeps UTF-8 BOM input identical", () => {
+		assertSameOutcome(Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from("hello world\n")]));
+		assertSameOutcome(Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from("한글 BOM 문서\n", "utf8")]));
+		assertSameOutcome(Buffer.from([0xef, 0xbb, 0xbf]));
+	});
+
+	it("keeps the empty buffer identical", () => {
+		assertSameOutcome(new Uint8Array(0));
+	});
+
+	it("keeps invalid byte sequences identical", () => {
+		const cases = [
+			new Uint8Array([0x80]),
+			new Uint8Array([0xc3]), // truncated two-byte sequence
+			new Uint8Array([0xe2, 0x82]), // truncated three-byte sequence
+			new Uint8Array([0xf0, 0x9f, 0x92]), // truncated four-byte sequence
+			new Uint8Array([0xff, 0xff, 0xff]),
+			new Uint8Array([0xc3, 0x28]), // invalid continuation
+			new Uint8Array([0x61, 0xc3, 0x28]), // valid byte then an invalid sequence
+			new Uint8Array([0xfe, 0x80, 0x80, 0x80]),
+		];
+		for (const bytes of cases) assertSameOutcome(bytes);
+	});
+
+	it("keeps NFC-normalizing input identical (combining characters)", () => {
+		// Decomposed Hangul and a decomposed Latin letter: NFC must actually fire in both paths.
+		assertSameOutcome(Buffer.from("한글", "utf8"));
+		assertSameOutcome(Buffer.from("e\u0301", "utf8"));
+		assertSameOutcome(Buffer.from("cafe\u0301 \u1100\u1161", "utf8"));
+	});
+
+	it("keeps null-byte input identical", () => {
+		const cases = [
+			new Uint8Array([0x61, 0x00, 0x62]),
+			new Uint8Array([0x61, 0x00, 0x62, 0x00]),
+			Buffer.concat([Buffer.from("한", "utf8"), new Uint8Array([0x00]), Buffer.from("글", "utf8")]),
+			new Uint8Array([0x00]),
+			new Uint8Array([0x00, 0x00, 0x00, 0x00]),
+		];
+		for (const bytes of cases) assertSameOutcome(bytes);
+	});
+});
+
+/** Deterministic PRNG (mulberry32) so property failures reproduce exactly. */
+function mulberry32(seed: number): () => number {
+	let state = seed;
+	return () => {
+		state = (state + 0x6d2b79f5) | 0;
+		let t = Math.imul(state ^ (state >>> 15), 1 | state);
+		t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+type ByteGenerator = (random: () => number, length: number) => Uint8Array;
+
+function randomBytes(random: () => number, length: number, pick: (random: () => number) => number): Uint8Array {
+	const bytes = new Uint8Array(length);
+	for (let i = 0; i < length; i += 1) bytes[i] = pick(random);
+	return bytes;
+}
+
+/** Every byte in 0x01-0x7F, ESC included, so the fast path boundary is exercised. */
+function asciiBytes(random: () => number, length: number): Uint8Array {
+	return randomBytes(random, length, () => 1 + Math.floor(random() * 127));
+}
+
+/** Mostly ASCII, with a sprinkle of nulls and high bytes crossing into legacy-path territory. */
+function mixedBytes(random: () => number, length: number): Uint8Array {
+	return randomBytes(random, length, () => {
+		const roll = random();
+		if (roll < 0.8) return 1 + Math.floor(random() * 127);
+		if (roll < 0.9) return 0;
+		return 128 + Math.floor(random() * 128);
+	});
+}
+
+/** Uniform 0x00-0xFF, the adversarial corner: arbitrary binary data. */
+function uniformBytes(random: () => number, length: number): Uint8Array {
+	return randomBytes(random, length, () => Math.floor(random() * 256));
+}
+
+/**
+ * Biased toward valid UTF-8 text (Korean, Latin-1 accents, CJK) with occasional invalid bytes,
+ * approximating real-world markdown corpora in several scripts.
+ */
+function utf8ishBytes(random: () => number, length: number): Uint8Array {
+	const fragments = ["한", "글", "문", "서", "é", "ü", "ñ", "日", "中", "Ж", "α", " ", "\n", "\t", "a", "9", "."];
+	const parts: Uint8Array[] = [];
+	let produced = 0;
+	while (produced < length) {
+		if (random() < 0.12) {
+			// A raw invalid byte: a lone high byte or a forbidden lead (0xC0-0xC1, 0xF5-0xFF).
+			const invalid = new Uint8Array([
+				random() < 0.5 ? 0x80 + Math.floor(random() * 64) : 0xc0 + Math.floor(random() * 2),
+			]);
+			parts.push(invalid);
+			produced += 1;
+		} else {
+			const fragment = Buffer.from(fragments[Math.floor(random() * fragments.length)] ?? "a", "utf8");
+			parts.push(fragment);
+			produced += fragment.length;
+		}
+	}
+	return Buffer.concat(parts).subarray(0, length);
+}
+
+function exerciseProperty(seed: number, count: number, generate: ByteGenerator, label: string): void {
+	const random = mulberry32(seed);
+	let fastPathHits = 0;
+	for (let i = 0; i < count; i += 1) {
+		const length = Math.floor(random() * 256);
+		const bytes = generate(random, length);
+		const fast = outcomeOf(decodeText, bytes);
+		const reference = outcomeOf(referenceDecodeText, bytes);
+		expect(fast, `${label} sample ${i}`).toEqual(reference);
+		if (fast.kind === "ok" && isFastPathEligible(bytes)) {
+			fastPathHits += 1;
+		}
+	}
+	// Every sample of this generator is fast-path eligible, so a batch that never takes the fast
+	// path means the predicate changed and the boundary moved out from under this test.
+	if (label === "ascii") {
+		expect(fastPathHits, `${label} must exercise the fast path`).toBeGreaterThan(0);
+	}
+}
+
+function isFastPathEligible(bytes: Uint8Array): boolean {
+	if (bytes.length === 0) return true;
+	if (bytes.length < 4) return false;
+	return bytes.every((byte) => byte >= 0x01 && byte <= 0x7f && byte !== 0x1b);
+}
+
+describe("decodeText fast path seeded property equivalence", () => {
+	it("matches the pre-change implementation on pure-ASCII buffers", () => {
+		exerciseProperty(0xa11ce, 400, asciiBytes, "ascii");
+	});
+
+	it("matches on mixed ASCII/null/high-byte buffers", () => {
+		exerciseProperty(0xbeef, 400, mixedBytes, "mixed");
+	});
+
+	it("matches on arbitrary 0x00-0xFF buffers", () => {
+		exerciseProperty(0xdead, 400, uniformBytes, "uniform");
+	});
+
+	it("matches on UTF-8-biased text buffers", () => {
+		exerciseProperty(0xf00d, 400, utf8ishBytes, "utf8ish");
+	});
+});
+
+describe("decodeText fast path observability", () => {
+	it("skips detect() for pure ASCII and still consults it otherwise", () => {
+		detectImpl.current = () => {
+			throw new Error("detect must not be called");
+		};
+		try {
+			// Pure ASCII without ESC: the fast path answers without chardet.
+			expect(decodeText(Buffer.from("pure ascii body\nline two\n"))).toBe("pure ascii body\nline two\n");
+			expect(decodeText(new Uint8Array(0))).toBe("");
+			// ESC routes to the legacy path, which calls detect() and must hit the throwing mock.
+			expect(() => decodeText(Buffer.from("\x1b$B"))).toThrow("detect must not be called");
+			// Any non-ASCII byte routes to the legacy path as well.
+			expect(() => decodeText(Buffer.from("한글", "utf8"))).toThrow("detect must not be called");
+			expect(() => decodeText(new Uint8Array([0x61, 0x00]))).toThrow("detect must not be called");
+		} finally {
+			detectImpl.current = null;
+		}
+	});
+});


### PR DESCRIPTION
`chardet.detect()` dominates document reading, and it runs even when the answer is already determined.

Per 4KB file:

| step | cost |
|---|---|
| `iconv.decode(buffer, "utf8")` | 10 us |
| **`chardet.detect(buffer)`** | **672 us** |
| `.normalize("NFC")` | 1 us |

So ~98% of the per-file budget is spent deciding what encoding a file is in — including for plain ASCII files, where every plausible answer decodes to the same string.

## Change

Skip detection when the buffer is **pure ASCII**: at least 4 bytes, every byte in `0x01`–`0x7F`, no ESC.

## Why this cannot change output

For a buffer meeting that predicate, `chardet` can only return `ASCII`, `UTF-8`, `ISO-8859-x`, `Shift_JIS`, `Big5`, `EUC-JP`, `EUC-KR` or `GB18030`. The others are structurally excluded:

- UTF-16 / UTF-32 need a BOM or NUL bytes — NUL is excluded by the predicate
- ISO-2022 needs ESC — excluded
- `windows-125x` recognizers need C1 bytes (`0x80`–`0x9F`) — excluded

Every remaining candidate maps `0x01`–`0x7F` to the same code points, and NFC is the identity on that range. So the decoded string is identical by construction, not by luck.

Buffers shorter than 4 bytes deliberately stay on the legacy path: `chardet`'s UTF-32LE heuristic can claim UTF-32LE for short control-character buffers, and `iconv-lite` then drops the incomplete trailing unit, so the existing output for those is `""`. Preserving that keeps this a pure optimization rather than a silent behavior change.

## Effect

Cold refresh of a 200-document corpus, median of 5 runs, same corpus and machine, comparing this branch against a separate checkout of `main`:

| corpus | `main` | this branch | |
|---|---|---|---|
| ASCII | 175 ms | **42 ms** | **4.2x** |
| **Korean** | 199 ms | 200 ms | **1.0x** |

Korean documents are not pure ASCII, so they take the legacy path and see no change. Worth stating plainly given this project's primary corpus: this speeds up English/code/ASCII-markdown ingestion and leaves Korean ingestion where it was.

Widening the predicate to "any valid UTF-8" would help Korean, but it is **not** safe as a pure optimization: the current code follows `chardet` even when UTF-8 decodes cleanly, so short or ambiguous inputs could decode differently. That would be a semantics change needing a version bump and re-parse, so it is out of scope here.

## Verification

`test/parser/decode-text.test.ts` keeps a copy of the previous implementation and asserts both produce byte-identical output across boundary lengths (0–5), boundary byte values (`0x00`, `0x01`, `0x7F`, `0x80`), UTF-8 BOM, NUL bytes, CP949-encoded Korean, combining characters, invalid sequences, and seeded pseudo-random buffers.

Adversarial sweeps beyond the committed test found no divergence in 321,053 generated cases.

`test/bench/measure-decode.ts` reproduces the numbers above; it is not collected by vitest.

## Scope

This is one of three optimizations I measured; it is the only one that is fully independent, so it is offered on its own. The other two (skipping BM25 rebuilds for an unchanged corpus, and caching query-time state) share a fingerprint mechanism and a cross-process lock, and they change CLI exit-code semantics, so they are a separate and much larger conversation. Happy to open that separately if this direction is welcome.
