### PR TITLE
fix(subagents): route in-process explorer discovery

### DIFF
--- a/scripts/manual-qa/run-issue-1455-live.ts
+++ b/scripts/manual-qa/run-issue-1455-live.ts
@@ -1,0 +1,100 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadLocalAutoRAGModels } from "../../src/subagents/local-models.ts";
+import { createMandatorySubagentSession } from "../../src/subagents/runtime.ts";
+
+const root = mkdtempSync(join(tmpdir(), "autorag-issue-1455-live-"));
+const docs = join(root, "docs");
+const agentDir = join(root, "pi-agent");
+const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+mkdirSync(docs, { recursive: true });
+writeFileSync(
+	join(docs, "policy.txt"),
+	[
+		"Atlas refund policy",
+		"Refund exceptions require director approval before payout.",
+		"The policy was revised on 2026-07-01.",
+	].join("\n"),
+);
+delete process.env.PI_CODING_AGENT_DIR;
+
+try {
+	const models = loadLocalAutoRAGModels();
+	const runtime = await createMandatorySubagentSession({
+		cwd: docs,
+		agentDir,
+		model: models.orchestrator,
+		explorerModel: models.explorer,
+		apiKey: models.apiKey,
+		providerApiKeys: { [models.provider]: models.apiKey },
+		systemPrompt: "Run the requested explorer task.",
+		tools: [],
+	});
+
+	try {
+		if (process.env.PI_CODING_AGENT_DIR !== agentDir) {
+			throw new Error(`Expected active agent directory ${agentDir}, got ${process.env.PI_CODING_AGENT_DIR}`);
+		}
+		const subagent = runtime.session.getToolDefinition("subagent");
+		if (subagent === undefined) throw new Error("The mandatory subagent tool was not registered");
+
+		const result = await subagent.execute(
+			"issue-1455-live",
+			{
+				agent: "autorag-explorer",
+				agentScope: "user",
+				artifacts: false,
+				model: `${models.provider}/${models.explorer.id}`,
+				cwd: docs,
+				task: [
+					"<<<AUTORAG_ASSIGNMENT_V1>>>",
+					JSON.stringify({
+						originalQuery: "What approval is required for Atlas refund exceptions?",
+						method: "contained read",
+						queryVariants: ["Atlas refund exception approval", "refund policy approver"],
+					}),
+					"<<<END_AUTORAG_ASSIGNMENT_V1>>>",
+					"Required handoff: include retrievedAt and temporal metadata.",
+					"Read policy.txt and return candidate evidence only.",
+				].join("\n"),
+			},
+			undefined,
+			undefined,
+			runtime.session.extensionRunner.createContext(),
+		);
+		const serialized = JSON.stringify(result);
+		const results = (result.details as { results?: Array<{ exitCode?: number }> } | undefined)?.results ?? [];
+		if (result.isError || serialized.includes("Unknown agent: autorag-explorer")) {
+			throw new Error(`Explorer discovery failed: ${serialized}`);
+		}
+		if (!results.some((entry) => entry.exitCode === 0)) {
+			throw new Error(`Explorer did not complete successfully: ${serialized}`);
+		}
+		if (!serialized.toLowerCase().includes("director approval")) {
+			throw new Error(`Explorer did not return grounded policy evidence: ${serialized}`);
+		}
+		console.log(
+			JSON.stringify(
+				{
+					status: "LIVE E2E PASSED",
+					agent: "autorag-explorer",
+					model: `${models.provider}/${models.explorer.id}`,
+					exitCode: 0,
+				},
+				null,
+				2,
+			),
+		);
+	} finally {
+		runtime.session.dispose();
+	}
+
+	if (process.env.PI_CODING_AGENT_DIR !== undefined) {
+		throw new Error(`Session did not restore PI_CODING_AGENT_DIR: ${process.env.PI_CODING_AGENT_DIR}`);
+	}
+} finally {
+	if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+	else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+	rmSync(root, { recursive: true, force: true });
+}

--- a/src/subagents/runtime.ts
+++ b/src/subagents/runtime.ts
@@ -422,6 +422,7 @@ interface ChildEnvironmentLease {
 	readonly agentDir: string;
 	readonly registryIdentity: string;
 	readonly environmentIdentity: string;
+	readonly previousPiCodingAgentDir: string | undefined;
 	owners: number;
 }
 
@@ -839,7 +840,12 @@ function acquireChildEnvironment(request: ChildEnvironmentLeaseRequest): () => v
 			released = true;
 			if (childEnvironmentLease === undefined) return;
 			childEnvironmentLease.owners -= 1;
-			if (childEnvironmentLease.owners === 0) childEnvironmentLease = undefined;
+			if (childEnvironmentLease.owners === 0) {
+				const { previousPiCodingAgentDir } = childEnvironmentLease;
+				childEnvironmentLease = undefined;
+				if (previousPiCodingAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+				else process.env.PI_CODING_AGENT_DIR = previousPiCodingAgentDir;
+			}
 		};
 	}
 
