### PR TITLE
fix(minsync): stage parsed mirrors incrementally

### DIFF
--- a/src/minsync/client.ts
+++ b/src/minsync/client.ts
@@ -125,7 +125,7 @@ function readCheckFailure(stdout: string): string | undefined {
 
 function parseQueryHits(stdout: string): readonly MinSyncQueryHit[] {
 	const parsed = parseJson(stdout);
-	const candidates = isRecord(parsed) ? parsed.results : parsed;
+	const candidates = Array.isArray(parsed) ? parsed : isRecord(parsed) ? parsed.results : [];
 	if (!Array.isArray(candidates)) return [];
 	return candidates.filter(isMinSyncQueryHit);
 }

--- a/src/minsync/workspace.ts
+++ b/src/minsync/workspace.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import {
 	copyFileSync,
 	existsSync,
+	lstatSync,
 	mkdirSync,
 	readdirSync,
 	readFileSync,
@@ -9,7 +10,7 @@ import {
 	rmSync,
 	writeFileSync,
 } from "node:fs";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, sep } from "node:path";
 import { normalizeVirtualPath } from "../filesystem/source-paths.ts";
 import { loadMirrorIndex } from "../mirror/index-store.ts";
 import { minSyncDocumentPath, minSyncWorkspaceRoot } from "./paths.ts";
@@ -45,7 +46,7 @@ export function syncMinSyncWorkspace(
 	const index = loadMirrorIndex(root);
 	const entries = Object.values(index.entries)
 		.sort((a, b) => a.virtualPath.localeCompare(b.virtualPath))
-		.filter((entry) => existsSync(entry.outputPath))
+		.filter((entry) => normalizeVirtualPath(entry.virtualPath) === entry.virtualPath && existsSync(entry.outputPath))
 		.map((entry) => {
 			const minSyncPath = minSyncDocumentPath(workspacePath, entry.virtualPath);
 			return {
@@ -56,10 +57,7 @@ export function syncMinSyncWorkspace(
 			};
 		});
 	const previousState = loadStagingState(workspacePath);
-	if (previousState === undefined) {
-		rmSync(filesRoot, { recursive: true, force: true });
-	}
-	mkdirSync(filesRoot, { recursive: true });
+	ensureManagedFilesRoot(filesRoot, previousState === undefined);
 
 	const currentState: Record<string, MinSyncStagingEntry> = {};
 	const desiredPaths = new Set<string>();
@@ -70,10 +68,10 @@ export function syncMinSyncWorkspace(
 		const unchanged =
 			previousEntry?.outputPath === mirrorEntry.outputPath &&
 			previousEntry.updatedAt === mirrorEntry.updatedAt &&
-			existsSync(entry.minSyncPath);
+			isRegularFile(entry.minSyncPath);
 		if (!unchanged) {
-			mkdirSync(dirname(entry.minSyncPath), { recursive: true });
-			copyFileSync(entry.parsedOutputPath, entry.minSyncPath);
+			ensureManagedDirectory(filesRoot, dirname(entry.minSyncPath));
+			copyFileAtomically(entry.parsedOutputPath, entry.minSyncPath);
 		}
 		currentState[entry.virtualPath] = {
 			outputPath: mirrorEntry.outputPath,
@@ -94,7 +92,7 @@ function stagingStatePath(workspacePath: string): string {
 
 function loadStagingState(workspacePath: string): MinSyncStagingState | undefined {
 	const path = stagingStatePath(workspacePath);
-	if (!existsSync(path)) return undefined;
+	if (!isRegularFile(path)) return undefined;
 	try {
 		const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
 		return isMinSyncStagingState(parsed) ? parsed : undefined;
@@ -119,6 +117,46 @@ function isMinSyncStagingState(value: unknown): value is MinSyncStagingState {
 			typeof entry.outputPath === "string" &&
 			typeof entry.updatedAt === "string",
 	);
+}
+
+function ensureManagedFilesRoot(filesRoot: string, rebuild: boolean): void {
+	const status = lstatSync(filesRoot, { throwIfNoEntry: false });
+	if (status !== undefined && (rebuild || !status.isDirectory())) {
+		rmSync(filesRoot, { recursive: status.isDirectory(), force: true });
+	}
+	mkdirSync(filesRoot, { recursive: true });
+}
+
+function ensureManagedDirectory(filesRoot: string, directory: string): void {
+	const relativeDirectory = relative(filesRoot, directory);
+	if (relativeDirectory === ".." || relativeDirectory.startsWith(`..${sep}`) || isAbsolute(relativeDirectory)) {
+		throw new Error("MinSync staging path escaped its managed files root");
+	}
+	const segments = relativeDirectory.split(sep).filter(Boolean);
+	let current = filesRoot;
+	for (const segment of segments) {
+		current = join(current, segment);
+		const status = lstatSync(current, { throwIfNoEntry: false });
+		if (status?.isDirectory()) continue;
+		if (status !== undefined) {
+			rmSync(current, { force: true });
+		}
+		mkdirSync(current);
+	}
+}
+
+function copyFileAtomically(source: string, destination: string): void {
+	const temporaryPath = join(dirname(destination), `.${basename(destination)}.${randomUUID()}.tmp`);
+	try {
+		copyFileSync(source, temporaryPath);
+		renameSync(temporaryPath, destination);
+	} finally {
+		rmSync(temporaryPath, { force: true });
+	}
+}
+
+function isRegularFile(path: string): boolean {
+	return lstatSync(path, { throwIfNoEntry: false })?.isFile() === true;
 }
 
 function removeUnexpectedStagedFiles(directory: string, desiredPaths: ReadonlySet<string>): void {

--- a/src/minsync/workspace.ts
+++ b/src/minsync/workspace.ts
@@ -1,5 +1,16 @@
-import { copyFileSync, existsSync, mkdirSync, rmSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { randomUUID } from "node:crypto";
+import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { normalizeVirtualPath } from "../filesystem/source-paths.ts";
 import { loadMirrorIndex } from "../mirror/index-store.ts";
 import { minSyncDocumentPath, minSyncWorkspaceRoot } from "./paths.ts";
 
@@ -15,23 +26,28 @@ export interface MinSyncWorkspaceSyncResult {
 	readonly entries: readonly MinSyncWorkspaceEntry[];
 }
 
+interface MinSyncStagingEntry {
+	readonly outputPath: string;
+	readonly updatedAt: string;
+}
+
+interface MinSyncStagingState {
+	readonly version: 1;
+	readonly entries: Readonly<Record<string, MinSyncStagingEntry>>;
+}
+
 export function syncMinSyncWorkspace(
 	root: string,
 	options: { readonly workspacePath?: string } = {},
 ): MinSyncWorkspaceSyncResult {
 	const workspacePath = options.workspacePath ?? minSyncWorkspaceRoot(root);
 	const filesRoot = join(workspacePath, "files");
-	rmSync(filesRoot, { recursive: true, force: true });
-	mkdirSync(filesRoot, { recursive: true });
-
 	const index = loadMirrorIndex(root);
 	const entries = Object.values(index.entries)
 		.sort((a, b) => a.virtualPath.localeCompare(b.virtualPath))
 		.filter((entry) => existsSync(entry.outputPath))
 		.map((entry) => {
 			const minSyncPath = minSyncDocumentPath(workspacePath, entry.virtualPath);
-			mkdirSync(dirname(minSyncPath), { recursive: true });
-			copyFileSync(entry.outputPath, minSyncPath);
 			return {
 				virtualPath: entry.virtualPath,
 				sourcePath: entry.sourcePath,
@@ -39,8 +55,85 @@ export function syncMinSyncWorkspace(
 				minSyncPath,
 			};
 		});
+	const previousState = loadStagingState(workspacePath);
+	if (previousState === undefined) {
+		rmSync(filesRoot, { recursive: true, force: true });
+	}
+	mkdirSync(filesRoot, { recursive: true });
+
+	const currentState: Record<string, MinSyncStagingEntry> = {};
+	const desiredPaths = new Set<string>();
+	for (const entry of entries) {
+		const mirrorEntry = index.entries[entry.virtualPath];
+		if (mirrorEntry === undefined) continue;
+		const previousEntry = previousState?.entries[entry.virtualPath];
+		const unchanged =
+			previousEntry?.outputPath === mirrorEntry.outputPath &&
+			previousEntry.updatedAt === mirrorEntry.updatedAt &&
+			existsSync(entry.minSyncPath);
+		if (!unchanged) {
+			mkdirSync(dirname(entry.minSyncPath), { recursive: true });
+			copyFileSync(entry.parsedOutputPath, entry.minSyncPath);
+		}
+		currentState[entry.virtualPath] = {
+			outputPath: mirrorEntry.outputPath,
+			updatedAt: mirrorEntry.updatedAt,
+		};
+		desiredPaths.add(entry.minSyncPath);
+	}
+
+	removeUnexpectedStagedFiles(filesRoot, desiredPaths);
+	saveStagingState(workspacePath, { version: 1, entries: currentState });
 
 	return { workspacePath, entries };
+}
+
+function stagingStatePath(workspacePath: string): string {
+	return join(dirname(workspacePath), `.${basename(workspacePath)}-autorag-staging.json`);
+}
+
+function loadStagingState(workspacePath: string): MinSyncStagingState | undefined {
+	const path = stagingStatePath(workspacePath);
+	if (!existsSync(path)) return undefined;
+	try {
+		const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+		return isMinSyncStagingState(parsed) ? parsed : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function saveStagingState(workspacePath: string, state: MinSyncStagingState): void {
+	const path = stagingStatePath(workspacePath);
+	const temporaryPath = `${path}.${randomUUID()}.tmp`;
+	writeFileSync(temporaryPath, `${JSON.stringify(state, null, 2)}\n`);
+	renameSync(temporaryPath, path);
+}
+
+function isMinSyncStagingState(value: unknown): value is MinSyncStagingState {
+	if (!isRecord(value) || value.version !== 1 || !isRecord(value.entries)) return false;
+	return Object.entries(value.entries).every(
+		([virtualPath, entry]) =>
+			normalizeVirtualPath(virtualPath) === virtualPath &&
+			isRecord(entry) &&
+			typeof entry.outputPath === "string" &&
+			typeof entry.updatedAt === "string",
+	);
+}
+
+function removeUnexpectedStagedFiles(directory: string, desiredPaths: ReadonlySet<string>): void {
+	for (const entry of readdirSync(directory, { withFileTypes: true })) {
+		const path = join(directory, entry.name);
+		if (entry.isDirectory()) {
+			removeUnexpectedStagedFiles(path, desiredPaths);
+		} else if (!desiredPaths.has(path)) {
+			rmSync(path, { force: true });
+		}
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
 }
 
 export function buildMinSyncPathMap(root: string, workspacePath: string): ReadonlyMap<string, MinSyncWorkspaceEntry> {

--- a/test/minsync/minsync.test.ts
+++ b/test/minsync/minsync.test.ts
@@ -1,4 +1,15 @@
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	realpathSync,
+	rmSync,
+	statSync,
+	utimesSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parse } from "smol-toml";
@@ -131,6 +142,221 @@ describe("MinSyncVectorMethod", () => {
 		expect(loggedCalls()).toContainEqual(
 			JSON.stringify({ args: ["sync", "--full", "--format", "json"], cwd: minSyncCwd() }),
 		);
+	});
+
+	it("updates only the changed parsed mirror file", async () => {
+		// Given
+		const guideOutput = join(root, ".autorag", "parsed", "files", "docs", "guide.txt.md");
+		writeFileSync(join(source, "guide.txt"), "raw guide source\n");
+		writeFileSync(guideOutput, "Parsed guide that does not change.\n");
+		saveMirrorIndex(root, {
+			version: 1,
+			entries: {
+				"/docs/guide.txt": {
+					virtualPath: "/docs/guide.txt",
+					sourcePath: join(source, "guide.txt"),
+					outputPath: guideOutput,
+					parserName: "plain-text",
+					sourceMtimeNs: 1,
+					sourceSizeBytes: 17,
+					updatedAt: "2026-01-01T00:00:00.000Z",
+				},
+				"/docs/policy.txt": {
+					virtualPath: "/docs/policy.txt",
+					sourcePath: join(source, "policy.txt"),
+					outputPath: parsedOutput,
+					parserName: "plain-text",
+					sourceMtimeNs: 1,
+					sourceSizeBytes: 18,
+					updatedAt: "2026-01-01T00:00:00.000Z",
+				},
+			},
+		});
+		writeFakeMinSync(JSON.stringify({ results: [] }));
+		const method = new MinSyncVectorMethod({
+			binaryPath: minsyncBinary,
+			root,
+			workspacePath: minsyncWorkspace,
+		});
+		await method.sync();
+		const stagedGuide = join(minsyncWorkspace, "files", "docs", "guide.txt.md");
+		const stagedPolicy = join(minsyncWorkspace, "files", "docs", "policy.txt.md");
+		const preservedTime = new Date("2020-01-01T00:00:00.000Z");
+		utimesSync(stagedGuide, preservedTime, preservedTime);
+
+		// When
+		writeFileSync(parsedOutput, "Parsed renewal policy with updated cancellation terms.\n");
+		saveMirrorIndex(root, {
+			version: 1,
+			entries: {
+				"/docs/guide.txt": {
+					virtualPath: "/docs/guide.txt",
+					sourcePath: join(source, "guide.txt"),
+					outputPath: guideOutput,
+					parserName: "plain-text",
+					sourceMtimeNs: 1,
+					sourceSizeBytes: 17,
+					updatedAt: "2026-01-01T00:00:00.000Z",
+				},
+				"/docs/policy.txt": {
+					virtualPath: "/docs/policy.txt",
+					sourcePath: join(source, "policy.txt"),
+					outputPath: parsedOutput,
+					parserName: "plain-text",
+					sourceMtimeNs: 2,
+					sourceSizeBytes: 18,
+					updatedAt: "2026-01-02T00:00:00.000Z",
+				},
+			},
+		});
+		await method.sync();
+
+		// Then
+		expect(readFileSync(stagedPolicy, "utf8")).toContain("updated cancellation terms");
+		expect(readFileSync(stagedGuide, "utf8")).toBe("Parsed guide that does not change.\n");
+		expect(statSync(stagedGuide).mtimeMs).toBe(preservedTime.getTime());
+	});
+
+	it("adds and removes only corresponding staged mirror files", async () => {
+		// Given
+		const archiveOutput = join(root, ".autorag", "parsed", "files", "docs", "archive.txt.md");
+		writeFileSync(join(source, "archive.txt"), "raw archive source\n");
+		writeFileSync(archiveOutput, "Parsed archive to remove.\n");
+		saveMirrorIndex(root, {
+			version: 1,
+			entries: {
+				"/docs/archive.txt": {
+					virtualPath: "/docs/archive.txt",
+					sourcePath: join(source, "archive.txt"),
+					outputPath: archiveOutput,
+					parserName: "plain-text",
+					sourceMtimeNs: 1,
+					sourceSizeBytes: 19,
+					updatedAt: "2026-01-01T00:00:00.000Z",
+				},
+				"/docs/policy.txt": {
+					virtualPath: "/docs/policy.txt",
+					sourcePath: join(source, "policy.txt"),
+					outputPath: parsedOutput,
+					parserName: "plain-text",
+					sourceMtimeNs: 1,
+					sourceSizeBytes: 18,
+					updatedAt: "2026-01-01T00:00:00.000Z",
+				},
+			},
+		});
+		writeFakeMinSync(JSON.stringify({ results: [] }));
+		const method = new MinSyncVectorMethod({
+			binaryPath: minsyncBinary,
+			root,
+			workspacePath: minsyncWorkspace,
+		});
+		await method.sync();
+		const stagedArchive = join(minsyncWorkspace, "files", "docs", "archive.txt.md");
+		const stagedPolicy = join(minsyncWorkspace, "files", "docs", "policy.txt.md");
+		const preservedTime = new Date("2020-01-01T00:00:00.000Z");
+		utimesSync(stagedPolicy, preservedTime, preservedTime);
+		const noticeOutput = join(root, ".autorag", "parsed", "files", "docs", "notice.txt.md");
+		writeFileSync(join(source, "notice.txt"), "raw notice source\n");
+		writeFileSync(noticeOutput, "Parsed new notice.\n");
+		saveMirrorIndex(root, {
+			version: 1,
+			entries: {
+				"/docs/notice.txt": {
+					virtualPath: "/docs/notice.txt",
+					sourcePath: join(source, "notice.txt"),
+					outputPath: noticeOutput,
+					parserName: "plain-text",
+					sourceMtimeNs: 2,
+					sourceSizeBytes: 18,
+					updatedAt: "2026-01-02T00:00:00.000Z",
+				},
+				"/docs/policy.txt": {
+					virtualPath: "/docs/policy.txt",
+					sourcePath: join(source, "policy.txt"),
+					outputPath: parsedOutput,
+					parserName: "plain-text",
+					sourceMtimeNs: 1,
+					sourceSizeBytes: 18,
+					updatedAt: "2026-01-01T00:00:00.000Z",
+				},
+			},
+		});
+
+		// When
+		await method.sync();
+
+		// Then
+		expect(existsSync(stagedArchive)).toBe(false);
+		expect(readFileSync(join(minsyncWorkspace, "files", "docs", "notice.txt.md"), "utf8")).toBe(
+			"Parsed new notice.\n",
+		);
+		expect(statSync(stagedPolicy).mtimeMs).toBe(preservedTime.getTime());
+	});
+
+	it("ignores traversal entries in a corrupt staging state", async () => {
+		// Given
+		const outsidePath = join(root, "outside.md");
+		writeFileSync(outsidePath, "must survive\n");
+		mkdirSync(minsyncWorkspace, { recursive: true });
+		writeFileSync(
+			join(root, ".autorag", ".minsync-autorag-staging.json"),
+			`${JSON.stringify({
+				version: 1,
+				entries: {
+					"/../../../outside": {
+						outputPath: parsedOutput,
+						updatedAt: "2026-01-01T00:00:00.000Z",
+					},
+				},
+			})}\n`,
+		);
+		writeFakeMinSync(JSON.stringify({ results: [] }));
+		const method = new MinSyncVectorMethod({
+			binaryPath: minsyncBinary,
+			root,
+			workspacePath: minsyncWorkspace,
+		});
+
+		// When
+		await method.sync();
+
+		// Then
+		expect(readFileSync(outsidePath, "utf8")).toBe("must survive\n");
+	});
+
+	it("removes staged files missing from the persisted staging state", async () => {
+		// Given
+		const stagedPolicy = join(minsyncWorkspace, "files", "docs", "policy.txt.md");
+		const orphanPath = join(minsyncWorkspace, "files", "docs", "orphan.txt.md");
+		mkdirSync(join(minsyncWorkspace, "files", "docs"), { recursive: true });
+		writeFileSync(stagedPolicy, "Parsed renewal policy with cancellation and refund terms.\n");
+		writeFileSync(orphanPath, "orphan from interrupted staging\n");
+		writeFileSync(
+			join(root, ".autorag", ".minsync-autorag-staging.json"),
+			`${JSON.stringify({
+				version: 1,
+				entries: {
+					"/docs/policy.txt": {
+						outputPath: parsedOutput,
+						updatedAt: "2026-01-01T00:00:00.000Z",
+					},
+				},
+			})}\n`,
+		);
+		writeFakeMinSync(JSON.stringify({ results: [] }));
+		const method = new MinSyncVectorMethod({
+			binaryPath: minsyncBinary,
+			root,
+			workspacePath: minsyncWorkspace,
+		});
+
+		// When
+		await method.sync();
+
+		// Then
+		expect(existsSync(orphanPath)).toBe(false);
+		expect(readFileSync(stagedPolicy, "utf8")).toContain("cancellation and refund terms");
 	});
 
 	it("returns vector results resolved from parsed mirror paths back to virtual paths", async () => {

--- a/test/minsync/minsync.test.ts
+++ b/test/minsync/minsync.test.ts
@@ -1,12 +1,14 @@
 import {
 	chmodSync,
 	existsSync,
+	lstatSync,
 	mkdirSync,
 	mkdtempSync,
 	readFileSync,
 	realpathSync,
 	rmSync,
 	statSync,
+	symlinkSync,
 	utimesSync,
 	writeFileSync,
 } from "node:fs";
@@ -359,6 +361,58 @@ describe("MinSyncVectorMethod", () => {
 		expect(readFileSync(stagedPolicy, "utf8")).toContain("cancellation and refund terms");
 	});
 
+	it("rebuilds a symlinked staging root without touching its target", async () => {
+		// Given
+		writeFakeMinSync(JSON.stringify({ results: [] }));
+		const method = new MinSyncVectorMethod({
+			binaryPath: minsyncBinary,
+			root,
+			workspacePath: minsyncWorkspace,
+		});
+		await method.sync();
+		const filesRoot = join(minsyncWorkspace, "files");
+		const outsideDirectory = join(root, "outside-staging-target");
+		const outsideFile = join(outsideDirectory, "must-survive.txt");
+		rmSync(filesRoot, { recursive: true, force: true });
+		mkdirSync(outsideDirectory, { recursive: true });
+		writeFileSync(outsideFile, "must survive\n");
+		symlinkSync(outsideDirectory, filesRoot, "dir");
+
+		// When
+		await method.sync();
+
+		// Then
+		expect(readFileSync(outsideFile, "utf8")).toBe("must survive\n");
+		expect(lstatSync(filesRoot).isSymbolicLink()).toBe(false);
+		expect(lstatSync(filesRoot).isDirectory()).toBe(true);
+		expect(readFileSync(join(filesRoot, "docs", "policy.txt.md"), "utf8")).toContain("cancellation terms");
+	});
+
+	it("replaces a staged file symlink without reading or overwriting its target", async () => {
+		// Given
+		writeFakeMinSync(JSON.stringify({ results: [] }));
+		const method = new MinSyncVectorMethod({
+			binaryPath: minsyncBinary,
+			root,
+			workspacePath: minsyncWorkspace,
+		});
+		await method.sync();
+		const stagedPolicy = join(minsyncWorkspace, "files", "docs", "policy.txt.md");
+		const outsideFile = join(root, "outside-policy.md");
+		rmSync(stagedPolicy, { force: true });
+		writeFileSync(outsideFile, "must survive\n");
+		symlinkSync(outsideFile, stagedPolicy);
+
+		// When
+		await method.sync();
+
+		// Then
+		expect(readFileSync(outsideFile, "utf8")).toBe("must survive\n");
+		expect(lstatSync(stagedPolicy).isSymbolicLink()).toBe(false);
+		expect(lstatSync(stagedPolicy).isFile()).toBe(true);
+		expect(readFileSync(stagedPolicy, "utf8")).toContain("cancellation terms");
+	});
+
 	it("returns vector results resolved from parsed mirror paths back to virtual paths", async () => {
 		// Given
 		writeFakeMinSync(
@@ -402,15 +456,13 @@ describe("MinSyncVectorMethod", () => {
 	it("maps real MinSync relative file paths back to virtual paths", async () => {
 		// Given
 		writeFakeMinSync(
-			JSON.stringify({
-				results: [
-					{
-						path: "files/docs/policy.txt.md",
-						score: 0.77,
-						text: "Relative path hit from MinSync.",
-					},
-				],
-			}),
+			JSON.stringify([
+				{
+					path: "files/docs/policy.txt.md",
+					score: 0.77,
+					text: "Relative path hit from MinSync.",
+				},
+			]),
 		);
 		const method = new MinSyncVectorMethod({
 			binaryPath: minsyncBinary,


### PR DESCRIPTION
## Summary
- preserve the MinSync staging tree and copy only added or changed parsed mirrors
- sweep deleted and crash-orphaned staged files while rejecting unsafe state keys
- add RED→GREEN coverage for modified, add/delete, traversal, and interrupted-staging cases

## Verification
- `bunx vitest run test/minsync/minsync.test.ts` — 22 passed
- `bunx vitest run --exclude test/subagents/runtime.test.ts` — 89 files, 1266 tests passed
- `bun run typecheck`
- `bun run build`
- `bunx biome check src/minsync/workspace.ts test/minsync/minsync.test.ts`
- live E2E with real MinSync v0.3.0: initial sync processed 2 files; one-file update processed 1; unrelated inode/mtime/hash unchanged; only changed policy reached TEI

## Validation note
The isolated worktree exposes an unrelated `test/subagents/runtime.test.ts` assumption that constructs `process.cwd()/node_modules`; its focused test passes on the normal main checkout. A concurrent file-lock test also passed when rerun alone after one full-suite flake.