### PR TITLE
feat(datasource): add WhatsApp wacrawl backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Security defaults are intentionally strict:
 | Datasource | Skill | Connects via | Notes |
 |---|---|---|---|
 | KakaoTalk | `katok` | external [`katok`](https://github.com/NomaDamas/katok) CLI | first datasource skill; AutoRAG never reads KakaoTalk databases directly |
+| WhatsApp | `whatsapp` | external [`wacrawl`](https://github.com/openclaw/wacrawl) CLI | local-first incremental archive + FTS5 search; live desktop ingestion is macOS-only |
 | Slack | `slack` | Slack Web API (bot token) | workspace/channel history; per-channel scope failures degrade to warnings |
 | Discord | `discord` | Discord REST v10 (bot token) | guild/channel messages; Hangul channel names work as scopes |
 | Notion | `notion` | Notion API (integration token) | pages/databases shared with the integration; block-tree text |
@@ -143,13 +144,14 @@ Security defaults are intentionally strict:
 | Obsidian vault | `obsidian` | filesystem (markdown) | frontmatter/inline tags, wiki links `[[...]]`, embeds `![[...]]` |
 | RSS / news | `rss` | HTTP feed polling | RSS 2.0 + Atom, feed/category hierarchy, 24h dedupe window |
 
-All of them share one framework: a trusted connector fetches documents at refresh time, chunks persist under `<workspace>/.autorag/datasources/<skill>/<instance>/`, and queries run against a local BM25 lexical index (Korean-aware prefix matching) through `search_datasource_documents`. Tokens are referenced by environment variable name only (e.g. `SLACK_BOT_TOKEN`), never stored in config. Auth/permission/rate-limit failures surface as path/PII-opaque diagnostics. See [docs/manual-qa-datasources.md](docs/manual-qa-datasources.md) for the QA harnesses.
+Connector-backed skills fetch documents into AutoRAG's local chunk store. External-crawler skills such as KakaoTalk and WhatsApp leave incremental archive and FTS ownership with their CLI and map query results into the same retrieval pipeline. Tokens are referenced by environment variable name only, never stored in config. Process/API failures surface as path/PII-opaque diagnostics. See [docs/manual-qa-datasources.md](docs/manual-qa-datasources.md) for the QA harnesses.
 
 Configure them in `config.json` (CLI) or pass `datasourceSkills` programmatically:
 
 ```jsonc
 {
   "datasources": {
+    "whatsapp": { "instanceId": "personal", "connector": { "binaryPath": "wacrawl" } },
     "slack":    { "connector": { "tokenEnv": "SLACK_BOT_TOKEN" } },
     "github":   { "connector": { "repos": ["owner/repo"] } },
     "gmail":    { "connector": { "backend": "himalaya", "account": "gmail", "folder": "INBOX" } },
@@ -158,11 +160,13 @@ Configure them in `config.json` (CLI) or pass `datasourceSkills` programmaticall
     "rss":      { "connector": { "feeds": [{ "url": "https://example.com/feed.xml" }] } }
   },
   "datasourceAccess": {
-    "allowedTags": ["slack", "github", "gmail", "gdrive", "obsidian", "rss"],
-    "allowedScopes": ["/slack/**", "/github/**", "/gmail/**", "/gdrive/**", "/obsidian/**", "/rss/**"]
+    "allowedTags": ["whatsapp", "slack", "github", "gmail", "gdrive", "obsidian", "rss"],
+    "allowedScopes": ["/whatsapp/**", "/slack/**", "/github/**", "/gmail/**", "/gdrive/**", "/obsidian/**", "/rss/**"]
   }
 }
 ```
+
+Install wacrawl with `brew install openclaw/tap/wacrawl`. AutoRAG invokes `wacrawl sync` during datasource refresh and `wacrawl --json --sync never search` during retrieval. Optional trusted connector fields are `binaryPath`, `databasePath`, and `sourcePath`. The child process receives only a restricted environment; unrelated model/provider secrets are not forwarded. Live WhatsApp Desktop discovery requires macOS and the permissions documented by wacrawl, while an existing portable archive can be queried on other supported platforms.
 
 #### KakaoTalk (katok)
 

--- a/docs/manual-qa-datasources.md
+++ b/docs/manual-qa-datasources.md
@@ -1,8 +1,10 @@
-# Manual QA — Connector-Backed Datasource Skills
+# Manual QA — Datasource Skills
 
 Covers issues #1300 (Slack), #1301 (Google Drive), #1302 (Notion), #1303
 (GitHub Issues/PRs), #1304 (Gmail), #1305 (Discord), #1311 (local mail
 export), #1314 (Obsidian vault), #1316 (RSS/news), #1350 (macOS Spotlight).
+Issue #1416 adds external-crawler process coverage, beginning with WhatsApp
+through wacrawl.
 
 ## Harnesses
 
@@ -11,6 +13,7 @@ export), #1314 (Obsidian vault), #1316 (RSS/news), #1350 (macOS Spotlight).
 | `scripts/manual-qa/run-qa.ts` | Protocol-accurate local mocks of Slack/Discord/Notion/GitHub/Drive/Gmail APIs + real filesystem fixtures (Obsidian vault, mbox/eml exports) + local RSS feed | `bun scripts/manual-qa/run-qa.ts` |
 | `scripts/manual-qa/run-qa-live.ts` | Real public GitHub REST API (this repo's issues) and a real RSS feed (hnrss.org), credential-free | `bun scripts/manual-qa/run-qa-live.ts` |
 | `scripts/manual-qa/run-qa-spotlight-live.ts` | Real macOS Spotlight (`mdfind`/`mdimport`) end-to-end; macOS only, no credentials | `bun scripts/manual-qa/run-qa-spotlight-live.ts` |
+| `test/datasource/skills/wacrawl.test.ts` | Real child-process boundary with a deterministic fake wacrawl executable: argv, JSON parsing, env isolation, missing binary, malformed output, indexing, retrieval | `bunx vitest run test/datasource/skills/wacrawl.test.ts` |
 
 Skills that need tenant credentials (Slack bot token, Discord bot token,
 Notion integration token, Drive/Gmail OAuth tokens) are QA'd against the
@@ -19,6 +22,12 @@ failures (`invalid_auth`, HTTP 401/403/429). To QA against a real tenant,
 point `connector.baseUrl` at the real API base and supply the token via the
 default env var (`SLACK_BOT_TOKEN`, `DISCORD_BOT_TOKEN`, `NOTION_TOKEN`,
 `GITHUB_TOKEN`, `GDRIVE_ACCESS_TOKEN`, `GMAIL_ACCESS_TOKEN`).
+
+WhatsApp uses the external wacrawl CLI instead of an HTTP mock. The deterministic
+test executable exercises the actual spawn/stdout/stderr contract without
+requiring access to a private WhatsApp archive. For a live macOS check, install
+wacrawl, grant its documented Full Disk Access, configure
+`datasources.whatsapp`, then run `autorag refresh --method datasources`.
 
 ## Checklist (all automated by the harnesses)
 

--- a/skills/autorag-setup/SKILL.md
+++ b/skills/autorag-setup/SKILL.md
@@ -234,7 +234,7 @@ via the role-specific flags or:
 
 ## Configure datasource skills (optional)
 
-External datasources (Slack, Discord, Notion, GitHub Issues/PRs, Google
+External datasources (WhatsApp, Slack, Discord, Notion, GitHub Issues/PRs, Google
 Drive, Gmail, local mail exports, Obsidian vaults, RSS/news) are configured
 as **datasource skills** in the trusted config file — never via model/tool
 arguments. Add a `datasources` section (skill name → config) plus a trusted
@@ -243,6 +243,7 @@ arguments. Add a `datasources` section (skill name → config) plus a trusted
 ```jsonc
 {
   "datasources": {
+    "whatsapp": { "instanceId": "personal", "connector": { "binaryPath": "wacrawl" } },
     "slack":    { "connector": { "tokenEnv": "SLACK_BOT_TOKEN", "channels": ["eng"] } },
     "discord":  { "connector": { "tokenEnv": "DISCORD_BOT_TOKEN", "guildId": "..." } },
     "notion":   { "connector": { "tokenEnv": "NOTION_TOKEN" } },
@@ -254,8 +255,8 @@ arguments. Add a `datasources` section (skill name → config) plus a trusted
     "rss":      { "connector": { "feeds": [{ "url": "https://example.com/feed.xml" }] } }
   },
   "datasourceAccess": {
-    "allowedTags": ["slack", "github", "rss"],
-    "allowedScopes": ["/slack/**", "/github/**", "/rss/**"]
+    "allowedTags": ["whatsapp", "slack", "github", "rss"],
+    "allowedScopes": ["/whatsapp/**", "/slack/**", "/github/**", "/rss/**"]
   }
 }
 ```
@@ -273,6 +274,11 @@ Rules:
   any of rclone's 70+ backends) configured via `rclone config` — Docs/Sheets
   are exported as text through `--drive-export-formats`. Auth lives entirely
   in the external tool's own config, matching the katok pattern.
+- `whatsapp` requires the external
+  [wacrawl](https://github.com/openclaw/wacrawl) binary
+  (`brew install openclaw/tap/wacrawl`). Optional trusted connector fields are
+  `binaryPath`, `databasePath`, and `sourcePath`. Live desktop ingestion is
+  macOS-only; the crawler owns Full Disk Access and archive setup.
 - Access is **default-deny**: without `datasourceAccess.allowedTags`, no
   datasource skill is announced or searchable, even when configured.
   `allowedScopes` are opaque slash-hierarchical roots like `/slack/<instance>/**`.

--- a/src/datasource/crawler-client.ts
+++ b/src/datasource/crawler-client.ts
@@ -1,0 +1,177 @@
+import type { ChildProcess } from "node:child_process";
+import { spawn } from "node:child_process";
+import type {
+	CrawlerCliOptions,
+	CrawlerFailure,
+	CrawlerProfile,
+	CrawlerSearchOptions,
+	CrawlerSearchResult,
+	CrawlerSyncResult,
+} from "./crawler-types.ts";
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_MAX_BUFFER_BYTES = 1_048_576;
+const SAFE_ENV_KEYS = new Set(["HOME", "LANG", "LC_ALL", "PATH", "TMPDIR", "TMP", "TEMP", "NO_COLOR"]);
+
+type ProcessResult = {
+	readonly ok: boolean;
+	readonly reason?: CrawlerFailure["reason"];
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly code: number | null;
+};
+
+type BufferState = {
+	readonly text: string;
+	readonly bytes: number;
+	readonly capped: boolean;
+};
+
+export class CrawlerCliClient {
+	private readonly profile: CrawlerProfile;
+	private readonly options: CrawlerCliOptions;
+
+	constructor(profile: CrawlerProfile, options: CrawlerCliOptions = {}) {
+		this.profile = profile;
+		this.options = options;
+	}
+
+	async sync(signal?: AbortSignal): Promise<CrawlerSyncResult> {
+		const result = await this.run(this.profile.syncArgs(this.options), signal);
+		if (!result.ok) return toFailure(this.profile.binaryName, result);
+		const count = this.profile.parseSyncCount(result.stdout);
+		if (count === undefined) return toFailure(this.profile.binaryName, result, "invalid-output");
+		return { ok: true, count, stdout: result.stdout, stderr: result.stderr, code: result.code ?? 0 };
+	}
+
+	async search(query: string, options: CrawlerSearchOptions = {}): Promise<CrawlerSearchResult> {
+		const topK = options.topK ?? 20;
+		const result = await this.run(this.profile.searchArgs(this.options, query, topK), options.signal);
+		if (!result.ok) return toFailure(this.profile.binaryName, result);
+		const hits = this.profile.parseHits(result.stdout);
+		if (hits === undefined) return toFailure(this.profile.binaryName, result, "invalid-output");
+		return { ok: true, hits, stdout: result.stdout, stderr: result.stderr, code: result.code ?? 0 };
+	}
+
+	private run(args: readonly string[], signal?: AbortSignal): Promise<ProcessResult> {
+		const env = controlledEnv(this.profile.allowedEnvPrefixes, this.options.env);
+		env.CRAWLKIT_NO_UPDATE_CHECK = "1";
+		return spawnCrawler(this.options.binaryPath ?? this.profile.binaryName, args, env, signal, this.options);
+	}
+}
+
+function spawnCrawler(
+	command: string,
+	args: readonly string[],
+	env: NodeJS.ProcessEnv,
+	signal: AbortSignal | undefined,
+	options: CrawlerCliOptions,
+): Promise<ProcessResult> {
+	return new Promise((resolve) => {
+		const child = spawn(command, args, { env, stdio: ["ignore", "pipe", "pipe"] });
+		let stdout: BufferState = { text: "", bytes: 0, capped: false };
+		let stderr: BufferState = { text: "", bytes: 0, capped: false };
+		let settled = false;
+		let finalReason: CrawlerFailure["reason"] | undefined;
+		const maxBuffer = options.maxBufferBytes ?? DEFAULT_MAX_BUFFER_BYTES;
+		const timeout = setTimeout(() => {
+			finalReason = "timeout";
+			terminate(child);
+		}, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+		const abortHandler = (): void => {
+			finalReason = "aborted";
+			terminate(child);
+		};
+		if (signal?.aborted) abortHandler();
+		signal?.addEventListener("abort", abortHandler, { once: true });
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk: string) => {
+			stdout = appendBounded(stdout, chunk, maxBuffer);
+			if (stdout.capped) {
+				finalReason = "stdout-too-large";
+				terminate(child);
+			}
+		});
+		child.stderr.on("data", (chunk: string) => {
+			stderr = appendBounded(stderr, chunk, maxBuffer);
+			if (stderr.capped) {
+				finalReason = "stderr-too-large";
+				terminate(child);
+			}
+		});
+		child.on("error", (error: NodeJS.ErrnoException) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			signal?.removeEventListener("abort", abortHandler);
+			resolve({
+				ok: false,
+				reason: error.code === "ENOENT" ? "binary-missing" : "spawn-error",
+				stdout: stdout.text,
+				stderr: "",
+				code: null,
+			});
+		});
+		child.on("close", (code) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			signal?.removeEventListener("abort", abortHandler);
+			resolve({
+				ok: code === 0 && finalReason === undefined,
+				...(finalReason !== undefined
+					? { reason: finalReason }
+					: code === 0
+						? {}
+						: { reason: "nonzero-exit" as const }),
+				stdout: stdout.text,
+				stderr: stderr.text,
+				code,
+			});
+		});
+	});
+}
+
+function controlledEnv(
+	allowedPrefixes: readonly string[],
+	configured: Readonly<Record<string, string | undefined>> | undefined,
+): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = {};
+	for (const [key, value] of Object.entries(process.env)) {
+		if (value !== undefined && isAllowedEnvKey(key, allowedPrefixes)) env[key] = value;
+	}
+	for (const [key, value] of Object.entries(configured ?? {})) {
+		if (value === undefined) delete env[key];
+		else if (isAllowedEnvKey(key, allowedPrefixes)) env[key] = value;
+	}
+	return env;
+}
+
+function isAllowedEnvKey(key: string, allowedPrefixes: readonly string[]): boolean {
+	return (
+		SAFE_ENV_KEYS.has(key) || key.startsWith("CRAWLKIT_") || allowedPrefixes.some((prefix) => key.startsWith(prefix))
+	);
+}
+
+function appendBounded(state: BufferState, chunk: string, maxBytes: number): BufferState {
+	const nextBytes = state.bytes + Buffer.byteLength(chunk);
+	if (nextBytes <= maxBytes) return { text: state.text + chunk, bytes: nextBytes, capped: false };
+	const remaining = Math.max(maxBytes - state.bytes, 0);
+	return { text: state.text + chunk.slice(0, remaining), bytes: maxBytes, capped: true };
+}
+
+function terminate(child: ChildProcess): void {
+	if (!child.killed) child.kill("SIGTERM");
+}
+
+function toFailure(binaryName: string, result: ProcessResult, reason?: CrawlerFailure["reason"]): CrawlerFailure {
+	const failed = result.stderr.length > 0 || result.stdout.length > 0;
+	return {
+		ok: false,
+		reason: reason ?? result.reason ?? "nonzero-exit",
+		stdout: "",
+		stderr: failed ? `${binaryName} command failed; details suppressed for datasource privacy` : "",
+		code: result.code,
+	};
+}