@@ -847,15 +853,22 @@ function acquireChildEnvironment(request: ChildEnvironmentLeaseRequest): () => v
 		agentDir: request.agentDir,
 		registryIdentity: request.registryIdentity,
 		environmentIdentity: request.environmentIdentity,
+		previousPiCodingAgentDir: process.env.PI_CODING_AGENT_DIR,
 		owners: 1,
 	};
+	process.env.PI_CODING_AGENT_DIR = request.agentDir;
 	let released = false;
 	return () => {
 		if (released) return;
 		released = true;
 		if (childEnvironmentLease === undefined) return;
 		childEnvironmentLease.owners -= 1;
-		if (childEnvironmentLease.owners === 0) childEnvironmentLease = undefined;
+		if (childEnvironmentLease.owners === 0) {
+			const { previousPiCodingAgentDir } = childEnvironmentLease;
+			childEnvironmentLease = undefined;
+			if (previousPiCodingAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = previousPiCodingAgentDir;
+		}
 	};
 }
 
@@ -916,10 +929,16 @@ export async function createMandatorySubagentSession(
 		apiKeyName: explorerRoleModel.reference.apiKeyReference,
 		...(explorerCredential === undefined ? {} : { apiKey: explorerCredential }),
 	};
+	const releaseChildEnvironment = acquireChildEnvironment({
+		agentDir,
+		registryIdentity: modelRegistryIdentity(modelsPath, roleModels),
+		environmentIdentity: explorerEnvironmentIdentity(explorerEnvironment),
+	});
 	let extensionFactory: ExtensionFactory;
 	try {
 		extensionFactory = await loadScopedPiSubagentsExtension(extensionPath, explorerEnvironment);
 	} catch (error) {
+		releaseChildEnvironment();
 		throw new Error(`Mandatory pi-subagents extension failed to load: ${(error as Error).message}`, {
 			cause: error,
 		});
@@ -937,6 +956,7 @@ export async function createMandatorySubagentSession(
 	try {
 		await resourceLoader.reload();
 	} catch (error) {
+		releaseChildEnvironment();
 		throw new Error(`Mandatory pi-subagents extension failed to load: ${(error as Error).message}`, {
 			cause: error,
 		});
@@ -944,13 +964,9 @@ export async function createMandatorySubagentSession(
 	const extensionResult = resourceLoader.getExtensions();
 	if (extensionResult.errors.length > 0) {
 		const messages = extensionResult.errors.map((error) => error.error).join("; ");
+		releaseChildEnvironment();
 		throw new Error(`Mandatory pi-subagents extension failed to load: ${messages}`);
 	}
-	const releaseChildEnvironment = acquireChildEnvironment({
-		agentDir,
-		registryIdentity: modelRegistryIdentity(modelsPath, roleModels),
-		environmentIdentity: explorerEnvironmentIdentity(explorerEnvironment),
-	});
 	try {
 		await persistPiModels(modelsPath, roleModels, parentProviderCredentials);
 		const modelRuntime = await ModelRuntime.create({

--- a/test/subagents/runtime.test.ts
+++ b/test/subagents/runtime.test.ts
@@ -1800,7 +1800,7 @@ Project override body.
 		}
 	});
 
-	it("matches the installed subagent schema after discovering the managed explorer", async () => {
+	it("matches the installed subagent schema while AutoRAG rejects nested artifacts separately", async () => {
 		const root = mkdtempSync(join(tmpdir(), "autorag-pi-artifacts-schema-"));
 		tempDirs.push(root);
 		const runtime = await createMandatorySubagentSession({
@@ -1837,7 +1837,7 @@ Project override body.
 					artifacts: false,
 					chain: [nestedArtifacts],
 				}),
-			).toBe(false);
+			).toBe(true);
 		} finally {
 			runtime.session.dispose();
 		}

--- a/test/subagents/runtime.test.ts
+++ b/test/subagents/runtime.test.ts
@@ -797,7 +797,7 @@ describe("mandatory pi-subagents runtime", () => {
 				);
 				expect(config.providers["test-proxy"]?.apiKey).toBe("$TEST_PROXY_API_KEY");
 				expect(modelsJson).not.toContain(sentinel);
-				expect(process.env.PI_CODING_AGENT_DIR).toBe(previousPiAgentDir);
+				expect(process.env.PI_CODING_AGENT_DIR).toBe(resolve(agentDir));
 				expect(process.env.TEST_PROXY_API_KEY).toBe(previousApiKey);
 
 				const piBinary = join(
@@ -831,6 +831,34 @@ describe("mandatory pi-subagents runtime", () => {
 		} finally {
 			if (previousApiKey === undefined) delete process.env.TEST_PROXY_API_KEY;
 			else process.env.TEST_PROXY_API_KEY = previousApiKey;
+			if (previousPiAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = previousPiAgentDir;
+		}
+	});
+
+	it("routes in-process subagent discovery through the active AutoRAG agent directory", async () => {
+		const root = mkdtempSync(join(tmpdir(), "autorag-pi-in-process-discovery-"));
+		tempDirs.push(root);
+		const agentDir = join(root, "agent");
+		const previousPiAgentDir = process.env.PI_CODING_AGENT_DIR;
+		delete process.env.PI_CODING_AGENT_DIR;
+
+		try {
+			const runtime = await createMandatorySubagentSession({
+				cwd: root,
+				agentDir,
+				model,
+				explorerModel,
+				systemPrompt: "test prompt",
+				tools: [customTool],
+			});
+			try {
+				expect(process.env.PI_CODING_AGENT_DIR).toBe(resolve(agentDir));
+			} finally {
+				runtime.session.dispose();
+			}
+			expect(process.env.PI_CODING_AGENT_DIR).toBeUndefined();
+		} finally {
 			if (previousPiAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 			else process.env.PI_CODING_AGENT_DIR = previousPiAgentDir;
 		}
@@ -882,7 +910,7 @@ describe("mandatory pi-subagents runtime", () => {
 		}
 	});
 
-	it("gives only the explorer credential to Pi while a concurrent generic child keeps the parent environment", async () => {
+	it("gives only the explorer credential to Pi while generic children inherit discovery routing", async () => {
 		const root = mkdtempSync(join(tmpdir(), "autorag-pi-provider-credentials-"));
 		tempDirs.push(root);
 		const agentDir = join(root, "agent");
@@ -1017,7 +1045,7 @@ describe("mandatory pi-subagents runtime", () => {
 				tools: [customTool],
 			});
 			try {
-				expect(process.env.PI_CODING_AGENT_DIR).toBe(previousPiAgentDir);
+				expect(process.env.PI_CODING_AGENT_DIR).toBe(resolve(agentDir));
 				expect(process.env.OPENAI_API_KEY).toBe(orchestratorSecret);
 				expect(process.env.OTHER_PROVIDER_API_KEY).toBeUndefined();
 				expect(process.env.UNLISTED_PARENT_SECRET).toBe(unlistedParentSecret);
@@ -1066,6 +1094,7 @@ describe("mandatory pi-subagents runtime", () => {
 				);
 				expect(genericChild.status).toBe(0);
 				expect(JSON.parse(genericChild.stdout)).toEqual({
+					agentDir: resolve(agentDir),
 					orchestratorSecretVisible: true,
 					explorerSecretVisible: false,
 					unlistedParentSecretVisible: true,
@@ -1348,7 +1377,7 @@ describe("mandatory pi-subagents runtime", () => {
 		}
 	});
 
-	it("keeps compatible routing leases without changing the parent environment", async () => {
+	it("keeps compatible routing active until the final session releases it", async () => {
 		const root = mkdtempSync(join(tmpdir(), "autorag-pi-compatible-lease-"));
 		tempDirs.push(root);
 		const agentDir = join(root, "agent");
@@ -1380,7 +1409,7 @@ describe("mandatory pi-subagents runtime", () => {
 
 			firstRuntime.session.dispose();
 			firstRuntime = undefined;
-			expect(process.env.PI_CODING_AGENT_DIR).toBe(previousAgentDir);
+			expect(process.env.PI_CODING_AGENT_DIR).toBe(resolve(agentDir));
 			expect(process.env.TEST_PROXY_API_KEY).toBe(previousApiKey);
 
 			secondRuntime.session.dispose();
@@ -1771,7 +1800,7 @@ Project override body.
 		}
 	});
 
-	it("matches the installed subagent schema while AutoRAG rejects nested artifacts separately", async () => {
+	it("matches the installed subagent schema after discovering the managed explorer", async () => {
 		const root = mkdtempSync(join(tmpdir(), "autorag-pi-artifacts-schema-"));
 		tempDirs.push(root);
 		const runtime = await createMandatorySubagentSession({
@@ -1808,7 +1837,7 @@ Project override body.
 					artifacts: false,
 					chain: [nestedArtifacts],
 				}),
-			).toBe(true);
+			).toBe(false);
 		} finally {
 			runtime.session.dispose();
 		}


### PR DESCRIPTION
## Summary
- route the orchestrator process through the active AutoRAG Pi agent directory while a subagent session is alive
- restore the caller's previous `PI_CODING_AGENT_DIR` after the final compatible session is disposed
- add regression coverage for discovery routing, concurrent leases, child inheritance, and failure cleanup
- add a live E2E harness that launches the real `autorag-explorer` through the configured Luna model

## TDD
- red: `routes in-process subagent discovery through the active AutoRAG agent directory` failed because `PI_CODING_AGENT_DIR` was unset
- green: complete runtime suite passes after scoped lease routing

## Verification
- `node node_modules/vitest/vitest.mjs run test/subagents/runtime.test.ts test/agent/search-documents.test.ts test/agent/search-documents-live-e2e.test.ts` — 174 passed
- `bun run typecheck` — passed
- `bun run build` — passed
- `bunx biome check src/subagents/runtime.ts test/subagents/runtime.test.ts scripts/manual-qa/run-issue-1455-live.ts` — passed
- `bun scripts/manual-qa/run-issue-1455-live.ts` — LIVE E2E PASSED with `myproxy/gpt-5.6-luna`, exit code 0
- `bun scripts/manual-qa/run-qa-live.ts` — LIVE QA PASSED against GitHub and RSS
- CLI manual QA: `--help`, invalid command, and `health --help`

Closes #1455