### PR TITLE
fix: add Windows test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "prepublishOnly": "bun run typecheck && bun run build",
     "prepare": "bun run build",
     "test": "node scripts/run-test-files.mjs",
+    "test:windows": "node scripts/run-test-files.mjs",
     "check": "biome check --write .",
     "lint": "biome check .",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
## Summary
- add the documented `test:windows` package script
- route it through the same Node-based full-suite runner used by `test`
- follow up on the broken command merged in #1434

## Verification
- `bun run test:windows` — all 91 test files passed
- `bun run typecheck`
- `bun run build`
- `git diff --check`

Fixes the review finding noted in #1434.