--- a/src/datasource/crawler-skill.ts
+++ b/src/datasource/crawler-skill.ts
@@ -1,0 +1,256 @@
+import type {
+	RetrievalMethod,
+	RetrievalMethodDescriptor,
+	RetrievalOptions,
+	RetrievalResult,
+} from "../retrieval/types.ts";
+import type { CrawlerSearchOptions, CrawlerSearchResult, CrawlerSyncResult } from "./crawler-types.ts";
+import { datasourceSourcePath, matchesDatasourceScope } from "./scope.ts";
+import type {
+	DatasourceDiagnosticCode,
+	DatasourceIndexResult,
+	DatasourceSkill,
+	DatasourceSkillDescriptor,
+	DatasourceSkillManifest,
+	PollingMetadata,
+	SourceDescription,
+} from "./types.ts";
+
+export interface CrawlerSkillClient {
+	sync(signal?: AbortSignal): Promise<CrawlerSyncResult>;
+	search(query: string, options?: CrawlerSearchOptions): Promise<CrawlerSearchResult>;
+}
+
+export interface CrawlerDatasourceDefinition {
+	readonly datasourceId: string;
+	readonly skillType: string;
+	readonly description: string;
+	readonly defaultTags: readonly string[];
+	readonly contentType: string;
+	readonly manifestDescription: string;
+	readonly backendName: string;
+}
+
+export interface CrawlerDatasourceSkillOptions {
+	readonly client: CrawlerSkillClient;
+	readonly instanceId?: string;
+	readonly instances?: readonly string[];
+	readonly pollingIntervalMs?: number;
+	readonly tags?: readonly string[];
+	readonly lastIndexedAt?: number;
+}
+
+const DEFAULT_INSTANCE_ID = "default";
+const DEFAULT_POLLING_INTERVAL_MS = 15 * 60 * 1000;
+
+export class CrawlerDatasourceSkill implements DatasourceSkill {
+	private readonly definition: CrawlerDatasourceDefinition;
+	private readonly client: CrawlerSkillClient;
+	private readonly instanceId: string;
+	private readonly instances: readonly string[];
+	private readonly pollingIntervalMs: number;
+	private readonly tags: readonly string[];
+	private lastIndexedAt: number | undefined;
+
+	constructor(definition: CrawlerDatasourceDefinition, options: CrawlerDatasourceSkillOptions) {
+		this.definition = definition;
+		this.client = options.client;
+		this.instanceId = options.instanceId ?? DEFAULT_INSTANCE_ID;
+		this.instances =
+			options.instances !== undefined && options.instances.length > 0 ? options.instances : [this.instanceId];
+		this.pollingIntervalMs = options.pollingIntervalMs ?? DEFAULT_POLLING_INTERVAL_MS;
+		this.tags = options.tags ?? definition.defaultTags;
+		this.lastIndexedAt = options.lastIndexedAt;
+	}
+
+	describe(): DatasourceSkillDescriptor {
+		return {
+			name: this.definition.datasourceId,
+			id: this.definition.datasourceId,
+			type: this.definition.skillType,
+			description: this.definition.description,
+			capabilities: ["external-cli", "polling", "incremental", "fts5", "lexical"],
+			tags: this.tags,
+			status: "active",
+			requiresExternalCli: true,
+			datasourceId: this.definition.datasourceId,
+			instanceId: this.instanceId,
+			instances: this.instances,
+		};
+	}
+
+	polling(): PollingMetadata {
+		return {
+			mode: this.pollingIntervalMs > 0 ? "poll" : "none",
+			...(this.pollingIntervalMs > 0 ? { intervalMs: this.pollingIntervalMs } : {}),
+			lastIndexedAt: this.lastIndexedAt,
+		};
+	}
+
+	async index(): Promise<DatasourceIndexResult> {
+		try {
+			const result = await this.client.sync();
+			if (!result.ok) return this.fail(failureCode(result.reason), result.reason);
+			this.lastIndexedAt = Date.now();
+			return {
+				ok: true,
+				instanceId: this.instanceId,
+				skill: this.definition.datasourceId,
+				chunkCount: result.count,
+				indexedAt: this.lastIndexedAt,
+				diagnostics: [],
+			};
+		} catch {
+			return this.fail("datasource-unavailable", "spawn-error");
+		}
+	}
+
+	retrievalMethods(): readonly RetrievalMethod[] {
+		return [
+			new CrawlerLexicalMethod({
+				client: this.client,
+				datasourceId: this.definition.datasourceId,
+				skillType: this.definition.skillType,
+				instanceId: this.instanceId,
+				tags: this.tags,
+				backendName: this.definition.backendName,
+			}),
+		];
+	}
+
+	describeSources(): readonly SourceDescription[] {
+		return this.instances.map((instanceId) => ({
+			source: datasourceSourcePath(this.definition.datasourceId, instanceId),
+			datasourceId: this.definition.datasourceId,
+			skill: this.definition.datasourceId,
+			instanceId,
+			contentType: this.definition.contentType,
+			metadata: { datasourceId: this.definition.datasourceId, instanceId, tags: this.tags },
+		}));
+	}
+
+	skillManifest(): DatasourceSkillManifest {
+		const scopes = this.instances
+			.map((instanceId) => `- \`${datasourceSourcePath(this.definition.datasourceId, instanceId)}\``)
+			.join("\n");
+		return {
+			name: `datasource-${this.definition.datasourceId}`,
+			description: this.definition.manifestDescription,
+			content: [
+				`# ${this.definition.description} (${this.definition.skillType})`,
+				"",
+				`This datasource is indexed and searched through the external \`${this.definition.backendName}\` CLI. AutoRAG never opens the source application's private database directly.`,
+				"",
+				"## When to use",
+				this.definition.manifestDescription,
+				"",
+				"## How to search",
+				"Call `search_datasource_documents` with a query and optional narrowing scope:",
+				scopes,
+				"",
+				"`scope` can only narrow within already-authorized scopes; it can never widen access.",
+			].join("\n"),
+		};
+	}
+
+	private fail(code: DatasourceDiagnosticCode, reason: string): DatasourceIndexResult {
+		const message = `${this.definition.backendName} ${reason}`;
+		return {
+			ok: false,
+			instanceId: this.instanceId,
+			skill: this.definition.datasourceId,
+			indexedAt: Date.now(),
+			diagnostics: [
+				{
+					code,
+					severity: code === "datasource-unavailable" ? "warning" : "error",
+					message,
+					instanceId: this.instanceId,
+					source: this.definition.datasourceId,
+				},
+			],
+			error: reason,
+			code,
+			message,
+		};
+	}
+}
+
+type CrawlerLexicalMethodOptions = {
+	readonly client: CrawlerSkillClient;
+	readonly datasourceId: string;
+	readonly skillType: string;
+	readonly instanceId: string;
+	readonly tags: readonly string[];
+	readonly backendName: string;
+};
+
+class CrawlerLexicalMethod implements RetrievalMethod {
+	private readonly options: CrawlerLexicalMethodOptions;
+
+	constructor(options: CrawlerLexicalMethodOptions) {
+		this.options = options;
+	}
+
+	describe(): RetrievalMethodDescriptor {
+		return {
+			name: `${this.options.datasourceId}-fts`,
+			type: "bm25",
+			description: `FTS5 retrieval over ${this.options.skillType} via ${this.options.backendName}`,
+			status: "active",
+			capabilities: ["lexical", "fts5", "scoped", "external-cli", "path-opaque-sources"],
+			datasourceId: this.options.datasourceId,
+			tags: this.options.tags,
+		};
+	}
+
+	async retrieve(query: string, options: RetrievalOptions): Promise<RetrievalResult[]> {
+		const trimmed = query.trim();
+		if (trimmed.length === 0) return [];
+		let result: CrawlerSearchResult;
+		try {
+			result = await this.options.client.search(trimmed, options);
+		} catch {
+			return [];
+		}
+		if (!result.ok) return [];
+		const mapped: RetrievalResult[] = [];
+		for (const hit of result.hits) {
+			const source = datasourceSourcePath(this.options.datasourceId, this.options.instanceId, hit.id);
+			if (!matchesScope(source, options.scope, options.allowedScopes)) continue;
+			mapped.push({
+				id: `${this.options.datasourceId}:${this.options.instanceId}:${hit.id}`,
+				content: hit.content,
+				source,
+				score: hit.score,
+				metadata: {
+					...(hit.metadata ?? {}),
+					method: `${this.options.datasourceId}-fts`,
+					datasourceId: this.options.datasourceId,
+					instanceId: this.options.instanceId,
+					backend: this.options.backendName,
+					...(hit.title !== undefined ? { title: hit.title } : {}),
+					...(hit.hierarchy !== undefined ? { hierarchy: hit.hierarchy.join("/") } : {}),
+					...(hit.publishedAt !== undefined ? { publishedAt: hit.publishedAt } : {}),
+				},
+			});
+		}
+		return mapped;
+	}
+}
+
+function matchesScope(
+	source: string,
+	scope: string | undefined,
+	allowedScopes: readonly string[] | undefined,
+): boolean {
+	if (!matchesDatasourceScope(source, scope)) return false;
+	if (allowedScopes === undefined || allowedScopes.length === 0) return true;
+	return allowedScopes.some((entry) => matchesDatasourceScope(source, entry));
+}
+
+function failureCode(reason: string): DatasourceDiagnosticCode {
+	return reason === "binary-missing" || reason === "spawn-error" || reason === "timeout" || reason === "aborted"
+		? "datasource-unavailable"
+		: "datasource-index-failed";
+}

