### PR TITLE
feat(datasource): add Telegram telecrawl backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Security defaults are intentionally strict:
 |---|---|---|---|
 | KakaoTalk | `katok` | external [`katok`](https://github.com/NomaDamas/katok) CLI | first datasource skill; AutoRAG never reads KakaoTalk databases directly |
 | WhatsApp | `whatsapp` | external [`wacrawl`](https://github.com/openclaw/wacrawl) CLI | local-first incremental archive + FTS5 search; live desktop ingestion is macOS-only |
+| Telegram | `telegram` | external [`telecrawl`](https://github.com/openclaw/telecrawl) CLI | local-first archive + FTS5 search; live desktop ingestion is macOS-only |
 | Slack | `slack` | Slack Web API (bot token) | workspace/channel history; per-channel scope failures degrade to warnings |
 | Discord | `discord` | external [`discrawl`](https://github.com/openclaw/discrawl) CLI | guild/channel/thread/DM archive; FTS5 + semantic + hybrid retrieval, incremental sync |
 | Notion | `notion` | Notion API (integration token) | pages/databases shared with the integration; block-tree text |
@@ -144,7 +145,7 @@ Security defaults are intentionally strict:
 | Obsidian vault | `obsidian` | filesystem (markdown) | frontmatter/inline tags, wiki links `[[...]]`, embeds `![[...]]` |
 | RSS / news | `rss` | HTTP feed polling | RSS 2.0 + Atom, feed/category hierarchy, 24h dedupe window |
 
-Connector-backed skills fetch documents into AutoRAG's local chunk store. External-crawler skills such as KakaoTalk and WhatsApp leave incremental archive and FTS ownership with their CLI and map query results into the same retrieval pipeline. Tokens are referenced by environment variable name only, never stored in config. Process/API failures surface as path/PII-opaque diagnostics. See [docs/manual-qa-datasources.md](docs/manual-qa-datasources.md) for the QA harnesses.
+Connector-backed skills fetch documents into AutoRAG's local chunk store. External-crawler skills such as KakaoTalk, WhatsApp, and Telegram leave incremental archive and FTS ownership with their CLI and map query results into the same retrieval pipeline. Tokens are referenced by environment variable name only, never stored in config. Process/API failures surface as path/PII-opaque diagnostics. See [docs/manual-qa-datasources.md](docs/manual-qa-datasources.md) for the QA harnesses.
 
 Configure them in `config.json` (CLI) or pass `datasourceSkills` programmatically:
 
@@ -152,6 +153,7 @@ Configure them in `config.json` (CLI) or pass `datasourceSkills` programmaticall
 {
   "datasources": {
     "whatsapp": { "instanceId": "personal", "connector": { "binaryPath": "wacrawl" } },
+    "telegram": { "instanceId": "personal", "connector": { "binaryPath": "telecrawl" } },
     "slack":    { "connector": { "tokenEnv": "SLACK_BOT_TOKEN" } },
     "github":   { "connector": { "repos": ["owner/repo"] } },
     "gmail":    { "connector": { "backend": "himalaya", "account": "gmail", "folder": "INBOX" } },
@@ -160,13 +162,15 @@ Configure them in `config.json` (CLI) or pass `datasourceSkills` programmaticall
     "rss":      { "connector": { "feeds": [{ "url": "https://example.com/feed.xml" }] } }
   },
   "datasourceAccess": {
-    "allowedTags": ["whatsapp", "slack", "github", "gmail", "gdrive", "obsidian", "rss"],
-    "allowedScopes": ["/whatsapp/**", "/slack/**", "/github/**", "/gmail/**", "/gdrive/**", "/obsidian/**", "/rss/**"]
+    "allowedTags": ["whatsapp", "telegram", "slack", "github", "gmail", "gdrive", "obsidian", "rss"],
+    "allowedScopes": ["/whatsapp/**", "/telegram/**", "/slack/**", "/github/**", "/gmail/**", "/gdrive/**", "/obsidian/**", "/rss/**"]
   }
 }
 ```
 
 Install wacrawl with `brew install openclaw/tap/wacrawl`. AutoRAG invokes `wacrawl sync` during datasource refresh and `wacrawl --json --sync never search` during retrieval. Optional trusted connector fields are `binaryPath`, `databasePath`, and `sourcePath`. The child process receives only a restricted environment; unrelated model/provider secrets are not forwarded. Live WhatsApp Desktop discovery requires macOS and the permissions documented by wacrawl, while an existing portable archive can be queried on other supported platforms.
+
+Install telecrawl with `brew install openclaw/tap/telecrawl`. AutoRAG invokes `telecrawl import` during datasource refresh and `telecrawl --json search` during retrieval. It uses the same optional trusted connector fields and restricted child environment as wacrawl. Live Telegram Desktop discovery requires macOS and the permissions documented by telecrawl, while an existing portable archive can be queried on other supported platforms.
 
 #### KakaoTalk (katok)
 

--- a/docs/manual-qa-datasources.md
+++ b/docs/manual-qa-datasources.md
@@ -3,8 +3,8 @@
 Covers issues #1300 (Slack), #1301 (Google Drive), #1302 (Notion), #1303
 (GitHub Issues/PRs), #1304 (Gmail), #1311 (local mail
 export), #1314 (Obsidian vault), #1316 (RSS/news), #1350 (macOS Spotlight).
-Issue #1416 adds external-crawler process coverage, beginning with WhatsApp
-through wacrawl.
+Issue #1416 adds external-crawler process coverage for WhatsApp through
+wacrawl and Telegram through telecrawl.
 
 ## Harnesses
 
@@ -15,6 +15,7 @@ through wacrawl.
 | `scripts/manual-qa/run-qa-live.ts` | Real public GitHub REST API (this repo's issues) and a real RSS feed (hnrss.org), credential-free | `bun scripts/manual-qa/run-qa-live.ts` |
 | `scripts/manual-qa/run-qa-spotlight-live.ts` | Real macOS Spotlight (`mdfind`/`mdimport`) end-to-end; macOS only, no credentials | `bun scripts/manual-qa/run-qa-spotlight-live.ts` |
 | `test/datasource/skills/wacrawl.test.ts` | Real child-process boundary with a deterministic fake wacrawl executable: argv, JSON parsing, env isolation, missing binary, malformed output, indexing, retrieval | `bunx vitest run test/datasource/skills/wacrawl.test.ts` |
+| `test/datasource/skills/telecrawl.test.ts` | Real child-process boundary with a deterministic fake telecrawl executable: argv, JSON parsing, env isolation, missing binary, malformed output, indexing, retrieval | `bunx vitest run test/datasource/skills/telecrawl.test.ts` |
 
 Skills that need tenant credentials (Slack bot token,
 Notion integration token, Drive/Gmail OAuth tokens) are QA'd against the
@@ -29,6 +30,12 @@ test executable exercises the actual spawn/stdout/stderr contract without
 requiring access to a private WhatsApp archive. For a live macOS check, install
 wacrawl, grant its documented Full Disk Access, configure
 `datasources.whatsapp`, then run `autorag refresh --method datasources`.
+
+Telegram uses the external telecrawl CLI instead of an HTTP mock. Its
+deterministic executable covers the same process boundary without private
+Telegram data. For a live macOS check, install telecrawl, grant its documented
+Full Disk Access, configure `datasources.telegram`, then run
+`autorag refresh --method datasources`.
 
 ## Checklist (all automated by the harnesses)
 

--- a/skills/autorag-setup/SKILL.md
+++ b/skills/autorag-setup/SKILL.md
@@ -234,7 +234,7 @@ via the role-specific flags or:
 
 ## Configure datasource skills (optional)
 
-External datasources (WhatsApp, Slack, Discord, Notion, GitHub Issues/PRs, Google
+External datasources (WhatsApp, Telegram, Slack, Discord, Notion, GitHub Issues/PRs, Google
 Drive, Gmail, local mail exports, Obsidian vaults, RSS/news) are configured
 as **datasource skills** in the trusted config file — never via model/tool
 arguments. Add a `datasources` section (skill name → config) plus a trusted
@@ -244,6 +244,7 @@ arguments. Add a `datasources` section (skill name → config) plus a trusted
 {
   "datasources": {
     "whatsapp": { "instanceId": "personal", "connector": { "binaryPath": "wacrawl" } },
+    "telegram": { "instanceId": "personal", "connector": { "binaryPath": "telecrawl" } },
     "slack":    { "connector": { "tokenEnv": "SLACK_BOT_TOKEN", "channels": ["eng"] } },
     "discord":  { "connector": { "tokenEnv": "DISCORD_BOT_TOKEN", "guildId": "..." } },
     "notion":   { "connector": { "tokenEnv": "NOTION_TOKEN" } },
@@ -255,8 +256,8 @@ arguments. Add a `datasources` section (skill name → config) plus a trusted
     "rss":      { "connector": { "feeds": [{ "url": "https://example.com/feed.xml" }] } }
   },
   "datasourceAccess": {
-    "allowedTags": ["whatsapp", "slack", "github", "rss"],
-    "allowedScopes": ["/whatsapp/**", "/slack/**", "/github/**", "/rss/**"]
+    "allowedTags": ["whatsapp", "telegram", "slack", "github", "rss"],
+    "allowedScopes": ["/whatsapp/**", "/telegram/**", "/slack/**", "/github/**", "/rss/**"]
   }
 }
 ```
@@ -279,6 +280,11 @@ Rules:
   (`brew install openclaw/tap/wacrawl`). Optional trusted connector fields are
   `binaryPath`, `databasePath`, and `sourcePath`. Live desktop ingestion is
   macOS-only; the crawler owns Full Disk Access and archive setup.
+- `telegram` requires the external
+  [telecrawl](https://github.com/openclaw/telecrawl) binary
+  (`brew install openclaw/tap/telecrawl`). Optional trusted connector fields
+  are `binaryPath`, `databasePath`, and `sourcePath`. Live desktop ingestion
+  is macOS-only; the crawler owns Full Disk Access and archive setup.
 - Access is **default-deny**: without `datasourceAccess.allowedTags`, no
   datasource skill is announced or searchable, even when configured.
   `allowedScopes` are opaque slash-hierarchical roots like `/slack/<instance>/**`.

--- a/src/datasource/index.ts
+++ b/src/datasource/index.ts
@@ -131,6 +131,12 @@ export {
 	SpotlightSkill,
 	type SpotlightSkillOptions,
 } from "./skills/spotlight/index.ts";
+export {
+	TelecrawlClient,
+	type TelecrawlOptions,
+	TelecrawlSkill,
+	type TelecrawlSkillOptions,
+} from "./skills/telecrawl/index.ts";
 export { WacrawlClient, type WacrawlOptions, WacrawlSkill, type WacrawlSkillOptions } from "./skills/wacrawl/index.ts";
 export type {
 	DatasourceAccessible,

--- a/src/datasource/skills/factory.ts
+++ b/src/datasource/skills/factory.ts
@@ -21,6 +21,7 @@ import { type ObsidianConnectorOptions, ObsidianSkill } from "./obsidian/index.t
 import { type RssConnectorOptions, RssSkill } from "./rss/index.ts";
 import { type SlackConnectorOptions, SlackSkill } from "./slack/index.ts";
 import { type SpotlightConnectorOptions, SpotlightSkill } from "./spotlight/index.ts";
+import { type TelecrawlOptions, TelecrawlSkill } from "./telecrawl/index.ts";
 import { type WacrawlOptions, WacrawlSkill } from "./wacrawl/index.ts";
 
 /** One configured datasource entry (the trusted `datasources.<name>` value). */
@@ -45,6 +46,13 @@ export interface BuildDatasourceSkillsResult {
 type SkillBuilder = (config: DatasourceSkillConfig, workspaceRoot: string | undefined) => DatasourceSkill;
 
 const BUILDERS: Readonly<Record<string, SkillBuilder>> = {
+	telegram: (config) =>
+		new TelecrawlSkill({
+			...(config.instanceId !== undefined ? { instanceId: config.instanceId } : {}),
+			...(config.pollingIntervalMs !== undefined ? { pollingIntervalMs: config.pollingIntervalMs } : {}),
+			...(config.tags !== undefined ? { tags: config.tags } : {}),
+			connectorOptions: config.connector as TelecrawlOptions,
+		}),
 	whatsapp: (config) =>
 		new WacrawlSkill({
 			...(config.instanceId !== undefined ? { instanceId: config.instanceId } : {}),

--- a/src/datasource/skills/telecrawl/index.ts
+++ b/src/datasource/skills/telecrawl/index.ts
@@ -1,0 +1,134 @@
+import { CrawlerCliClient } from "../../crawler-client.ts";
+import {
+	CrawlerDatasourceSkill,
+	type CrawlerDatasourceSkillOptions,
+	type CrawlerSkillClient,
+} from "../../crawler-skill.ts";
+import type { CrawlerCliOptions, CrawlerHit, CrawlerProfile } from "../../crawler-types.ts";
+
+export interface TelecrawlOptions extends CrawlerCliOptions {}
+
+const TELECRAWL_PROFILE: CrawlerProfile = {
+	binaryName: "telecrawl",
+	allowedEnvPrefixes: ["TELECRAWL_"],
+	syncArgs: (options) => [...globalArgs(options), "import"],
+	searchArgs: (options, query, topK) => [...globalArgs(options), "search", "--limit", String(topK), query],
+	parseSyncCount: parseCount,
+	parseHits,
+};
+
+const TELEGRAM_DEFINITION = {
+	datasourceId: "telegram",
+	skillType: "telegram-archive",
+	description: "Telegram archive datasource via telecrawl",
+	defaultTags: ["telegram", "chat", "personal", "pii"],
+	contentType: "chat",
+	manifestDescription:
+		"Search archived Telegram messages, chats, senders, topics, threads, and media titles. Use for questions about Telegram conversations or who said what.",
+	backendName: "telecrawl",
+} as const;
+
+export class TelecrawlClient extends CrawlerCliClient {
+	constructor(options: TelecrawlOptions = {}) {
+		super(TELECRAWL_PROFILE, options);
+	}
+}
+
+export interface TelecrawlSkillOptions extends Omit<CrawlerDatasourceSkillOptions, "client"> {
+	readonly client?: CrawlerSkillClient;
+	readonly connectorOptions?: TelecrawlOptions;
+}
+
+export class TelecrawlSkill extends CrawlerDatasourceSkill {
+	constructor(options: TelecrawlSkillOptions = {}) {
+		const { client, connectorOptions, ...skillOptions } = options;
+		super(TELEGRAM_DEFINITION, {
+			...skillOptions,
+			client: client ?? new TelecrawlClient(connectorOptions),
+		});
+	}
+}
+
+function globalArgs(options: CrawlerCliOptions): readonly string[] {
+	return [
+		"--json",
+		...(options.databasePath !== undefined ? ["--db", options.databasePath] : []),
+		...(options.sourcePath !== undefined ? ["--source", options.sourcePath] : []),
+	];
+}
+
+function parseCount(stdout: string): number | undefined {
+	const parsed = parseJson(stdout);
+	if (parsed === undefined) return undefined;
+	if (Array.isArray(parsed)) return parsed.length;
+	if (!isRecord(parsed)) return undefined;
+	for (const key of ["messages", "message_count", "messageCount", "imported", "count"]) {
+		const value = parsed[key];
+		if (typeof value === "number" && Number.isFinite(value)) return value;
+	}
+	return 0;
+}
+
+function parseHits(stdout: string): readonly CrawlerHit[] | undefined {
+	const parsed = parseJson(stdout);
+	const rows = Array.isArray(parsed)
+		? parsed
+		: isRecord(parsed) && Array.isArray(parsed.messages)
+			? parsed.messages
+			: undefined;
+	if (rows === undefined) return undefined;
+	const hits: CrawlerHit[] = [];
+	for (const [index, row] of rows.entries()) {
+		if (!isRecord(row)) return undefined;
+		const id = stringValue(row, ["message_id", "event_id", "id"]);
+		const content = stringValue(row, ["snippet", "text", "content"]);
+		if (id === undefined || content === undefined) return undefined;
+		const chatId = stringValue(row, ["chat_jid", "chat_id"]);
+		const chatName = stringValue(row, ["chat_name"]);
+		const senderName = stringValue(row, ["sender_name"]);
+		const topicName = stringValue(row, ["topic_name"]);
+		const timestamp = stringValue(row, ["timestamp"]);
+		hits.push({
+			id,
+			content,
+			score: 1 / (index + 1),
+			...(chatName !== undefined ? { title: chatName } : {}),
+			...(chatName !== undefined || chatId !== undefined
+				? { hierarchy: ["chats", chatName ?? chatId ?? "unknown", ...(topicName !== undefined ? [topicName] : [])] }
+				: {}),
+			...(timestamp !== undefined && Number.isFinite(Date.parse(timestamp))
+				? { publishedAt: Date.parse(timestamp) }
+				: {}),
+			metadata: {
+				...(chatId !== undefined ? { chatId } : {}),
+				...(chatName !== undefined ? { chatName } : {}),
+				...(senderName !== undefined ? { senderName } : {}),
+				...(topicName !== undefined ? { topicName } : {}),
+				...(timestamp !== undefined ? { timestamp } : {}),
+			},
+		});
+	}
+	return hits;
+}
+
+function parseJson(stdout: string): unknown {
+	const trimmed = stdout.trim();
+	if (trimmed.length === 0) return [];
+	try {
+		return JSON.parse(trimmed);
+	} catch {
+		return undefined;
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(record: Record<string, unknown>, keys: readonly string[]): string | undefined {
+	for (const key of keys) {
+		const value = record[key];
+		if (typeof value === "string" && value.length > 0) return value;
+	}
+	return undefined;
+}

--- a/test/cli/config.datasources.test.ts
+++ b/test/cli/config.datasources.test.ts
@@ -89,6 +89,27 @@ describe("CLI config datasources wiring", () => {
 		});
 	});
 
+	it("materializes Telegram through the external telecrawl backend", () => {
+		const configPath = writeConfig({
+			searchPaths: [tmpRoot],
+			workspacePath: tmpRoot,
+			datasources: {
+				telegram: { instanceId: "personal", connector: { binaryPath: "/opt/bin/telecrawl" } },
+			},
+		});
+
+		const options = buildAgentOptions(resolveConfig({ flags: { config: configPath } }));
+		const skills = (options.datasourceSkills ?? []) as readonly DatasourceSkill[];
+
+		expect(skills).toHaveLength(1);
+		expect(skills[0]?.describe()).toMatchObject({
+			name: "telegram",
+			type: "telegram-archive",
+			instanceId: "personal",
+			requiresExternalCli: true,
+		});
+	});
+
 	it("rejects malformed datasources and datasourceAccess sections", () => {
 		const badDatasources = writeConfig({ searchPaths: [tmpRoot], datasources: ["rss"] });
 		expect(() => resolveConfig({ flags: { config: badDatasources } })).toThrow(ConfigError);

--- a/test/datasource/skills/telecrawl.test.ts
+++ b/test/datasource/skills/telecrawl.test.ts
@@ -1,0 +1,161 @@
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { TelecrawlClient, TelecrawlSkill } from "../../../src/datasource/skills/telecrawl/index.ts";
+
+let root: string;
+let binaryPath: string;
+let logPath: string;
+
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), "autorag-telecrawl-"));
+	const binDir = join(root, "bin");
+	mkdirSync(binDir, { recursive: true });
+	binaryPath = join(binDir, "telecrawl");
+	logPath = join(root, "calls.jsonl");
+});
+
+afterEach(() => {
+	rmSync(root, { recursive: true, force: true });
+});
+
+function writeFakeTelecrawl(): void {
+	writeFileSync(
+		binaryPath,
+		`#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({
+  args: process.argv.slice(2),
+  openai: process.env.OPENAI_API_KEY ?? null,
+  updateCheck: process.env.CRAWLKIT_NO_UPDATE_CHECK ?? null,
+}) + "\\n");
+process.stdout.write(process.env.TELECRAWL_FAKE_OUTPUT ?? "{}");
+`,
+	);
+	chmodSync(binaryPath, 0o755);
+}
+
+function calls(): readonly {
+	readonly args: readonly string[];
+	readonly openai: string | null;
+	readonly updateCheck: string | null;
+}[] {
+	if (!existsSync(logPath)) return [];
+	return readFileSync(logPath, "utf8")
+		.trim()
+		.split("\n")
+		.filter((line) => line.length > 0)
+		.map((line) => {
+			const parsed: unknown = JSON.parse(line);
+			if (!isCall(parsed)) throw new Error("unexpected fake telecrawl call");
+			return parsed;
+		});
+}
+
+describe("TelecrawlClient", () => {
+	it("spawns import and search with bounded private environment", async () => {
+		writeFakeTelecrawl();
+		const client = new TelecrawlClient({
+			binaryPath,
+			databasePath: join(root, "archive.db"),
+			sourcePath: join(root, "source"),
+			env: {
+				TELECRAWL_FAKE_OUTPUT: JSON.stringify({ imported: 4 }),
+				OPENAI_API_KEY: "must-not-leak",
+			},
+		});
+
+		expect(await client.sync()).toMatchObject({ ok: true, count: 4 });
+		const searchClient = new TelecrawlClient({
+			binaryPath,
+			env: {
+				TELECRAWL_FAKE_OUTPUT: JSON.stringify([
+					{
+						message_id: "tg-1",
+						chat_jid: "engineering",
+						chat_name: "Engineering",
+						topic_name: "Deployments",
+						sender_name: "Alice",
+						timestamp: "2026-08-16T01:02:03Z",
+						snippet: "Release starts at seven",
+					},
+				]),
+			},
+		});
+		const search = await searchClient.search("release", { topK: 5 });
+		expect(search).toMatchObject({
+			ok: true,
+			hits: [{ id: "tg-1", content: "Release starts at seven", title: "Engineering" }],
+		});
+
+		expect(calls()[0]?.args).toEqual([
+			"--json",
+			"--db",
+			join(root, "archive.db"),
+			"--source",
+			join(root, "source"),
+			"import",
+		]);
+		expect(calls()[1]?.args).toEqual(["--json", "search", "--limit", "5", "release"]);
+		expect(calls().every((call) => call.openai === null)).toBe(true);
+		expect(calls().every((call) => call.updateCheck === "1")).toBe(true);
+	});
+
+	it("maps a missing binary and malformed output without throwing", async () => {
+		const missing = new TelecrawlClient({ binaryPath: join(root, "missing") });
+		expect(await missing.sync()).toMatchObject({ ok: false, reason: "binary-missing" });
+
+		writeFakeTelecrawl();
+		const malformed = new TelecrawlClient({
+			binaryPath,
+			env: { TELECRAWL_FAKE_OUTPUT: "not-json" },
+		});
+		expect(await malformed.search("query")).toMatchObject({ ok: false, reason: "invalid-output" });
+	});
+});
+
+describe("TelecrawlSkill", () => {
+	it("indexes and retrieves Telegram messages through the crawler surface", async () => {
+		writeFakeTelecrawl();
+		const syncClient = new TelecrawlClient({
+			binaryPath,
+			env: { TELECRAWL_FAKE_OUTPUT: JSON.stringify({ imported: 1 }) },
+		});
+		const skill = new TelecrawlSkill({ client: syncClient, instanceId: "personal" });
+		expect(skill.describe()).toMatchObject({
+			name: "telegram",
+			type: "telegram-archive",
+			requiresExternalCli: true,
+		});
+		expect(await skill.index()).toMatchObject({ ok: true, chunkCount: 1 });
+
+		const searchClient = new TelecrawlClient({
+			binaryPath,
+			env: {
+				TELECRAWL_FAKE_OUTPUT: JSON.stringify([
+					{ message_id: "tg-2", chat_name: "Ops", topic_name: "Releases", text: "Deploy freeze starts Friday" },
+				]),
+			},
+		});
+		const searchable = new TelecrawlSkill({ client: searchClient, instanceId: "personal" });
+		const [method] = searchable.retrievalMethods();
+		const results = await method?.retrieve("deploy freeze", { topK: 5 });
+		expect(results?.[0]?.source).toBe("/telegram/personal/chunks/tg-2");
+		expect(results?.[0]?.metadata).toMatchObject({ backend: "telecrawl", title: "Ops" });
+	});
+});
+
+function isCall(
+	value: unknown,
+): value is { readonly args: readonly string[]; readonly openai: string | null; readonly updateCheck: string | null } {
+	if (typeof value !== "object" || value === null) return false;
+	if (!("args" in value) || !Array.isArray(value.args) || !value.args.every((arg) => typeof arg === "string"))
+		return false;
+	return (
+		"openai" in value &&
+		(value.openai === null || typeof value.openai === "string") &&
+		"updateCheck" in value &&
+		(value.updateCheck === null || typeof value.updateCheck === "string")
+	);
+}


### PR DESCRIPTION
## Summary

- add the platform-facing telegram datasource backed by openclaw/telecrawl
- invoke telecrawl import and bounded JSON search through the shared crawler process foundation
- preserve Telegram topic hierarchy and private environment isolation
- document installation, trusted connector options, platform limits, and deterministic process QA

## Verification

- bunx vitest run test/datasource/skills/wacrawl.test.ts test/datasource/skills/telecrawl.test.ts test/cli/config.datasources.test.ts test/agent/connector-datasource-integration.test.ts
- bun run typecheck
- bun run build
- @biomejs/biome 2.5.6 check on changed TypeScript files
- manual process-surface driver: index count 3, /telegram/qa/chunks/qa-telegram-1, missing binary diagnostic, secretLeaked=false

## Stack

1. #1418 WhatsApp -> wacrawl
2. This PR: Telegram -> telecrawl
3. Slack -> slacrawl
4. Notion -> notcrawl

Tracks #1416.
