### PR TITLE
fix(explorer): skip File Provider placeholders in grep/read

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.9/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.10/schema.json",
 	"linter": {
 		"enabled": true,
 		"rules": {

--- a/src/filesystem/cloud-placeholder.ts
+++ b/src/filesystem/cloud-placeholder.ts
@@ -1,0 +1,123 @@
+import { execFile } from "node:child_process";
+import { lstat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, relative, sep } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/** Darwin `st_flags` bit. Present on iCloud/File Provider placeholders. */
+export const UF_DATALESS = 0x0000_8000;
+export const FILE_PROVIDER_XATTR = "com.apple.file-provider-domain-id";
+
+const CLOUD_PATH_MARKERS = [
+	`${sep}Library${sep}CloudStorage${sep}`,
+	`${sep}Library${sep}Mobile Documents${sep}`,
+] as const;
+
+export type FilesystemKind = "local" | "file-provider";
+
+export interface FilesystemClassification {
+	readonly kind: FilesystemKind;
+	readonly provider?: string;
+	readonly reason: "path-marker" | "file-provider-xattr" | "local";
+}
+
+export function pathLooksLikeCloudRoot(target: string): boolean {
+	return CLOUD_PATH_MARKERS.some((marker) => target.includes(marker));
+}
+
+export function homeCloudRoots(home = homedir()): readonly string[] {
+	return [join(home, "Library", "CloudStorage"), join(home, "Library", "Mobile Documents")];
+}
+
+export async function classifyFilesystemRoot(target: string): Promise<FilesystemClassification> {
+	if (pathLooksLikeCloudRoot(target)) {
+		return { kind: "file-provider", reason: "path-marker", provider: "cloud-storage-path" };
+	}
+	if (process.platform !== "darwin") {
+		return { kind: "local", reason: "local" };
+	}
+	let cursor = target;
+	for (let depth = 0; depth < 8; depth += 1) {
+		const provider = await readFileProviderDomain(cursor);
+		if (provider !== undefined) {
+			return { kind: "file-provider", reason: "file-provider-xattr", provider };
+		}
+		const parent = dirname(cursor);
+		if (parent === cursor) break;
+		cursor = parent;
+	}
+	return { kind: "local", reason: "local" };
+}
+
+export async function isDatalessPlaceholder(target: string): Promise<boolean> {
+	if (process.platform !== "darwin") return false;
+	try {
+		const { stdout } = await execFileAsync("/usr/bin/stat", ["-f", "%f", target], { timeout: 2_000 });
+		const flags = Number.parseInt(stdout.trim(), 16);
+		return Number.isFinite(flags) && (flags & UF_DATALESS) !== 0;
+	} catch {
+		return false;
+	}
+}
+
+export interface MaterializedWalk {
+	readonly materialized: readonly string[];
+	readonly skippedDataless: number;
+}
+
+export async function listMaterializedFiles(
+	root: string,
+	options: { readonly limit?: number; readonly timeoutMs?: number } = {},
+): Promise<MaterializedWalk> {
+	const limit = options.limit ?? 20_000;
+	if (process.platform !== "darwin") {
+		return { materialized: [], skippedDataless: 0 };
+	}
+	try {
+		const { stdout } = await execFileAsync("/usr/bin/find", [root, "-type", "f", "!", "-flags", "+dataless"], {
+			timeout: options.timeoutMs ?? 15_000,
+			maxBuffer: 16 * 1024 * 1024,
+		});
+		const materialized = stdout
+			.split("\n")
+			.filter((line) => line.length > 0)
+			.slice(0, limit);
+		let skippedDataless = 0;
+		try {
+			const skipped = await execFileAsync("/usr/bin/find", [root, "-flags", "+dataless"], {
+				timeout: options.timeoutMs ?? 15_000,
+				maxBuffer: 16 * 1024 * 1024,
+			});
+			skippedDataless = skipped.stdout.split("\n").filter((line) => line.length > 0).length;
+		} catch {
+			skippedDataless = 0;
+		}
+		return { materialized, skippedDataless };
+	} catch {
+		return { materialized: [], skippedDataless: 0 };
+	}
+}
+
+export function relativeCloudHint(root: string, filePath: string): string {
+	const rel = relative(root, filePath);
+	return rel === "" ? filePath : rel.split(sep).join("/");
+}
+
+async function readFileProviderDomain(target: string): Promise<string | undefined> {
+	try {
+		await lstat(target);
+	} catch {
+		return undefined;
+	}
+	try {
+		const { stdout } = await execFileAsync("/usr/bin/xattr", ["-p", FILE_PROVIDER_XATTR, target], {
+			timeout: 2_000,
+		});
+		const value = stdout.trim();
+		return value.length > 0 ? value : undefined;
+	} catch {
+		return undefined;
+	}
+}

--- a/test/filesystem/cloud-placeholder.test.ts
+++ b/test/filesystem/cloud-placeholder.test.ts
@@ -1,0 +1,46 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	classifyFilesystemRoot,
+	homeCloudRoots,
+	pathLooksLikeCloudRoot,
+} from "../../src/filesystem/cloud-placeholder.ts";
+
+describe("cloud placeholder detection", () => {
+	it("treats CloudStorage and Mobile Documents paths as file-provider roots", () => {
+		expect(pathLooksLikeCloudRoot("/Users/x/Library/CloudStorage/OneDrive-Personal/docs")).toBe(true);
+		expect(pathLooksLikeCloudRoot("/Users/x/Library/Mobile Documents/com~apple~CloudDocs")).toBe(true);
+		expect(pathLooksLikeCloudRoot("/Users/x/Downloads")).toBe(false);
+		expect(pathLooksLikeCloudRoot("/Users/x/PycharmProjects/banana/paper")).toBe(false);
+	});
+
+	it("lists well-known home cloud roots", () => {
+		const roots = homeCloudRoots("/Users/demo");
+		expect(roots).toContain("/Users/demo/Library/CloudStorage");
+		expect(roots).toContain("/Users/demo/Library/Mobile Documents");
+	});
+
+	it("classifies a local temp directory as local", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "autorag-cloud-"));
+		mkdirSync(join(dir, "docs"));
+		writeFileSync(join(dir, "docs", "a.txt"), "hello\n");
+		const classified = await classifyFilesystemRoot(dir);
+		expect(classified.kind).toBe("local");
+		expect(classified.reason).toBe("local");
+	});
+
+	it("classifies CloudStorage paths without touching the filesystem", async () => {
+		const classified = await classifyFilesystemRoot("/Users/demo/Library/CloudStorage/GoogleDrive-x/My Drive");
+		expect(classified.kind).toBe("file-provider");
+		expect(classified.reason).toBe("path-marker");
+	});
+
+	it("classifies this machine's Documents as file-provider when the xattr is present", async () => {
+		if (process.platform !== "darwin") return;
+		const classified = await classifyFilesystemRoot(`${process.env.HOME ?? ""}/Documents`);
+		if (classified.kind === "local") return;
+		expect(classified.reason).toBe("file-provider-xattr");
+	});
+});


### PR DESCRIPTION
Draft follow-up for #1424.

## Problem

`autorag-explorer` `grep`/`read` can stall for the full ~20 minute subagent timeout on macOS iCloud Desktop/Documents (and other File Provider roots). Ripgrep itself is fine on local SSD; `open()` on UF_DATALESS placeholders hydrates via File Provider. A parent `subagent` batch then waits for the slowest child.

## Change

- Detect File Provider roots (`Library/CloudStorage`, `Library/Mobile Documents`, ancestor `com.apple.file-provider-domain-id`).
- `grep` on those roots uses only materialized files (`find ! -flags +dataless`) plus a 20s abort.
- `read` of a dataless path returns a skip message instead of hydrating.

Linux/Windows are unchanged (no-op). Parent `bash rg` still bypasses this wrapper; explorers have no bash.

## Test

`bun test test/filesystem/cloud-placeholder.test.ts` and the local-cwd cases in `test/subagents/explorer-tools-extension.test.ts`.

Closes #1424