--- a/src/datasource/crawler-types.ts
+++ b/src/datasource/crawler-types.ts
@@ -1,0 +1,69 @@
+import type { RetrievalOptions } from "../retrieval/types.ts";
+
+export type CrawlerFailureReason =
+	| "binary-missing"
+	| "nonzero-exit"
+	| "spawn-error"
+	| "timeout"
+	| "aborted"
+	| "stdout-too-large"
+	| "stderr-too-large"
+	| "invalid-output";
+
+export interface CrawlerFailure {
+	readonly ok: false;
+	readonly reason: CrawlerFailureReason;
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly code: number | null;
+}
+
+export interface CrawlerHit {
+	readonly id: string;
+	readonly content: string;
+	readonly score: number;
+	readonly title?: string;
+	readonly hierarchy?: readonly string[];
+	readonly publishedAt?: number;
+	readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface CrawlerSyncOk {
+	readonly ok: true;
+	readonly count: number;
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly code: number;
+}
+
+export interface CrawlerSearchOk {
+	readonly ok: true;
+	readonly hits: readonly CrawlerHit[];
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly code: number;
+}
+
+export type CrawlerSyncResult = CrawlerSyncOk | CrawlerFailure;
+export type CrawlerSearchResult = CrawlerSearchOk | CrawlerFailure;
+export type CrawlerSearchOptions = RetrievalOptions;
+
+export interface CrawlerCliOptions {
+	readonly binaryPath?: string;
+	readonly databasePath?: string;
+	readonly sourcePath?: string;
+	readonly configPath?: string;
+	readonly syncSource?: string;
+	readonly timeoutMs?: number;
+	readonly maxBufferBytes?: number;
+	readonly env?: Readonly<Record<string, string | undefined>>;
+}
+
+export interface CrawlerProfile {
+	readonly binaryName: string;
+	readonly allowedEnvPrefixes: readonly string[];
+	readonly syncArgs: (options: CrawlerCliOptions) => readonly string[];
+	readonly searchArgs: (options: CrawlerCliOptions, query: string, topK: number) => readonly string[];
+	readonly parseSyncCount: (stdout: string) => number | undefined;
+	readonly parseHits: (stdout: string) => readonly CrawlerHit[] | undefined;
+}

--- a/src/datasource/index.ts
+++ b/src/datasource/index.ts
@@ -117,6 +117,7 @@ export {
 	SpotlightSkill,
 	type SpotlightSkillOptions,
 } from "./skills/spotlight/index.ts";
+export { WacrawlClient, type WacrawlOptions, WacrawlSkill, type WacrawlSkillOptions } from "./skills/wacrawl/index.ts";
 export type {
 	DatasourceAccessible,
 	DatasourceDiagnostic,

--- a/src/datasource/skills/factory.ts
+++ b/src/datasource/skills/factory.ts
@@ -21,6 +21,7 @@ import { type ObsidianConnectorOptions, ObsidianSkill } from "./obsidian/index.t
 import { type RssConnectorOptions, RssSkill } from "./rss/index.ts";
 import { type SlackConnectorOptions, SlackSkill } from "./slack/index.ts";
 import { type SpotlightConnectorOptions, SpotlightSkill } from "./spotlight/index.ts";
+import { type WacrawlOptions, WacrawlSkill } from "./wacrawl/index.ts";
 
 /** One configured datasource entry (the trusted `datasources.<name>` value). */
 export interface DatasourceSkillConfig {
@@ -44,6 +45,13 @@ export interface BuildDatasourceSkillsResult {
 type SkillBuilder = (config: DatasourceSkillConfig, workspaceRoot: string | undefined) => DatasourceSkill;
 
 const BUILDERS: Readonly<Record<string, SkillBuilder>> = {
+	whatsapp: (config) =>
+		new WacrawlSkill({
+			...(config.instanceId !== undefined ? { instanceId: config.instanceId } : {}),
+			...(config.pollingIntervalMs !== undefined ? { pollingIntervalMs: config.pollingIntervalMs } : {}),
+			...(config.tags !== undefined ? { tags: config.tags } : {}),
+			connectorOptions: config.connector as WacrawlOptions,
+		}),
 	slack: (config, workspaceRoot) =>
 		new SlackSkill({ ...common(config, workspaceRoot), connectorOptions: config.connector as SlackConnectorOptions }),
 	discord: (config, workspaceRoot) =>

--- a/src/datasource/skills/wacrawl/index.ts
+++ b/src/datasource/skills/wacrawl/index.ts
@@ -1,0 +1,140 @@
+import { CrawlerCliClient } from "../../crawler-client.ts";
+import {
+	CrawlerDatasourceSkill,
+	type CrawlerDatasourceSkillOptions,
+	type CrawlerSkillClient,
+} from "../../crawler-skill.ts";
+import type { CrawlerCliOptions, CrawlerHit, CrawlerProfile } from "../../crawler-types.ts";
+
+export interface WacrawlOptions extends CrawlerCliOptions {}
+
+const WACRAWL_PROFILE: CrawlerProfile = {
+	binaryName: "wacrawl",
+	allowedEnvPrefixes: ["WACRAWL_"],
+	syncArgs: (options) => [...globalArgs(options), "sync"],
+	searchArgs: (options, query, topK) => [
+		...globalArgs(options),
+		"--sync",
+		"never",
+		"search",
+		"--limit",
+		String(topK),
+		query,
+	],
+	parseSyncCount: parseCount,
+	parseHits,
+};
+
+const WHATSAPP_DEFINITION = {
+	datasourceId: "whatsapp",
+	skillType: "whatsapp-archive",
+	description: "WhatsApp archive datasource via wacrawl",
+	defaultTags: ["whatsapp", "chat", "personal", "pii"],
+	contentType: "chat",
+	manifestDescription:
+		"Search archived WhatsApp messages, chats, senders, and media titles. Use for questions about WhatsApp conversations or who said what.",
+	backendName: "wacrawl",
+} as const;
+
+export class WacrawlClient extends CrawlerCliClient {
+	constructor(options: WacrawlOptions = {}) {
+		super(WACRAWL_PROFILE, options);
+	}
+}
+
+export interface WacrawlSkillOptions extends Omit<CrawlerDatasourceSkillOptions, "client"> {
+	readonly client?: CrawlerSkillClient;
+	readonly connectorOptions?: WacrawlOptions;
+}
+
+export class WacrawlSkill extends CrawlerDatasourceSkill {
+	constructor(options: WacrawlSkillOptions = {}) {
+		const { client, connectorOptions, ...skillOptions } = options;
+		super(WHATSAPP_DEFINITION, {
+			...skillOptions,
+			client: client ?? new WacrawlClient(connectorOptions),
+		});
+	}
+}
+
+function globalArgs(options: CrawlerCliOptions): readonly string[] {
+	return [
+		"--json",
+		...(options.databasePath !== undefined ? ["--db", options.databasePath] : []),
+		...(options.sourcePath !== undefined ? ["--source", options.sourcePath] : []),
+	];
+}
+
+function parseCount(stdout: string): number | undefined {
+	const parsed = parseJson(stdout);
+	if (parsed === undefined) return undefined;
+	if (Array.isArray(parsed)) return parsed.length;
+	if (!isRecord(parsed)) return undefined;
+	for (const key of ["messages", "message_count", "messageCount", "imported", "count"]) {
+		const value = parsed[key];
+		if (typeof value === "number" && Number.isFinite(value)) return value;
+	}
+	return 0;
+}
+
+function parseHits(stdout: string): readonly CrawlerHit[] | undefined {
+	const parsed = parseJson(stdout);
+	const rows = Array.isArray(parsed)
+		? parsed
+		: isRecord(parsed) && Array.isArray(parsed.messages)
+			? parsed.messages
+			: undefined;
+	if (rows === undefined) return undefined;
+	const hits: CrawlerHit[] = [];
+	for (const [index, row] of rows.entries()) {
+		if (!isRecord(row)) return undefined;
+		const id = stringValue(row, ["message_id", "event_id", "id"]);
+		const content = stringValue(row, ["snippet", "text", "content"]);
+		if (id === undefined || content === undefined) return undefined;
+		const chatId = stringValue(row, ["chat_jid", "chat_id"]);
+		const chatName = stringValue(row, ["chat_name"]);
+		const senderName = stringValue(row, ["sender_name"]);
+		const timestamp = stringValue(row, ["timestamp"]);
+		hits.push({
+			id,
+			content,
+			score: 1 / (index + 1),
+			...(chatName !== undefined ? { title: chatName } : {}),
+			...(chatName !== undefined || chatId !== undefined
+				? { hierarchy: ["chats", chatName ?? chatId ?? "unknown"] }
+				: {}),
+			...(timestamp !== undefined && Number.isFinite(Date.parse(timestamp))
+				? { publishedAt: Date.parse(timestamp) }
+				: {}),
+			metadata: {
+				...(chatId !== undefined ? { chatId } : {}),
+				...(chatName !== undefined ? { chatName } : {}),
+				...(senderName !== undefined ? { senderName } : {}),
+				...(timestamp !== undefined ? { timestamp } : {}),
+			},
+		});
+	}
+	return hits;
+}
+
+function parseJson(stdout: string): unknown {
+	const trimmed = stdout.trim();
+	if (trimmed.length === 0) return [];
+	try {
+		return JSON.parse(trimmed);
+	} catch {
+		return undefined;
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(record: Record<string, unknown>, keys: readonly string[]): string | undefined {
+	for (const key of keys) {
+		const value = record[key];
+		if (typeof value === "string" && value.length > 0) return value;
+	}
+	return undefined;
+}

--- a/test/cli/config.datasources.test.ts
+++ b/test/cli/config.datasources.test.ts
@@ -68,6 +68,27 @@ describe("CLI config datasources wiring", () => {
 		expect(() => buildAgentOptions(resolveConfig({ flags: { config: configPath } }))).toThrow(ConfigError);
 	});
 
+	it("materializes WhatsApp through the external wacrawl backend", () => {
+		const configPath = writeConfig({
+			searchPaths: [tmpRoot],
+			workspacePath: tmpRoot,
+			datasources: {
+				whatsapp: { instanceId: "personal", connector: { binaryPath: "/opt/bin/wacrawl" } },
+			},
+		});
+
+		const options = buildAgentOptions(resolveConfig({ flags: { config: configPath } }));
+		const skills = (options.datasourceSkills ?? []) as readonly DatasourceSkill[];
+
+		expect(skills).toHaveLength(1);
+		expect(skills[0]?.describe()).toMatchObject({
+			name: "whatsapp",
+			type: "whatsapp-archive",
+			instanceId: "personal",
+			requiresExternalCli: true,
+		});
+	});
+
 	it("rejects malformed datasources and datasourceAccess sections", () => {
 		const badDatasources = writeConfig({ searchPaths: [tmpRoot], datasources: ["rss"] });
 		expect(() => resolveConfig({ flags: { config: badDatasources } })).toThrow(ConfigError);

--- a/test/datasource/skills/wacrawl.test.ts
+++ b/test/datasource/skills/wacrawl.test.ts
@@ -1,0 +1,160 @@
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { WacrawlClient, WacrawlSkill } from "../../../src/datasource/skills/wacrawl/index.ts";
+
+let root: string;
+let binaryPath: string;
+let logPath: string;
+
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), "autorag-wacrawl-"));
+	const binDir = join(root, "bin");
+	mkdirSync(binDir, { recursive: true });
+	binaryPath = join(binDir, "wacrawl");
+	logPath = join(root, "calls.jsonl");
+});
+
+afterEach(() => {
+	rmSync(root, { recursive: true, force: true });
+});
+
+function writeFakeWacrawl(): void {
+	writeFileSync(
+		binaryPath,
+		`#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({
+  args: process.argv.slice(2),
+  openai: process.env.OPENAI_API_KEY ?? null,
+  updateCheck: process.env.CRAWLKIT_NO_UPDATE_CHECK ?? null,
+}) + "\\n");
+process.stdout.write(process.env.WACRAWL_FAKE_OUTPUT ?? "{}");
+`,
+	);
+	chmodSync(binaryPath, 0o755);
+}
+
+function calls(): readonly {
+	readonly args: readonly string[];
+	readonly openai: string | null;
+	readonly updateCheck: string | null;
+}[] {
+	if (!existsSync(logPath)) return [];
+	return readFileSync(logPath, "utf8")
+		.trim()
+		.split("\n")
+		.filter((line) => line.length > 0)
+		.map((line) => {
+			const parsed: unknown = JSON.parse(line);
+			if (!isCall(parsed)) throw new Error("unexpected fake wacrawl call");
+			return parsed;
+		});
+}
+
+describe("WacrawlClient", () => {
+	it("spawns sync and search with bounded private environment", async () => {
+		writeFakeWacrawl();
+		const client = new WacrawlClient({
+			binaryPath,
+			databasePath: join(root, "archive.db"),
+			sourcePath: join(root, "source"),
+			env: {
+				WACRAWL_FAKE_OUTPUT: JSON.stringify({ messages: 3 }),
+				OPENAI_API_KEY: "must-not-leak",
+			},
+		});
+
+		expect(await client.sync()).toMatchObject({ ok: true, count: 3 });
+		const searchClient = new WacrawlClient({
+			binaryPath,
+			env: {
+				WACRAWL_FAKE_OUTPUT: JSON.stringify([
+					{
+						message_id: "m-1",
+						chat_jid: "family",
+						chat_name: "Family",
+						sender_name: "Alice",
+						timestamp: "2026-08-16T01:02:03Z",
+						snippet: "Dinner is at seven",
+					},
+				]),
+			},
+		});
+		const search = await searchClient.search("dinner", { topK: 5 });
+		expect(search).toMatchObject({
+			ok: true,
+			hits: [{ id: "m-1", content: "Dinner is at seven", title: "Family" }],
+		});
+
+		expect(calls()[0]?.args).toEqual([
+			"--json",
+			"--db",
+			join(root, "archive.db"),
+			"--source",
+			join(root, "source"),
+			"sync",
+		]);
+		expect(calls()[1]?.args).toEqual(["--json", "--sync", "never", "search", "--limit", "5", "dinner"]);
+		expect(calls().every((call) => call.openai === null)).toBe(true);
+		expect(calls().every((call) => call.updateCheck === "1")).toBe(true);
+	});
+
+	it("maps a missing binary and malformed output without throwing", async () => {
+		const missing = new WacrawlClient({ binaryPath: join(root, "missing") });
+		expect(await missing.sync()).toMatchObject({ ok: false, reason: "binary-missing" });
+
+		writeFakeWacrawl();
+		const malformed = new WacrawlClient({
+			binaryPath,
+			env: { WACRAWL_FAKE_OUTPUT: "not-json" },
+		});
+		expect(await malformed.search("query")).toMatchObject({ ok: false, reason: "invalid-output" });
+	});
+});
+
+describe("WacrawlSkill", () => {
+	it("indexes and retrieves WhatsApp messages through the crawler surface", async () => {
+		writeFakeWacrawl();
+		const syncClient = new WacrawlClient({
+			binaryPath,
+			env: { WACRAWL_FAKE_OUTPUT: JSON.stringify({ messages: 1 }) },
+		});
+		const skill = new WacrawlSkill({ client: syncClient, instanceId: "personal" });
+		expect(skill.describe()).toMatchObject({
+			name: "whatsapp",
+			type: "whatsapp-archive",
+			requiresExternalCli: true,
+		});
+		expect(await skill.index()).toMatchObject({ ok: true, chunkCount: 1 });
+
+		const searchClient = new WacrawlClient({
+			binaryPath,
+			env: {
+				WACRAWL_FAKE_OUTPUT: JSON.stringify([
+					{ message_id: "m-2", chat_name: "Ops", text: "Deploy freeze starts Friday" },
+				]),
+			},
+		});
+		const searchable = new WacrawlSkill({ client: searchClient, instanceId: "personal" });
+		const [method] = searchable.retrievalMethods();
+		const results = await method?.retrieve("deploy freeze", { topK: 5 });
+		expect(results?.[0]?.source).toBe("/whatsapp/personal/chunks/m-2");
+		expect(results?.[0]?.metadata).toMatchObject({ backend: "wacrawl", title: "Ops" });
+	});
+});
+
+function isCall(
+	value: unknown,
+): value is { readonly args: readonly string[]; readonly openai: string | null; readonly updateCheck: string | null } {
+	if (typeof value !== "object" || value === null) return false;
+	if (!("args" in value) || !Array.isArray(value.args) || !value.args.every((arg) => typeof arg === "string"))
+		return false;
+	return (
+		"openai" in value &&
+		(value.openai === null || typeof value.openai === "string") &&
+		"updateCheck" in value &&
+		(value.updateCheck === null || typeof value.updateCheck === "string")
+	);
+}


### PR DESCRIPTION
## Summary

- add a shared bounded external-crawler process and datasource foundation
- add the platform-facing whatsapp datasource backed by openclaw/wacrawl
- preserve private environment boundaries and map missing/malformed crawler failures to datasource diagnostics
- document installation, trusted connector options, platform limits, and deterministic process QA

## Verification

- bunx vitest run test/datasource/skills/wacrawl.test.ts test/cli/config.datasources.test.ts test/agent/connector-datasource-integration.test.ts
- bun run typecheck
- bun run build
- @biomejs/biome 2.5.6 check on changed TypeScript files
- manual process-surface driver: index count 2, /whatsapp/qa/chunks/qa-message-1, missing binary diagnostic, secretLeaked=false

## Stack

1. This PR: WhatsApp -> wacrawl
2. Telegram -> telecrawl
3. Slack -> slacrawl
4. Notion -> notcrawl

Closes no issue; tracks #1416.
