### PR TITLE
feat(datasource): add incremental rclone cloud drives

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Security defaults are intentionally strict:
 | Discord | `discord` | external [`discrawl`](https://github.com/openclaw/discrawl) CLI | guild/channel/thread/DM archive; FTS5 + semantic + hybrid retrieval, incremental sync |
 | Notion | `notion` | external [`notcrawl`](https://github.com/openclaw/notcrawl) CLI | local-first page/database/block archive + FTS5 search |
 | GitHub Issues/PRs | `github` | GitHub REST (token optional) | issues + PR bodies per `owner/repo`; public repos work unauthenticated |
-| Google Drive | `gdrive` | Drive REST v3, or **[`rclone`](https://rclone.org) CLI** (`backend: "rclone"`) | Docs/Sheets exported as text; the rclone backend also opens any of rclone's 70+ remotes |
+| Cloud drives | `cloud-drive` | **[`rclone`](https://rclone.org) CLI** | Incremental Google Drive Tier-1; OneDrive/network remotes; iCloud experimental |
 | Gmail / IMAP | `gmail` | Gmail REST v1, or **[`himalaya`](https://pimalaya.org) CLI** (`backend: "himalaya"`) | the himalaya backend indexes any IMAP/Maildir account it has configured — no OAuth plumbing |
 | Local mail exports | `mail-export` | filesystem (`.mbox` / `.eml`) | classic `From_` splitting, mailparser-based; count-only warnings |
 | Obsidian vault | `obsidian` | external [`qmd`](https://github.com/tobi/qmd) CLI | incremental `qmd update`, BM25 `qmd search`, semantic `qmd vsearch`; vault path via `connector.vaultPath` |
@@ -158,13 +158,13 @@ Configure them in `config.json` (CLI) or pass `datasourceSkills` programmaticall
     "notion":   { "connector": { "binaryPath": "notcrawl", "configPath": "/path/to/notcrawl.yaml" } },
     "github":   { "connector": { "repos": ["owner/repo"] } },
     "gmail":    { "connector": { "backend": "himalaya", "account": "gmail", "folder": "INBOX" } },
-    "gdrive":   { "connector": { "backend": "rclone", "remote": "gdrive:" } },
+    "cloud-drive": { "instanceId": "team-docs", "connector": { "provider": "google-drive", "remote": "gdrive:", "include": ["**/*.md"] } },
     "obsidian": { "connector": { "vaultPath": "/path/to/vault" } },
     "rss":      { "connector": { "feeds": [{ "url": "https://example.com/feed.xml" }] } }
   },
   "datasourceAccess": {
-    "allowedTags": ["whatsapp", "telegram", "slack", "notion", "github", "gmail", "gdrive", "obsidian", "rss"],
-    "allowedScopes": ["/whatsapp/**", "/telegram/**", "/slack/**", "/notion/**", "/github/**", "/gmail/**", "/gdrive/**", "/obsidian/**", "/rss/**"]
+    "allowedTags": ["whatsapp", "telegram", "slack", "notion", "github", "gmail", "cloud-drive", "obsidian", "rss"],
+    "allowedScopes": ["/whatsapp/**", "/telegram/**", "/slack/**", "/notion/**", "/github/**", "/gmail/**", "/cloud-drive/**", "/obsidian/**", "/rss/**"]
   }
 }
 ```
@@ -176,6 +176,17 @@ Install telecrawl with `brew install openclaw/tap/telecrawl`. AutoRAG invokes `t
 Install slacrawl with `brew install openclaw/tap/slacrawl`. AutoRAG invokes `slacrawl sync` during datasource refresh and `slacrawl --json search` during retrieval. Optional trusted connector fields are `binaryPath`, `configPath`, and `syncSource`. Slack credentials and source definitions remain in slacrawl's own configuration rather than AutoRAG.
 
 Install notcrawl with `brew install openclaw/tap/notcrawl`. AutoRAG invokes `notcrawl sync` during datasource refresh and `notcrawl search --json` during retrieval. Optional trusted connector fields are `binaryPath` and `configPath`. Notion credentials and workspace definitions remain in notcrawl's own configuration rather than AutoRAG.
+
+Install and authenticate rclone separately (`brew install rclone && rclone
+config` on macOS), then configure the provider-neutral `cloud-drive` skill.
+AutoRAG inventories with `rclone lsjson`, keeps a workspace-local manifest and
+managed mirror, and downloads only added or changed indexable files. Google
+Drive is Tier-1. OneDrive, Dropbox, SMB/SFTP/WebDAV, and mounted drives share
+the same manifest contract. iCloud Drive is experimental because rclone marks
+that backend Tier 4 and Apple ID/2FA sessions periodically require
+reauthentication. See [docs/datasource-skills.md](docs/datasource-skills.md)
+for filtering, size, concurrency, bandwidth, dry-run, and agent tool-calling
+details.
 
 #### KakaoTalk (katok)
 

--- a/README.md
+++ b/README.md
@@ -158,13 +158,14 @@ Configure them in `config.json` (CLI) or pass `datasourceSkills` programmaticall
     "notion":   { "connector": { "binaryPath": "notcrawl", "configPath": "/path/to/notcrawl.yaml" } },
     "github":   { "connector": { "repos": ["owner/repo"] } },
     "gmail":    { "connector": { "backend": "himalaya", "account": "gmail", "folder": "INBOX" } },
-    "cloud-drive": { "instanceId": "team-docs", "connector": { "provider": "google-drive", "remote": "gdrive:", "include": ["**/*.md"] } },
+    "personal-google-drive": { "type": "cloud-drive", "instanceId": "personal", "connector": { "provider": "google-drive", "remote": "personal-gdrive:", "include": ["**/*.md"] } },
+    "company-onedrive": { "type": "cloud-drive", "instanceId": "work", "connector": { "provider": "onedrive", "remote": "company-onedrive:Documents" } },
     "obsidian": { "connector": { "vaultPath": "/path/to/vault" } },
     "rss":      { "connector": { "feeds": [{ "url": "https://example.com/feed.xml" }] } }
   },
   "datasourceAccess": {
     "allowedTags": ["whatsapp", "telegram", "slack", "notion", "github", "gmail", "cloud-drive", "obsidian", "rss"],
-    "allowedScopes": ["/whatsapp/**", "/telegram/**", "/slack/**", "/notion/**", "/github/**", "/gmail/**", "/cloud-drive/**", "/obsidian/**", "/rss/**"]
+    "allowedScopes": ["/whatsapp/**", "/telegram/**", "/slack/**", "/notion/**", "/github/**", "/gmail/**", "/personal-google-drive/**", "/company-onedrive/**", "/obsidian/**", "/rss/**"]
   }
 }
 ```
@@ -179,6 +180,10 @@ Install notcrawl with `brew install openclaw/tap/notcrawl`. AutoRAG invokes `not
 
 Install and authenticate rclone separately (`brew install rclone && rclone
 config` on macOS), then configure the provider-neutral `cloud-drive` skill.
+`cloud-drive` is a reusable `type`: each datasource config key is a connection
+alias and becomes a separate agent skill and scope. Multiple Google accounts,
+or Google Drive plus OneDrive/iCloud, can therefore be loaded and searched
+independently.
 AutoRAG inventories with `rclone lsjson`, keeps a workspace-local manifest and
 managed mirror, and downloads only added or changed indexable files. Google
 Drive is Tier-1. OneDrive, Dropbox, SMB/SFTP/WebDAV, and mounted drives share

--- a/docs/datasource-skills.md
+++ b/docs/datasource-skills.md
@@ -61,6 +61,67 @@ A skill can publish `instances`, for example:
 
 Every instance maps to a datasource root like `/kakao/personal` or `/slack/workspace/channel`.
 
+## Cloud drives via rclone
+
+The `cloud-drive` datasource uses the external [`rclone`](https://rclone.org)
+CLI as the provider boundary. Configure OAuth, Apple ID/session, or other
+credentials only in `rclone config`; AutoRAG receives the trusted remote name,
+never provider secrets.
+
+Tier-1 is Google Drive. OneDrive and mounted/network remotes use the same
+provider-neutral contract. iCloud Drive is explicitly experimental because
+its rclone backend is Tier 4 and periodically requires Apple ID/password,
+2FA, and reauthentication.
+
+```json
+{
+  "datasources": {
+    "cloud-drive": {
+      "instanceId": "team-docs",
+      "pollingIntervalMs": 900000,
+      "connector": {
+        "provider": "onedrive",
+        "remote": "onedrive:Team Docs",
+        "include": ["**/*.md", "**/*.pdf"],
+        "exclude": ["Archive/**"],
+        "maxBytesPerFile": 52428800,
+        "concurrency": 4,
+        "bandwidthLimit": "10M",
+        "dryRun": false
+      }
+    }
+  },
+  "datasourceAccess": {
+    "allowedTags": ["cloud-drive"],
+    "allowedScopes": ["/cloud-drive/team-docs/**"]
+  }
+}
+```
+
+Run the CLI datasource refresh with:
+
+```bash
+rclone config
+autorag refresh --method datasources --config ./config.json
+autorag search "the renewal terms in the team drive"
+```
+
+Each refresh runs `rclone lsjson --recursive --files-only --hash`, compares
+the result with the workspace-local manifest at
+`.autorag/datasources/cloud-drive/<instance>/manifest.json`, then copies only
+added/changed indexable files into `mirror/`. Deleted and renamed virtual paths
+are removed from the completed snapshot. A no-op refresh downloads zero bodies
+and does not rewrite `chunks.json`. A failed copy leaves the previous manifest
+and mirror available for query-time search. `include`, `exclude`,
+`maxBytesPerFile`, `concurrency`, `bandwidthLimit`, and `dryRun` are trusted
+server configuration; model/tool arguments cannot change them.
+
+Before searching, the agent loads the datasource skill with
+`load_datasource_skill`, then calls `search_datasource_documents` using a
+natural-language query and, when useful, a narrowing scope such as
+`/cloud-drive/team-docs/**`. It must not invoke `rclone` itself or request
+credentials.
+
 ## KakaoTalk via katok
 
 KakaoTalk support is implemented through the external [`katok`](https://github.com/NomaDamas/katok) CLI.

--- a/docs/datasource-skills.md
+++ b/docs/datasource-skills.md
@@ -76,8 +76,17 @@ its rclone backend is Tier 4 and periodically requires Apple ID/password,
 ```json
 {
   "datasources": {
-    "cloud-drive": {
-      "instanceId": "team-docs",
+    "personal-google-drive": {
+      "type": "cloud-drive",
+      "instanceId": "personal",
+      "connector": {
+        "provider": "google-drive",
+        "remote": "personal-gdrive:"
+      }
+    },
+    "company-onedrive": {
+      "type": "cloud-drive",
+      "instanceId": "work",
       "pollingIntervalMs": 900000,
       "connector": {
         "provider": "onedrive",
@@ -93,10 +102,27 @@ its rclone backend is Tier 4 and periodically requires Apple ID/password,
   },
   "datasourceAccess": {
     "allowedTags": ["cloud-drive"],
-    "allowedScopes": ["/cloud-drive/team-docs/**"]
+    "allowedScopes": [
+      "/personal-google-drive/personal/**",
+      "/company-onedrive/work/**"
+    ]
   }
 }
 ```
+
+`cloud-drive` is the reusable template, not the required connection name.
+Every key whose `type` is `"cloud-drive"` becomes an independent datasource:
+
+- its key is the datasource id and skill suffix;
+- `datasource-personal-google-drive` and `datasource-company-onedrive` are
+  independently loadable with `load_datasource_skill`;
+- source scopes are isolated under the same aliases;
+- manifests, mirrors, and chunks are stored independently under
+  `.autorag/datasources/<alias>/<instance>/`.
+
+This lets one process connect multiple accounts from the same provider as well
+as different providers. For example, `personal-google-drive` and
+`client-google-drive` may both use Google Drive but different rclone remotes.
 
 Run the CLI datasource refresh with:
 
@@ -108,7 +134,7 @@ autorag search "the renewal terms in the team drive"
 
 Each refresh runs `rclone lsjson --recursive --files-only --hash`, compares
 the result with the workspace-local manifest at
-`.autorag/datasources/cloud-drive/<instance>/manifest.json`, then copies only
+`.autorag/datasources/<connection-alias>/<instance>/manifest.json`, then copies only
 added/changed indexable files into `mirror/`. Deleted and renamed virtual paths
 are removed from the completed snapshot. A no-op refresh downloads zero bodies
 and does not rewrite `chunks.json`. A failed copy leaves the previous manifest
@@ -119,7 +145,7 @@ server configuration; model/tool arguments cannot change them.
 Before searching, the agent loads the datasource skill with
 `load_datasource_skill`, then calls `search_datasource_documents` using a
 natural-language query and, when useful, a narrowing scope such as
-`/cloud-drive/team-docs/**`. It must not invoke `rclone` itself or request
+`/company-onedrive/work/**`. It must not invoke `rclone` itself or request
 credentials.
 
 ## KakaoTalk via katok

--- a/docs/manual-qa-datasources.md
+++ b/docs/manual-qa-datasources.md
@@ -15,6 +15,7 @@ through notcrawl.
 | `scripts/manual-qa/run-qa-discrawl-live.ts` | Real Discord archive through the external `discrawl` CLI (FTS + semantic + hybrid, incremental re-sync) | `bun scripts/manual-qa/run-qa-discrawl-live.ts` |
 | `scripts/manual-qa/run-qa-live.ts` | Real public GitHub REST API (this repo's issues) and a real RSS feed (hnrss.org), credential-free | `bun scripts/manual-qa/run-qa-live.ts` |
 | `scripts/manual-qa/run-qa-spotlight-live.ts` | Real macOS Spotlight (`mdfind`/`mdimport`) end-to-end; macOS only, no credentials | `bun scripts/manual-qa/run-qa-spotlight-live.ts` |
+| `scripts/manual-qa/run-qa-rclone.ts` | Deterministic rclone process seam covering initial/no-op/update/delete/rename/interrupted recovery and scoped search | `bun scripts/manual-qa/run-qa-rclone.ts` |
 | `test/datasource/skills/wacrawl.test.ts` | Real child-process boundary with a deterministic fake wacrawl executable: argv, JSON parsing, env isolation, missing binary, malformed output, indexing, retrieval | `bunx vitest run test/datasource/skills/wacrawl.test.ts` |
 | `test/datasource/skills/telecrawl.test.ts` | Real child-process boundary with a deterministic fake telecrawl executable: argv, JSON parsing, env isolation, missing binary, malformed output, indexing, retrieval | `bunx vitest run test/datasource/skills/telecrawl.test.ts` |
 | `test/datasource/skills/slacrawl.test.ts` | Real child-process boundary with a deterministic fake slacrawl executable: argv, JSON parsing, env isolation, missing binary, malformed output, indexing, retrieval | `bunx vitest run test/datasource/skills/slacrawl.test.ts` |
@@ -95,6 +96,22 @@ mapping. Configure credentials in notcrawl itself, then set
 - [x] Per-item failures (a denied Slack channel, a 404 repo, one bad feed,
       an unparseable mbox message) degrade to warnings without failing the
       whole index run.
+
+### Rclone cloud-drive checklist
+
+- [x] `rclone lsjson --recursive --files-only --hash` is the only inventory
+      seed; provider credentials remain in rclone's own config.
+- [x] The workspace manifest stores stable virtual path, size, modtime,
+      hashes, and provider id when available.
+- [x] Initial sync copies indexable files; a no-op sync copies zero bodies and
+      does not rewrite the chunk store.
+- [x] Updating one file copies/reindexes only that file; delete and rename
+      remove stale mirror entries.
+- [x] A failed copy leaves the previous completed snapshot searchable.
+- [x] Google Drive is Tier-1; OneDrive and other remotes are provider-neutral;
+      iCloud Drive is documented as experimental/Tier 4.
+- [x] Include/exclude, maximum size, concurrency, bandwidth limit, and
+      dry-run are trusted CLI datasource configuration.
 
 ## Last run
 

--- a/scripts/manual-qa/run-qa-rclone.ts
+++ b/scripts/manual-qa/run-qa-rclone.ts
@@ -1,0 +1,93 @@
+/**
+ * Manual QA for issue #1453.
+ *
+ * This is intentionally process-boundary shaped but credential-free: the
+ * injected runner behaves like `rclone lsjson` and `rclone copyto`, allowing
+ * the full datasource/agent surface to be exercised deterministically.
+ */
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createSearchDatasourceDocumentsTool } from "../../src/agent/search-datasource-tool.ts";
+import { CloudDriveSkill } from "../../src/datasource/skills/cloud-drive/skill.ts";
+import type { RcloneRunResult } from "../../src/datasource/skills/gdrive/rclone-connector.ts";
+import { RcloneConnector } from "../../src/datasource/skills/gdrive/rclone-connector.ts";
+
+const root = mkdtempSync(join(tmpdir(), "autorag-rclone-manual-qa-"));
+let failures = 0;
+const check = (name: string, pass: boolean, note = "") => {
+	if (!pass) failures += 1;
+	console.log(`${pass ? "PASS" : "FAIL"}  ${name}${note ? ` — ${note}` : ""}`);
+};
+
+let version = 1;
+let failCopy = false;
+const listings = () =>
+	JSON.stringify(
+		version === 1
+			? [
+					{ Path: "reports/q3.md", Name: "q3.md", Size: 20, Hashes: { md5: "q3-v1" }, ModTime: "2026-08-01T00:00:00Z" },
+					{ Path: "old.md", Name: "old.md", Size: 10, Hashes: { md5: "old-v1" }, ModTime: "2026-08-01T00:00:00Z" },
+				]
+			: [{ Path: "reports/q3-renamed.md", Name: "q3-renamed.md", Size: 20, Hashes: { md5: "q3-v2" }, ModTime: "2026-08-02T00:00:00Z" }],
+	);
+
+const runner = async (args: readonly string[]): Promise<RcloneRunResult> => {
+	if (args[0] === "lsjson") return { ok: true, stdout: listings(), stderr: "", code: 0 };
+	if (args[0] === "copyto") {
+		if (failCopy) return { ok: false, stdout: "", stderr: "interrupted", code: 1 };
+		writeFileSync(args[2] ?? "", `content for ${args[1]}`);
+		return { ok: true, stdout: "", stderr: "", code: 0 };
+	}
+	return { ok: false, stdout: "", stderr: "unexpected", code: 1 };
+};
+
+try {
+	const connector = new RcloneConnector({
+		remote: "gdrive:",
+		skillName: "cloud-drive",
+		workspaceRoot: root,
+		instanceId: "manual",
+		runner,
+	});
+	const skill = new CloudDriveSkill({
+		instanceId: "manual",
+		workspaceRoot: root,
+		connector,
+	});
+
+	const initial = await skill.index();
+	check("initial sync indexes files", initial.ok && initial.chunkCount === 2);
+	const noop = await skill.index();
+	check("no-op sync changes nothing", noop.ok && noop.chunkCount === 2);
+
+	version = 2;
+	const update = await skill.index();
+	check("rename removes old virtual file and indexes new file", update.ok && update.chunkCount === 1);
+	const [method] = skill.retrievalMethods();
+	const renamed = await method?.retrieve("q3-renamed", { topK: 3 });
+	check("search finds renamed file", (renamed?.length ?? 0) > 0);
+
+	version = 1;
+	failCopy = true;
+	const interrupted = await skill.index();
+	check("interrupted sync reports failure", !interrupted.ok);
+	const previous = await method?.retrieve("q3-renamed", { topK: 3 });
+	check("previous snapshot remains searchable after failure", (previous?.length ?? 0) > 0);
+
+	failCopy = false;
+	const tool = createSearchDatasourceDocumentsTool({
+		async searchDatasourceDocuments(query, options) {
+			const results = (await method?.retrieve(query, { topK: options?.topK ?? 5, scope: options?.scope })) ?? [];
+			return { results, diagnostics: [] };
+		},
+	});
+	const toolResult = await tool.execute("manual-qa", { query: "q3-renamed", scope: "/cloud-drive/manual/**" });
+	check("search_datasource_documents returns scoped cloud-drive hit", toolResult.details.resultCount > 0);
+	check("manifest has stable virtual metadata", readFileSync(join(root, ".autorag", "datasources", "cloud-drive", "manual", "manifest.json"), "utf8").includes("reports"));
+} finally {
+	rmSync(root, { recursive: true, force: true });
+}
+
+console.log(failures === 0 ? "\nRCLONE MANUAL QA PASSED" : `\nRCLONE MANUAL QA: ${failures} failure(s)`);
+if (failures > 0) process.exitCode = 1;

--- a/scripts/manual-qa/run-qa-rclone.ts
+++ b/scripts/manual-qa/run-qa-rclone.ts
@@ -43,17 +43,19 @@ const runner = async (args: readonly string[]): Promise<RcloneRunResult> => {
 };
 
 try {
-	const connector = new RcloneConnector({
+	const personalConnector = new RcloneConnector({
 		remote: "gdrive:",
-		skillName: "cloud-drive",
+		skillName: "personal-google-drive",
 		workspaceRoot: root,
-		instanceId: "manual",
+		instanceId: "personal",
 		runner,
 	});
 	const skill = new CloudDriveSkill({
-		instanceId: "manual",
+		skillName: "personal-google-drive",
+		instanceId: "personal",
+		provider: "google-drive",
 		workspaceRoot: root,
-		connector,
+		connector: personalConnector,
 	});
 
 	const initial = await skill.index();
@@ -82,12 +84,39 @@ try {
 			return { results, diagnostics: [] };
 		},
 	});
-	const toolResult = await tool.execute("manual-qa", { query: "q3-renamed", scope: "/cloud-drive/manual/**" });
-	check("search_datasource_documents returns scoped cloud-drive hit", toolResult.details.resultCount > 0);
-	check("manifest has stable virtual metadata", readFileSync(join(root, ".autorag", "datasources", "cloud-drive", "manual", "manifest.json"), "utf8").includes("reports"));
+	const toolResult = await tool.execute("manual-qa", {
+		query: "q3-renamed",
+		scope: "/personal-google-drive/personal/**",
+	});
+	check("search_datasource_documents returns scoped personal-drive hit", toolResult.details.resultCount > 0);
+	check(
+		"manifest is isolated under the connection alias",
+		readFileSync(
+			join(root, ".autorag", "datasources", "personal-google-drive", "personal", "manifest.json"),
+			"utf8",
+		).includes("reports"),
+	);
+
+	const company = new CloudDriveSkill({
+		skillName: "company-onedrive",
+		instanceId: "work",
+		provider: "onedrive",
+		workspaceRoot: root,
+		connector: { fetch: async () => ({ ok: true, documents: [{ docId: "policy.md", content: "company policy sentinel" }] }) },
+	});
+	expectDistinctConnection(skill, company);
+	check("multiple connections expose distinct skill manifests", skill.skillManifest().name !== company.skillManifest().name);
 } finally {
 	rmSync(root, { recursive: true, force: true });
 }
 
 console.log(failures === 0 ? "\nRCLONE MANUAL QA PASSED" : `\nRCLONE MANUAL QA: ${failures} failure(s)`);
 if (failures > 0) process.exitCode = 1;
+
+function expectDistinctConnection(first: CloudDriveSkill, second: CloudDriveSkill): void {
+	check("multiple connections expose distinct datasource ids", first.describe().datasourceId !== second.describe().datasourceId);
+	check(
+		"multiple connections expose distinct source roots",
+		first.describeSources()[0]?.source !== second.describeSources()[0]?.source,
+	);
+}

--- a/src/agent/search-datasource-tool.ts
+++ b/src/agent/search-datasource-tool.ts
@@ -33,7 +33,7 @@ export function createSearchDatasourceDocumentsTool(
 		name: SEARCH_DATASOURCE_DOCUMENTS_TOOL_NAME,
 		label: "Search Datasource Documents",
 		description:
-			"Search configured external datasource skills such as KakaoTalk chats. Authority is server-configured; tool arguments can only provide query, topK, and an optional narrowing scope.",
+			"Search configured external datasource skills such as cloud drives and KakaoTalk chats. Load the matching datasource skill first; authority is server-configured and tool arguments can only provide query, topK, and an optional narrowing scope.",
 		parameters: searchDatasourceSchema,
 		async execute(_toolCallId, params): Promise<AgentToolResult<SearchDatasourceDocumentsDetails>> {
 			const query = params.query.trim();

--- a/src/datasource/chunk-store.ts
+++ b/src/datasource/chunk-store.ts
@@ -85,31 +85,23 @@ export class DatasourceChunkStore {
 	 * (in-memory contents stay authoritative for this process).
 	 */
 	replaceDocuments(documents: readonly ConnectorDocument[]): number {
-		const chunks: StoredChunk[] = [];
-		const seenIds = new Set<string>();
-		for (const document of documents) {
-			const docSegment = sanitizeIdSegment(document.docId);
-			const hierarchy = (document.hierarchy ?? []).map(sanitizeIdSegment).filter((segment) => segment.length > 0);
-			const parts = splitContent(document.content, this.maxChunkChars);
-			for (const [index, part] of parts.entries()) {
-				let chunkId = parts.length === 1 ? docSegment : `${docSegment}-p${index + 1}`;
-				while (seenIds.has(chunkId)) chunkId = `${chunkId}x`;
-				seenIds.add(chunkId);
-				chunks.push({
-					chunkId,
-					docId: document.docId,
-					hierarchy,
-					...(document.title !== undefined ? { title: document.title } : {}),
-					content: part,
-					...(document.publishedAt !== undefined ? { publishedAt: document.publishedAt } : {}),
-					metadata: { ...(document.metadata ?? {}) },
-				});
-			}
-		}
-		this.chunkList = chunks;
+		this.chunkList = buildChunks(documents, this.maxChunkChars);
 		this.loaded = true;
 		this.persist();
-		return chunks.length;
+		return this.chunkList.length;
+	}
+
+	/** Apply file-level additions/updates/deletions without rebuilding unchanged chunks. */
+	updateDocuments(documents: readonly ConnectorDocument[], deletedDocIds: readonly string[] = []): number {
+		this.ensureLoaded();
+		const replaced = new Set(documents.map((document) => document.docId));
+		const deleted = new Set(deletedDocIds);
+		const unchanged = this.chunkList.filter((chunk) => !replaced.has(chunk.docId) && !deleted.has(chunk.docId));
+		const additions = buildChunks(documents, this.maxChunkChars, new Set(unchanged.map((chunk) => chunk.chunkId)));
+		this.chunkList = [...unchanged, ...additions];
+		this.loaded = true;
+		this.persist();
+		return this.chunkList.length;
 	}
 
 	/** Load persisted chunks when present. Returns true when data was loaded. */
@@ -218,6 +210,34 @@ export class DatasourceChunkStore {
 			// Persistence is best-effort; in-memory contents stay authoritative.
 		}
 	}
+}
+
+function buildChunks(
+	documents: readonly ConnectorDocument[],
+	maxChunkChars: number,
+	seenIds = new Set<string>(),
+): StoredChunk[] {
+	const chunks: StoredChunk[] = [];
+	for (const document of documents) {
+		const docSegment = sanitizeIdSegment(document.docId);
+		const hierarchy = (document.hierarchy ?? []).map(sanitizeIdSegment).filter((segment) => segment.length > 0);
+		const parts = splitContent(document.content, maxChunkChars);
+		for (const [index, part] of parts.entries()) {
+			let chunkId = parts.length === 1 ? docSegment : `${docSegment}-p${index + 1}`;
+			while (seenIds.has(chunkId)) chunkId = `${chunkId}x`;
+			seenIds.add(chunkId);
+			chunks.push({
+				chunkId,
+				docId: document.docId,
+				hierarchy,
+				...(document.title !== undefined ? { title: document.title } : {}),
+				content: part,
+				...(document.publishedAt !== undefined ? { publishedAt: document.publishedAt } : {}),
+				metadata: { ...(document.metadata ?? {}) },
+			});
+		}
+	}
+	return chunks;
 }
 
 function splitContent(content: string, maxChars: number): readonly string[] {

--- a/src/datasource/connector-skill.ts
+++ b/src/datasource/connector-skill.ts
@@ -51,6 +51,7 @@ export interface ConnectorSkillDefinition {
 	readonly description: string;
 	/** Capability tags such as `"chat"`, `"api"`, `"polling"`. */
 	readonly capabilities: readonly string[];
+	readonly requiresExternalCli?: boolean;
 	/** Default authorization tags when the server config supplies none. */
 	readonly defaultTags: readonly string[];
 	/** Content type reported on source descriptions, e.g. `"chat"`. */
@@ -123,6 +124,7 @@ export class ConnectorDatasourceSkill implements DatasourceSkill {
 			type: this.definition.skillType,
 			description: this.definition.description,
 			capabilities: this.definition.capabilities,
+			...(this.definition.requiresExternalCli === true ? { requiresExternalCli: true } : {}),
 			tags: this.tags,
 			status: "active",
 			datasourceId: this.definition.skillName,
@@ -155,7 +157,13 @@ export class ConnectorDatasourceSkill implements DatasourceSkill {
 			return this.fail(code, `${fetched.reason}: ${message}`);
 		}
 		const documents = this.applyDedupeWindow(fetched.documents);
-		const chunkCount = this.store.replaceDocuments(documents);
+		const changed = fetched.changed !== false;
+		const incremental = fetched.deletedDocIds !== undefined;
+		const chunkCount = !changed
+			? this.store.chunks().length
+			: incremental
+				? this.store.updateDocuments(documents, fetched.deletedDocIds)
+				: this.store.replaceDocuments(documents);
 		this.lastIndexedAt = Date.now();
 		this.lastError = undefined;
 		const diagnostics: DatasourceDiagnostic[] = (fetched.warnings ?? []).map((warning) => ({

--- a/src/datasource/connector.ts
+++ b/src/datasource/connector.ts
@@ -49,6 +49,10 @@ export interface ConnectorDocument {
 export interface ConnectorFetchOk {
 	readonly ok: true;
 	readonly documents: readonly ConnectorDocument[];
+	/** True when the completed datasource snapshot changed since the last fetch. */
+	readonly changed?: boolean;
+	/** Stable ids removed from an incremental datasource snapshot. */
+	readonly deletedDocIds?: readonly string[];
 	/** Sanitized, path/PII-opaque warning strings. */
 	readonly warnings?: readonly string[];
 }

--- a/src/datasource/index.ts
+++ b/src/datasource/index.ts
@@ -39,6 +39,11 @@ export {
 	normalizeVirtualPath,
 } from "./scope.ts";
 export {
+	CLOUD_DRIVE_SKILL_DEFINITION,
+	CloudDriveSkill,
+	type CloudDriveSkillOptions,
+} from "./skills/cloud-drive/index.ts";
+export {
 	DEFAULT_DISCRAWL_EMBEDDING_MODEL,
 	DEFAULT_DISCRAWL_MODE,
 	DEFAULT_DISCRAWL_SOURCE,

--- a/src/datasource/skills/cloud-drive/index.ts
+++ b/src/datasource/skills/cloud-drive/index.ts
@@ -1,0 +1,5 @@
+export {
+	CLOUD_DRIVE_SKILL_DEFINITION,
+	CloudDriveSkill,
+	type CloudDriveSkillOptions,
+} from "./skill.ts";

--- a/src/datasource/skills/cloud-drive/skill.ts
+++ b/src/datasource/skills/cloud-drive/skill.ts
@@ -1,0 +1,48 @@
+import type { DatasourceConnector } from "../../connector.ts";
+import {
+	ConnectorDatasourceSkill,
+	type ConnectorSkillDefinition,
+	type ConnectorSkillOptions,
+} from "../../connector-skill.ts";
+import { RcloneConnector, type RcloneConnectorOptions } from "../gdrive/rclone-connector.ts";
+
+export const CLOUD_DRIVE_SKILL_DEFINITION: ConnectorSkillDefinition = {
+	skillName: "cloud-drive",
+	skillType: "rclone-drive",
+	description: "rclone cloud-drive datasource",
+	capabilities: ["documents", "external-cli", "incremental", "polling"],
+	requiresExternalCli: true,
+	defaultTags: ["cloud-drive", "documents", "pii"],
+	contentType: "document",
+	manifestDescription:
+		"Search indexed documents from an authorized rclone remote such as Google Drive, OneDrive, iCloud Drive, Dropbox, SMB, SFTP, or WebDAV.",
+	manifestNotes: [
+		"Configure and authenticate the remote with `rclone config`; AutoRAG never receives or stores provider credentials.",
+		"Google Drive is Tier-1 supported. OneDrive and other rclone remotes use the same manifest contract. iCloud Drive is experimental and requires periodic Apple ID reauthentication.",
+		"Indexing is incremental: `rclone lsjson` inventories metadata, then only added or changed indexable files are mirrored. Search uses the last completed snapshot while a failed sync is retried.",
+		"Use `load_datasource_skill` before `search_datasource_documents`; pass only a natural-language query and optionally a narrowing scope such as `/cloud-drive/<instance>/**`.",
+	],
+};
+
+export interface CloudDriveSkillOptions extends Omit<ConnectorSkillOptions, "connector"> {
+	readonly provider?: "google-drive" | "onedrive" | "icloud" | string;
+	readonly connector?: DatasourceConnector;
+	readonly connectorOptions?: RcloneConnectorOptions;
+}
+
+export class CloudDriveSkill extends ConnectorDatasourceSkill {
+	constructor(options: CloudDriveSkillOptions = {}) {
+		const { connector, connectorOptions, provider: _provider, ...rest } = options;
+		super(CLOUD_DRIVE_SKILL_DEFINITION, {
+			...rest,
+			connector:
+				connector ??
+				new RcloneConnector({
+					...connectorOptions,
+					skillName: "cloud-drive",
+					instanceId: rest.instanceId,
+					workspaceRoot: rest.workspaceRoot,
+				}),
+		});
+	}
+}

--- a/src/datasource/skills/cloud-drive/skill.ts
+++ b/src/datasource/skills/cloud-drive/skill.ts
@@ -6,25 +6,11 @@ import {
 } from "../../connector-skill.ts";
 import { RcloneConnector, type RcloneConnectorOptions } from "../gdrive/rclone-connector.ts";
 
-export const CLOUD_DRIVE_SKILL_DEFINITION: ConnectorSkillDefinition = {
-	skillName: "cloud-drive",
-	skillType: "rclone-drive",
-	description: "rclone cloud-drive datasource",
-	capabilities: ["documents", "external-cli", "incremental", "polling"],
-	requiresExternalCli: true,
-	defaultTags: ["cloud-drive", "documents", "pii"],
-	contentType: "document",
-	manifestDescription:
-		"Search indexed documents from an authorized rclone remote such as Google Drive, OneDrive, iCloud Drive, Dropbox, SMB, SFTP, or WebDAV.",
-	manifestNotes: [
-		"Configure and authenticate the remote with `rclone config`; AutoRAG never receives or stores provider credentials.",
-		"Google Drive is Tier-1 supported. OneDrive and other rclone remotes use the same manifest contract. iCloud Drive is experimental and requires periodic Apple ID reauthentication.",
-		"Indexing is incremental: `rclone lsjson` inventories metadata, then only added or changed indexable files are mirrored. Search uses the last completed snapshot while a failed sync is retried.",
-		"Use `load_datasource_skill` before `search_datasource_documents`; pass only a natural-language query and optionally a narrowing scope such as `/cloud-drive/<instance>/**`.",
-	],
-};
+export const CLOUD_DRIVE_SKILL_DEFINITION = createCloudDriveSkillDefinition("cloud-drive");
 
 export interface CloudDriveSkillOptions extends Omit<ConnectorSkillOptions, "connector"> {
+	/** Unique model-visible datasource name for this configured connection. */
+	readonly skillName?: string;
 	readonly provider?: "google-drive" | "onedrive" | "icloud" | string;
 	readonly connector?: DatasourceConnector;
 	readonly connectorOptions?: RcloneConnectorOptions;
@@ -32,17 +18,50 @@ export interface CloudDriveSkillOptions extends Omit<ConnectorSkillOptions, "con
 
 export class CloudDriveSkill extends ConnectorDatasourceSkill {
 	constructor(options: CloudDriveSkillOptions = {}) {
-		const { connector, connectorOptions, provider: _provider, ...rest } = options;
-		super(CLOUD_DRIVE_SKILL_DEFINITION, {
+		const { connector, connectorOptions, provider, skillName = "cloud-drive", ...rest } = options;
+		super(createCloudDriveSkillDefinition(skillName, provider), {
 			...rest,
 			connector:
 				connector ??
 				new RcloneConnector({
 					...connectorOptions,
-					skillName: "cloud-drive",
+					skillName,
 					instanceId: rest.instanceId,
 					workspaceRoot: rest.workspaceRoot,
 				}),
 		});
+	}
+}
+
+function createCloudDriveSkillDefinition(skillName: string, provider?: string): ConnectorSkillDefinition {
+	const providerLabel = providerDisplayName(provider);
+	return {
+		skillName,
+		skillType: "rclone-drive",
+		description: `${providerLabel} datasource (${skillName})`,
+		capabilities: ["documents", "external-cli", "incremental", "polling"],
+		requiresExternalCli: true,
+		defaultTags: ["cloud-drive", provider ?? "rclone", "documents", "pii"],
+		contentType: "document",
+		manifestDescription: `Search indexed documents from the authorized ${providerLabel} connection named "${skillName}".`,
+		manifestNotes: [
+			"Configure and authenticate the remote with `rclone config`; AutoRAG never receives or stores provider credentials.",
+			"Google Drive is Tier-1 supported. OneDrive and other rclone remotes use the same manifest contract. iCloud Drive is experimental and requires periodic Apple ID reauthentication.",
+			"Indexing is incremental: `rclone lsjson` inventories metadata, then only added or changed indexable files are mirrored. Search uses the last completed snapshot while a failed sync is retried.",
+			`This connection is independently addressable. Load \`datasource-${skillName}\`, then call \`search_datasource_documents\` with an optional narrowing scope under \`/${skillName}/<instance>/**\`.`,
+		],
+	};
+}
+
+function providerDisplayName(provider: string | undefined): string {
+	switch (provider) {
+		case "google-drive":
+			return "Google Drive";
+		case "onedrive":
+			return "OneDrive";
+		case "icloud":
+			return "iCloud Drive (experimental)";
+		default:
+			return provider ?? "rclone cloud-drive";
 	}
 }

--- a/src/datasource/skills/factory.ts
+++ b/src/datasource/skills/factory.ts
@@ -9,6 +9,7 @@
  */
 
 import type { DatasourceSkill } from "../types.ts";
+import { CloudDriveSkill } from "./cloud-drive/index.ts";
 import { DiscrawlClient, type DiscrawlOptions, DiscrawlSkill } from "./discrawl/index.ts";
 import { type GDriveConnectorOptions, GDriveSkill } from "./gdrive/index.ts";
 import { RcloneConnector, type RcloneConnectorOptions } from "./gdrive/rclone-connector.ts";
@@ -105,7 +106,12 @@ const BUILDERS: Readonly<Record<string, SkillBuilder>> = {
 			const { backend: _backend, ...rcloneOptions } = connector;
 			return new GDriveSkill({
 				...common(config, workspaceRoot),
-				connector: new RcloneConnector(rcloneOptions),
+				connector: new RcloneConnector({
+					...rcloneOptions,
+					skillName: "gdrive",
+					instanceId: config.instanceId,
+					workspaceRoot,
+				}),
 			});
 		}
 		return new GDriveSkill({
@@ -113,6 +119,12 @@ const BUILDERS: Readonly<Record<string, SkillBuilder>> = {
 			connectorOptions: connector as GDriveConnectorOptions,
 		});
 	},
+	"cloud-drive": (config, workspaceRoot) =>
+		new CloudDriveSkill({
+			...common(config, workspaceRoot),
+			provider: typeof config.connector?.provider === "string" ? config.connector.provider : undefined,
+			connectorOptions: config.connector as RcloneConnectorOptions,
+		}),
 	gmail: (config, workspaceRoot) => {
 		const connector = config.connector as
 			| (GmailConnectorOptions & HimalayaConnectorOptions & { backend?: string })

--- a/src/datasource/skills/factory.ts
+++ b/src/datasource/skills/factory.ts
@@ -28,6 +28,8 @@ import { type WacrawlOptions, WacrawlSkill } from "./wacrawl/index.ts";
 /** One configured datasource entry (the trusted `datasources.<name>` value). */
 export interface DatasourceSkillConfig {
 	readonly enabled?: boolean;
+	/** Built-in datasource template used when the config key is a connection alias. */
+	readonly type?: string;
 	readonly instanceId?: string;
 	readonly pollingIntervalMs?: number;
 	readonly tags?: readonly string[];
@@ -44,7 +46,11 @@ export interface BuildDatasourceSkillsResult {
 	readonly unknown: readonly string[];
 }
 
-type SkillBuilder = (config: DatasourceSkillConfig, workspaceRoot: string | undefined) => DatasourceSkill;
+type SkillBuilder = (
+	config: DatasourceSkillConfig,
+	workspaceRoot: string | undefined,
+	registrationName: string,
+) => DatasourceSkill;
 
 const BUILDERS: Readonly<Record<string, SkillBuilder>> = {
 	telegram: (config) =>
@@ -119,9 +125,10 @@ const BUILDERS: Readonly<Record<string, SkillBuilder>> = {
 			connectorOptions: connector as GDriveConnectorOptions,
 		});
 	},
-	"cloud-drive": (config, workspaceRoot) =>
+	"cloud-drive": (config, workspaceRoot, registrationName) =>
 		new CloudDriveSkill({
 			...common(config, workspaceRoot),
+			skillName: registrationName,
 			provider: typeof config.connector?.provider === "string" ? config.connector.provider : undefined,
 			connectorOptions: config.connector as RcloneConnectorOptions,
 		}),
@@ -190,12 +197,17 @@ export function buildDatasourceSkills(
 		if (raw === false) continue;
 		const entry: DatasourceSkillConfig = raw === true ? {} : raw;
 		if (entry.enabled === false) continue;
-		const builder = BUILDERS[name];
+		const templateName = entry.type ?? name;
+		const builder = BUILDERS[templateName];
 		if (builder === undefined) {
 			unknown.push(name);
 			continue;
 		}
-		skills.push(builder(entry, workspaceRoot));
+		if (entry.type !== undefined && entry.type !== "cloud-drive") {
+			unknown.push(name);
+			continue;
+		}
+		skills.push(builder(entry, workspaceRoot, name));
 	}
 	return { skills, unknown };
 }

--- a/src/datasource/skills/gdrive/rclone-connector.ts
+++ b/src/datasource/skills/gdrive/rclone-connector.ts
@@ -1,18 +1,17 @@
 /**
- * Rclone-backed drive connector (issue #1301, rclone path).
+ * Provider-neutral incremental rclone mirror.
  *
- * Uses the external `rclone` CLI (https://rclone.org) as the trusted bridge
- * to Google Drive — or any of rclone's 70+ storage backends — so OAuth
- * setup and token refresh live entirely in `rclone config`, not here
- * (katok/himalaya pattern). Google Docs/Sheets are transparently exported
- * as text via rclone's `--drive-export-formats`. Never throws; failures map
- * onto the coarse connector failure union with path/PII-opaque messages.
- *
- * Listing: `rclone lsjson <remote> --recursive --files-only`
- * Content: `rclone cat <remote>/<path>` (bounded, text formats only)
+ * `lsjson` inventories a remote, a workspace manifest computes its diff, and
+ * only added/changed indexable files are copied into a managed mirror. The
+ * manifest is published only after every changed file is available, so search
+ * can continue using the previous completed snapshot after an interrupted run.
  */
 
 import { spawn } from "node:child_process";
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { dirname, join, normalize } from "node:path";
+import { createDefaultParserRegistry } from "../../../parser/defaults.ts";
 import type { ConnectorDocument, ConnectorFetchResult, DatasourceConnector } from "../../connector.ts";
 import { asArray, asRecord, asString, parseEpochMs } from "../../http.ts";
 
@@ -26,28 +25,39 @@ export interface RcloneRunResult {
 export type RcloneRunner = (args: readonly string[], timeoutMs: number) => Promise<RcloneRunResult>;
 
 export interface RcloneConnectorOptions {
-	/** Path to the rclone binary. Default bare `rclone` PATH lookup. */
 	readonly binaryPath?: string;
-	/**
-	 * Rclone remote path, e.g. `gdrive:` or `gdrive:Team/Docs`. Required
-	 * trusted configuration (`rclone config` defines the remote).
-	 */
 	readonly remote?: string;
-	/**
-	 * Indexable file extensions (lowercase, with dot). Google Docs/Sheets
-	 * surface as these after `--drive-export-formats txt,csv`.
-	 */
+	readonly provider?: string;
+	readonly workspaceRoot?: string;
+	readonly instanceId?: string;
+	readonly skillName?: string;
 	readonly extensions?: readonly string[];
-	/** Drive export formats forwarded to rclone. Default `txt,csv`. */
+	readonly include?: readonly string[];
+	readonly exclude?: readonly string[];
 	readonly exportFormats?: string;
-	/** Max files whose contents are fetched per run. Default 200. */
 	readonly maxDocuments?: number;
-	/** Files larger than this are skipped. Default 2 MiB. */
 	readonly maxBytesPerFile?: number;
-	/** Per-spawn timeout. Default 60s (cloud listings can be slow). */
+	readonly concurrency?: number;
+	readonly bandwidthLimit?: string;
+	readonly dryRun?: boolean;
 	readonly timeoutMs?: number;
-	/** Injectable process runner for tests. */
 	readonly runner?: RcloneRunner;
+}
+
+interface ManifestEntry {
+	readonly path: string;
+	readonly name: string;
+	readonly size: number;
+	readonly modTime?: string;
+	readonly mimeType?: string;
+	readonly hashes?: Readonly<Record<string, string>>;
+	readonly remoteId?: string;
+}
+
+interface RcloneManifest {
+	readonly version: 1;
+	readonly remoteName: string;
+	readonly entries: readonly ManifestEntry[];
 }
 
 const DEFAULT_BINARY = "rclone";
@@ -75,15 +85,10 @@ export class RcloneConnector implements DatasourceConnector {
 		}
 		const timeoutMs = this.options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 		const exportFormats = this.options.exportFormats ?? DEFAULT_EXPORT_FORMATS;
-		const extensions = this.options.extensions ?? DEFAULT_EXTENSIONS;
-		const maxDocuments = this.options.maxDocuments ?? DEFAULT_MAX_DOCUMENTS;
-		const maxBytes = this.options.maxBytesPerFile ?? DEFAULT_MAX_BYTES_PER_FILE;
-
-		// 1. Recursive listing as JSON.
 		let listResult: RcloneRunResult;
 		try {
 			listResult = await this.runner(
-				["lsjson", remote, "--recursive", "--files-only", "--drive-export-formats", exportFormats],
+				["lsjson", remote, "--recursive", "--files-only", "--hash", "--drive-export-formats", exportFormats],
 				timeoutMs,
 			);
 		} catch {
@@ -92,69 +97,333 @@ export class RcloneConnector implements DatasourceConnector {
 		if (!listResult.ok) {
 			return { ok: false, reason: classifyFailure(listResult.stderr), message: shortFailure(listResult) };
 		}
-		let entries: readonly unknown[];
+
+		let rawEntries: readonly unknown[];
 		try {
-			entries = asArray(JSON.parse(listResult.stdout));
+			rawEntries = asArray(JSON.parse(listResult.stdout));
 		} catch {
 			return { ok: false, reason: "invalid-data", message: "rclone listing was not valid JSON" };
 		}
 
-		// 2. Cat text files (bounded); per-file failures degrade to warnings.
-		const documents: ConnectorDocument[] = [];
-		let readFailures = 0;
+		const extensions =
+			this.options.extensions ??
+			(this.options.workspaceRoot === undefined ? DEFAULT_EXTENSIONS : defaultParserExtensions());
+		const maxDocuments = this.options.maxDocuments ?? DEFAULT_MAX_DOCUMENTS;
+		const maxBytes = this.options.maxBytesPerFile ?? DEFAULT_MAX_BYTES_PER_FILE;
 		let skipped = 0;
-		for (const raw of entries) {
-			if (documents.length >= maxDocuments) break;
-			const entry = asRecord(raw);
-			const path = asString(entry?.Path);
-			const name = asString(entry?.Name);
-			if (entry === undefined || path === undefined || name === undefined) continue;
-			const extension = name.includes(".") ? name.slice(name.lastIndexOf(".")).toLowerCase() : "";
-			if (!extensions.includes(extension)) {
+		const inventory: ManifestEntry[] = [];
+		for (const raw of rawEntries) {
+			const entry = toManifestEntry(raw);
+			if (entry === undefined) continue;
+			if (!matchesRules(entry.path, this.options.include, this.options.exclude)) {
 				skipped += 1;
 				continue;
 			}
-			const size = typeof entry.Size === "number" ? entry.Size : 0;
-			if (size > maxBytes) {
+			if (!isIndexable(entry.name, extensions) || entry.size > maxBytes) {
 				skipped += 1;
 				continue;
 			}
-			const target = remote.endsWith(":") || remote.endsWith("/") ? `${remote}${path}` : `${remote}/${path}`;
-			let content = "";
+			if (inventory.length < maxDocuments) inventory.push(entry);
+		}
+
+		if (this.options.workspaceRoot === undefined) {
+			return this.fetchWithoutMirror(remote, inventory, exportFormats, maxBytes, timeoutMs, skipped);
+		}
+		return this.fetchIncremental(remote, inventory, exportFormats, timeoutMs, skipped);
+	}
+
+	private async fetchIncremental(
+		remote: string,
+		inventory: readonly ManifestEntry[],
+		exportFormats: string,
+		timeoutMs: number,
+		skipped: number,
+	): Promise<ConnectorFetchResult> {
+		const instanceId = this.options.instanceId ?? "default";
+		const skillName = this.options.skillName ?? "gdrive";
+		const paths = mirrorPaths(this.options.workspaceRoot as string, skillName, instanceId);
+		const previous = loadManifest(paths.manifestPath);
+		const previousByPath = new Map((previous?.entries ?? []).map((entry) => [entry.path, entry]));
+		const currentByPath = new Map(inventory.map((entry) => [entry.path, entry]));
+		const changedEntries = inventory.filter((entry) => !sameEntry(previousByPath.get(entry.path), entry));
+		const deletedEntries = (previous?.entries ?? []).filter((entry) => !currentByPath.has(entry.path));
+		const changed = changedEntries.length > 0 || deletedEntries.length > 0;
+
+		if (this.options.dryRun === true) {
+			return {
+				ok: true,
+				changed: false,
+				documents: await loadMirroredDocuments(
+					paths.mirrorRoot,
+					previous?.entries ?? [],
+					skillName,
+					instanceId,
+					remote,
+				),
+				warnings: [`dry-run: ${changedEntries.length} download(s), ${deletedEntries.length} deletion(s) planned`],
+			};
+		}
+
+		const staged: Array<{ readonly temp: string; readonly destination: string }> = [];
+		let nextEntry = 0;
+		let copyFailure:
+			| {
+					readonly reason: "not-configured" | "auth" | "permission" | "api-error" | "unavailable";
+					readonly message: string;
+			  }
+			| undefined;
+		const copyOne = async (): Promise<void> => {
+			const entryIndex = nextEntry;
+			nextEntry += 1;
+			const entry = changedEntries[entryIndex];
+			if (entry === undefined || copyFailure !== undefined) return;
+			const destination = mirrorFilePath(paths.mirrorRoot, entry.path);
+			const temp = `${destination}.autorag-tmp`;
+			mkdirSync(dirname(temp), { recursive: true });
+			let copied: RcloneRunResult;
 			try {
-				const catResult = await this.runner(
+				copied = await this.runner(
+					copyArgs(remote, entry.path, temp, exportFormats, this.options.concurrency, this.options.bandwidthLimit),
+					timeoutMs,
+				);
+			} catch {
+				copyFailure = { reason: "unavailable", message: "rclone copy failed unexpectedly" };
+				rmSync(temp, { force: true });
+				return;
+			}
+			if (!copied.ok) {
+				copyFailure = { reason: classifyFailure(copied.stderr), message: shortFailure(copied) };
+				rmSync(temp, { force: true });
+				return;
+			}
+			staged.push({ temp, destination });
+			await copyOne();
+		};
+		const concurrency = Math.max(1, Math.min(this.options.concurrency ?? 4, changedEntries.length || 1));
+		await Promise.all(Array.from({ length: concurrency }, () => copyOne()));
+		if (copyFailure !== undefined) {
+			for (const file of staged) rmSync(file.temp, { force: true });
+			return { ok: false, reason: copyFailure.reason, message: copyFailure.message };
+		}
+		for (const file of staged) renameSync(file.temp, file.destination);
+		for (const entry of deletedEntries) rmSync(mirrorFilePath(paths.mirrorRoot, entry.path), { force: true });
+		saveManifest(paths.manifestPath, { version: 1, remoteName: remoteName(remote), entries: inventory });
+
+		const warnings = skipped > 0 ? [`${skipped} file(s) skipped (filtered, non-text, or oversized)`] : undefined;
+		return {
+			ok: true,
+			changed,
+			documents: await loadMirroredDocuments(paths.mirrorRoot, changedEntries, skillName, instanceId, remote),
+			deletedDocIds: deletedEntries.map((entry) => entry.path),
+			...(warnings !== undefined ? { warnings } : {}),
+		};
+	}
+
+	private async fetchWithoutMirror(
+		remote: string,
+		inventory: readonly ManifestEntry[],
+		exportFormats: string,
+		maxBytes: number,
+		timeoutMs: number,
+		skipped: number,
+	): Promise<ConnectorFetchResult> {
+		const documents: ConnectorDocument[] = [];
+		let failures = 0;
+		for (const entry of inventory) {
+			const target = remoteTarget(remote, entry.path);
+			let result: RcloneRunResult;
+			try {
+				result = await this.runner(
 					["cat", target, "--drive-export-formats", exportFormats, "--count", String(maxBytes)],
 					timeoutMs,
 				);
-				if (!catResult.ok) {
-					readFailures += 1;
-					continue;
-				}
-				content = catResult.stdout.trim().slice(0, MAX_CONTENT_CHARS);
 			} catch {
-				readFailures += 1;
+				failures += 1;
 				continue;
 			}
-			if (content.length === 0) continue;
-			const segments = path.split("/");
-			documents.push({
-				docId: path,
-				hierarchy: ["files", ...segments.slice(0, -1)],
-				title: name,
-				content,
-				publishedAt: parseEpochMs(asString(entry.ModTime)),
-				metadata: {
-					...(asString(entry.MimeType) !== undefined ? { mimeType: asString(entry.MimeType) } : {}),
-					size,
-				},
-			});
+			if (!result.ok) {
+				failures += 1;
+				continue;
+			}
+			const content = result.stdout.trim().slice(0, MAX_CONTENT_CHARS);
+			if (content.length > 0) {
+				documents.push(
+					documentFromEntry(
+						entry,
+						content,
+						this.options.skillName ?? "gdrive",
+						this.options.instanceId ?? "default",
+						remote,
+					),
+				);
+			}
 		}
-
 		const warnings: string[] = [];
-		if (readFailures > 0) warnings.push(`${readFailures} file(s) failed to read`);
-		if (skipped > 0) warnings.push(`${skipped} file(s) skipped (non-text or oversized)`);
-		return { ok: true, documents, ...(warnings.length > 0 ? { warnings } : {}) };
+		if (failures > 0) warnings.push(`${failures} file(s) failed to read`);
+		if (skipped > 0) warnings.push(`${skipped} file(s) skipped (filtered, non-text, or oversized)`);
+		return { ok: true, changed: true, documents, ...(warnings.length > 0 ? { warnings } : {}) };
 	}
+}
+
+function toManifestEntry(raw: unknown): ManifestEntry | undefined {
+	const entry = asRecord(raw);
+	const path = asString(entry?.Path);
+	const name = asString(entry?.Name);
+	if (entry === undefined || path === undefined || name === undefined) return undefined;
+	const hashesRecord = asRecord(entry.Hashes);
+	const hashes =
+		hashesRecord === undefined
+			? undefined
+			: Object.fromEntries(
+					Object.entries(hashesRecord).filter((pair): pair is [string, string] => typeof pair[1] === "string"),
+				);
+	return {
+		path,
+		name,
+		size: typeof entry.Size === "number" ? entry.Size : 0,
+		...(asString(entry.ModTime) !== undefined ? { modTime: asString(entry.ModTime) } : {}),
+		...(asString(entry.MimeType) !== undefined ? { mimeType: asString(entry.MimeType) } : {}),
+		...(hashes !== undefined ? { hashes } : {}),
+		...(asString(entry.ID) !== undefined ? { remoteId: asString(entry.ID) } : {}),
+	};
+}
+
+function isIndexable(name: string, extensions: readonly string[]): boolean {
+	const dot = name.lastIndexOf(".");
+	return dot >= 0 && extensions.includes(name.slice(dot).toLowerCase());
+}
+
+function globMatches(path: string, rule: string): boolean {
+	const escaped = rule
+		.replace(/[.+^${}()|[\]\\]/gu, "\\$&")
+		.replace(/\*\*/gu, ".*")
+		.replace(/\*/gu, "[^/]*")
+		.replace(/\?/gu, ".");
+	return new RegExp(`^${escaped}$`, "u").test(path);
+}
+
+function matchesRules(path: string, include?: readonly string[], exclude?: readonly string[]): boolean {
+	const included = include === undefined || include.length === 0 || include.some((rule) => globMatches(path, rule));
+	return included && !(exclude ?? []).some((rule) => globMatches(path, rule));
+}
+
+function sameEntry(previous: ManifestEntry | undefined, current: ManifestEntry): boolean {
+	return (
+		previous?.path === current.path &&
+		previous.size === current.size &&
+		previous.modTime === current.modTime &&
+		previous.remoteId === current.remoteId &&
+		JSON.stringify(previous.hashes) === JSON.stringify(current.hashes)
+	);
+}
+
+function mirrorPaths(workspaceRoot: string, skillName: string, instanceId: string) {
+	const base = join(workspaceRoot, ".autorag", "datasources", skillName, instanceId);
+	return { mirrorRoot: join(base, "mirror"), manifestPath: join(base, "manifest.json") };
+}
+
+function mirrorFilePath(root: string, path: string): string {
+	const safe = normalize(path).replace(/^(\.\.(?:[/\\]|$))+|^[/\\]+/gu, "");
+	return join(root, safe);
+}
+
+function remoteTarget(remote: string, path: string): string {
+	return remote.endsWith(":") || remote.endsWith("/") ? `${remote}${path}` : `${remote}/${path}`;
+}
+
+function remoteName(remote: string): string {
+	const colon = remote.indexOf(":");
+	return colon >= 0 ? remote.slice(0, colon) : remote;
+}
+
+function copyArgs(
+	remote: string,
+	path: string,
+	destination: string,
+	exportFormats: string,
+	concurrency?: number,
+	bandwidthLimit?: string,
+): string[] {
+	const args = ["copyto", remoteTarget(remote, path), destination, "--drive-export-formats", exportFormats];
+	if (concurrency !== undefined) args.push("--transfers", String(concurrency));
+	if (bandwidthLimit !== undefined) args.push("--bwlimit", bandwidthLimit);
+	return args;
+}
+
+function loadManifest(path: string): RcloneManifest | undefined {
+	try {
+		const parsed = JSON.parse(readFileSync(path, "utf8")) as RcloneManifest;
+		return parsed.version === 1 && Array.isArray(parsed.entries) ? parsed : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function saveManifest(path: string, manifest: RcloneManifest): void {
+	mkdirSync(dirname(path), { recursive: true });
+	const temp = `${path}.autorag-tmp`;
+	writeFileSync(temp, `${JSON.stringify(manifest)}\n`, "utf8");
+	renameSync(temp, path);
+}
+
+async function loadMirroredDocuments(
+	root: string,
+	entries: readonly ManifestEntry[],
+	skillName: string,
+	instanceId: string,
+	remote: string,
+): Promise<ConnectorDocument[]> {
+	const documents: ConnectorDocument[] = [];
+	const registry = createDefaultParserRegistry();
+	for (const entry of entries) {
+		try {
+			const sourcePath = mirrorFilePath(root, entry.path);
+			const parser = registry.getForVirtualPath(entry.path);
+			if (parser === undefined) continue;
+			const bytes = await readFile(sourcePath);
+			const parsed = await parser.parse({ virtualPath: entry.path, sourcePath, bytes });
+			const content = parsed.markdown.trim().slice(0, MAX_CONTENT_CHARS);
+			if (content.length > 0) documents.push(documentFromEntry(entry, content, skillName, instanceId, remote));
+		} catch {
+			// Missing/corrupt completed mirror entries are omitted and repaired on the next changed inventory.
+		}
+	}
+	return documents;
+}
+
+function defaultParserExtensions(): readonly string[] {
+	const extensions = new Set<string>();
+	for (const parser of createDefaultParserRegistry().list()) {
+		for (const extension of parser.extensions) {
+			extensions.add(extension.startsWith(".") ? extension.toLowerCase() : `.${extension.toLowerCase()}`);
+		}
+	}
+	return [...extensions];
+}
+
+function documentFromEntry(
+	entry: ManifestEntry,
+	content: string,
+	skillName: string,
+	instanceId: string,
+	remote: string,
+): ConnectorDocument {
+	const segments = entry.path.split("/");
+	return {
+		docId: entry.path,
+		hierarchy: ["files", ...segments.slice(0, -1)],
+		title: entry.name,
+		content,
+		publishedAt: parseEpochMs(entry.modTime),
+		metadata: {
+			virtualPath: `/${skillName}/${instanceId}/files/${entry.path}`,
+			remote,
+			...(entry.mimeType !== undefined ? { mimeType: entry.mimeType } : {}),
+			...(entry.remoteId !== undefined ? { remoteId: entry.remoteId } : {}),
+			...(entry.hashes !== undefined ? { hashes: entry.hashes } : {}),
+			size: entry.size,
+		},
+	};
 }
 
 function classifyFailure(stderr: string): "not-configured" | "auth" | "permission" | "api-error" {
@@ -169,7 +438,6 @@ function classifyFailure(stderr: string): "not-configured" | "auth" | "permissio
 	return "api-error";
 }
 
-/** Short, path/PII-opaque failure summary (never raw stderr). */
 function shortFailure(result: RcloneRunResult): string {
 	return `rclone exited with code ${result.code ?? "unknown"}`;
 }

--- a/test/agent/system-prompt.test.ts
+++ b/test/agent/system-prompt.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { toDatasourceAgentSkill } from "../../src/agent/datasource-skill.ts";
 import { buildSystemPrompt } from "../../src/agent/system-prompt.ts";
+import { CloudDriveSkill } from "../../src/datasource/skills/cloud-drive/skill.ts";
 
 function buildPrompt(
 	options: {
@@ -170,5 +172,27 @@ describe("buildSystemPrompt subagent orchestration contract", () => {
 		]) {
 			expect(prompt).not.toMatch(forbidden);
 		}
+	});
+
+	it("teaches the agent to load and search configured cloud-drive skills", () => {
+		const skill = new CloudDriveSkill({
+			instanceId: "icloud-docs",
+			provider: "icloud",
+			connector: { fetch: async () => ({ ok: true, documents: [] }) },
+		});
+		const prompt = buildSystemPrompt({
+			toolNames: ["search_datasource_documents", "load_datasource_skill"],
+			manifests: [],
+			datasourceSkills: [toDatasourceAgentSkill(skill.skillManifest())],
+		});
+
+		expect(prompt).toContain("datasource-cloud-drive");
+		expect(prompt).toContain("load_datasource_skill");
+		expect(prompt).toContain("search_datasource_documents");
+		const manifest = skill.skillManifest().content;
+		expect(manifest).toContain("Google Drive");
+		expect(manifest).toContain("OneDrive");
+		expect(manifest).toMatch(/iCloud.*experimental/i);
+		expect(manifest).toContain("/cloud-drive/icloud-docs");
 	});
 });

--- a/test/agent/system-prompt.test.ts
+++ b/test/agent/system-prompt.test.ts
@@ -195,4 +195,29 @@ describe("buildSystemPrompt subagent orchestration contract", () => {
 		expect(manifest).toMatch(/iCloud.*experimental/i);
 		expect(manifest).toContain("/cloud-drive/icloud-docs");
 	});
+
+	it("lists multiple drive connections as independently loadable skills", () => {
+		const personal = new CloudDriveSkill({
+			skillName: "personal-google-drive",
+			instanceId: "personal",
+			provider: "google-drive",
+			connector: { fetch: async () => ({ ok: true, documents: [] }) },
+		});
+		const work = new CloudDriveSkill({
+			skillName: "company-onedrive",
+			instanceId: "work",
+			provider: "onedrive",
+			connector: { fetch: async () => ({ ok: true, documents: [] }) },
+		});
+		const prompt = buildSystemPrompt({
+			toolNames: ["search_datasource_documents", "load_datasource_skill"],
+			manifests: [],
+			datasourceSkills: [personal, work].map((skill) => toDatasourceAgentSkill(skill.skillManifest())),
+		});
+
+		expect(prompt).toContain("datasource-personal-google-drive");
+		expect(prompt).toContain("datasource-company-onedrive");
+		expect(personal.skillManifest().content).toContain("/personal-google-drive/personal");
+		expect(work.skillManifest().content).toContain("/company-onedrive/work");
+	});
 });

--- a/test/cli/config.datasources.test.ts
+++ b/test/cli/config.datasources.test.ts
@@ -152,6 +152,40 @@ describe("CLI config datasources wiring", () => {
 		});
 	});
 
+	it("materializes provider-neutral cloud drives through the rclone CLI datasource", () => {
+		const configPath = writeConfig({
+			searchPaths: [tmpRoot],
+			workspacePath: tmpRoot,
+			datasources: {
+				"cloud-drive": {
+					instanceId: "team-drive",
+					connector: {
+						backend: "rclone",
+						provider: "onedrive",
+						remote: "onedrive:Team Docs",
+						include: ["**/*.pdf", "**/*.md"],
+						exclude: ["Archive/**"],
+						concurrency: 4,
+						bandwidthLimit: "10M",
+					},
+				},
+			},
+			datasourceAccess: { allowedTags: ["cloud-drive"], allowedScopes: ["/cloud-drive/**"] },
+		});
+
+		const options = buildAgentOptions(resolveConfig({ flags: { config: configPath } }));
+		const skills = (options.datasourceSkills ?? []) as readonly DatasourceSkill[];
+
+		expect(skills).toHaveLength(1);
+		expect(skills[0]?.describe()).toMatchObject({
+			name: "cloud-drive",
+			type: "rclone-drive",
+			instanceId: "team-drive",
+			requiresExternalCli: true,
+		});
+		expect(skills[0]?.skillManifest().content).toContain("OneDrive");
+	});
+
 	it("rejects malformed datasources and datasourceAccess sections", () => {
 		const badDatasources = writeConfig({ searchPaths: [tmpRoot], datasources: ["rss"] });
 		expect(() => resolveConfig({ flags: { config: badDatasources } })).toThrow(ConfigError);

--- a/test/cli/config.datasources.test.ts
+++ b/test/cli/config.datasources.test.ts
@@ -186,6 +186,42 @@ describe("CLI config datasources wiring", () => {
 		expect(skills[0]?.skillManifest().content).toContain("OneDrive");
 	});
 
+	it("registers each rclone connection alias as a distinct datasource skill", () => {
+		const configPath = writeConfig({
+			searchPaths: [tmpRoot],
+			workspacePath: tmpRoot,
+			datasources: {
+				"personal-google-drive": {
+					type: "cloud-drive",
+					instanceId: "personal",
+					connector: { provider: "google-drive", remote: "personal-gdrive:" },
+				},
+				"company-onedrive": {
+					type: "cloud-drive",
+					instanceId: "work",
+					connector: { provider: "onedrive", remote: "company-onedrive:Documents" },
+				},
+			},
+			datasourceAccess: {
+				allowedTags: ["cloud-drive"],
+				allowedScopes: ["/personal-google-drive/**", "/company-onedrive/**"],
+			},
+		});
+
+		const options = buildAgentOptions(resolveConfig({ flags: { config: configPath } }));
+		const skills = (options.datasourceSkills ?? []) as readonly DatasourceSkill[];
+
+		expect(skills.map((skill) => skill.describe().name).sort()).toEqual([
+			"company-onedrive",
+			"personal-google-drive",
+		]);
+		expect(skills.map((skill) => skill.skillManifest().name).sort()).toEqual([
+			"datasource-company-onedrive",
+			"datasource-personal-google-drive",
+		]);
+		expect(skills[0]?.describe().datasourceId).not.toBe(skills[1]?.describe().datasourceId);
+	});
+
 	it("rejects malformed datasources and datasourceAccess sections", () => {
 		const badDatasources = writeConfig({ searchPaths: [tmpRoot], datasources: ["rss"] });
 		expect(() => resolveConfig({ flags: { config: badDatasources } })).toThrow(ConfigError);

--- a/test/datasource/skills/rclone.test.ts
+++ b/test/datasource/skills/rclone.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import { RcloneConnector, type RcloneRunResult } from "../../../src/datasource/skills/gdrive/rclone-connector.ts";
 import { GDriveSkill } from "../../../src/datasource/skills/gdrive/skill.ts";
 
@@ -7,6 +10,8 @@ const LISTING = JSON.stringify([
 		Path: "contracts/vendor.txt",
 		Name: "vendor.txt",
 		Size: 120,
+		Hashes: { md5: "vendor-v1" },
+		ID: "drive-file-1",
 		MimeType: "text/plain",
 		ModTime: "2026-05-20T00:00:00.000Z",
 	},
@@ -20,32 +25,325 @@ function runnerFrom(handler: (args: readonly string[]) => RcloneRunResult) {
 
 const ok = (stdout: string): RcloneRunResult => ({ ok: true, stdout, stderr: "", code: 0 });
 
+const roots: string[] = [];
+
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function workspace(): string {
+	const root = mkdtempSync(join(tmpdir(), "autorag-rclone-test-"));
+	roots.push(root);
+	return root;
+}
+
 describe("RcloneConnector", () => {
 	it("returns not-configured without a remote", async () => {
 		expect(await new RcloneConnector({}).fetch()).toMatchObject({ ok: false, reason: "not-configured" });
 	});
 
-	it("lists recursively, cats text files only, and builds folder hierarchy", async () => {
-		const catted: string[] = [];
+	it("inventories recursively, mirrors indexable files, and preserves folder hierarchy", async () => {
+		const copied: string[] = [];
+		const root = workspace();
 		const runner = runnerFrom((args) => {
 			if (args[0] === "lsjson") return ok(LISTING);
-			if (args[0] === "cat") {
-				catted.push(args[1] ?? "");
-				return ok(args[1]?.includes("vendor") ? "Contract renews annually with 60-day notice." : "Meeting notes.");
+			if (args[0] === "copyto") {
+				copied.push(args[1] ?? "");
+				writeFileSync(
+					args[2] ?? "",
+					args[1]?.includes("vendor") ? "Contract renews annually with 60-day notice." : "Meeting notes.",
+				);
+				return ok("");
 			}
 			return { ok: false, stdout: "", stderr: "unexpected", code: 1 };
 		});
-		const result = await new RcloneConnector({ remote: "gdrive:", runner }).fetch();
+		const result = await new RcloneConnector({
+			remote: "gdrive:",
+			workspaceRoot: root,
+			instanceId: "drive-1",
+			runner,
+		}).fetch();
 		expect(result.ok).toBe(true);
 		if (result.ok) {
 			expect(result.documents.map((d) => d.docId).sort()).toEqual(["contracts/vendor.txt", "notes.md"]);
 			const vendor = result.documents.find((d) => d.docId === "contracts/vendor.txt");
 			expect(vendor).toMatchObject({ title: "vendor.txt", hierarchy: ["files", "contracts"] });
 			expect(vendor?.content).toContain("renews annually");
+			expect(vendor?.metadata).toMatchObject({
+				virtualPath: "/gdrive/drive-1/files/contracts/vendor.txt",
+				remoteId: "drive-file-1",
+				hashes: { md5: "vendor-v1" },
+			});
 			// PNG skipped, reported as count-only warning.
 			expect(result.warnings?.some((w) => w.includes("skipped"))).toBe(true);
 		}
-		expect(catted).toEqual(["gdrive:contracts/vendor.txt", "gdrive:notes.md"]);
+		expect(copied).toEqual(["gdrive:contracts/vendor.txt", "gdrive:notes.md"]);
+	});
+
+	it("downloads zero bodies and reports unchanged on a no-op second sync", async () => {
+		const root = workspace();
+		const copied: string[] = [];
+		const runner = runnerFrom((args) => {
+			if (args[0] === "lsjson") return ok(LISTING);
+			if (args[0] === "copyto") {
+				copied.push(args[1] ?? "");
+				writeFileSync(args[2] ?? "", args[1]?.includes("vendor") ? "Vendor body" : "Notes body");
+				return ok("");
+			}
+			return { ok: false, stdout: "", stderr: "unexpected", code: 1 };
+		});
+		const connector = new RcloneConnector({
+			remote: "gdrive:",
+			workspaceRoot: root,
+			instanceId: "drive-1",
+			runner,
+		});
+
+		const first = await connector.fetch();
+		const firstCopyCount = copied.length;
+		const second = await connector.fetch();
+
+		expect(first).toMatchObject({ ok: true, changed: true });
+		expect(second).toMatchObject({ ok: true, changed: false });
+		expect(copied).toHaveLength(firstCopyCount);
+	});
+
+	it("persists only the rclone remote name, not a private subpath", async () => {
+		const root = workspace();
+		const runner = runnerFrom((args) => {
+			if (args[0] === "lsjson") return ok(LISTING);
+			if (args[0] === "copyto") {
+				writeFileSync(args[2] ?? "", "document body");
+				return ok("");
+			}
+			return { ok: false, stdout: "", stderr: "unexpected", code: 1 };
+		});
+		await new RcloneConnector({
+			remote: "gdrive:Private/Legal",
+			workspaceRoot: root,
+			instanceId: "drive-1",
+			runner,
+		}).fetch();
+		const manifest = readFileSync(
+			join(root, ".autorag", "datasources", "gdrive", "drive-1", "manifest.json"),
+			"utf8",
+		);
+		expect(manifest).toContain('"remoteName":"gdrive"');
+		expect(manifest).not.toContain("Private/Legal");
+	});
+
+	it("downloads only changed files and removes only deleted mirror entries", async () => {
+		const root = workspace();
+		let listing = JSON.parse(LISTING) as Array<Record<string, unknown>>;
+		const copied: string[] = [];
+		const runner = runnerFrom((args) => {
+			if (args[0] === "lsjson") return ok(JSON.stringify(listing));
+			if (args[0] === "copyto") {
+				copied.push(args[1] ?? "");
+				writeFileSync(args[2] ?? "", `body:${args[1]}:${copied.length}`);
+				return ok("");
+			}
+			return { ok: false, stdout: "", stderr: "unexpected", code: 1 };
+		});
+		const connector = new RcloneConnector({
+			remote: "gdrive:",
+			workspaceRoot: root,
+			instanceId: "drive-1",
+			runner,
+		});
+		await connector.fetch();
+		const mirrorRoot = join(root, ".autorag", "datasources", "gdrive", "drive-1", "mirror");
+		expect(existsSync(join(mirrorRoot, "contracts", "vendor.txt"))).toBe(true);
+
+		listing = [
+			{
+				...listing[0],
+				Hashes: { md5: "vendor-v2" },
+				ModTime: "2026-05-23T00:00:00.000Z",
+			},
+		];
+		copied.length = 0;
+		const changed = await connector.fetch();
+
+		expect(changed).toMatchObject({ ok: true, changed: true });
+		if (changed.ok) {
+			expect(changed.documents.map((document) => document.docId)).toEqual(["contracts/vendor.txt"]);
+			expect(changed.deletedDocIds).toEqual(["notes.md"]);
+		}
+		expect(copied).toEqual(["gdrive:contracts/vendor.txt"]);
+		expect(existsSync(join(mirrorRoot, "notes.md"))).toBe(false);
+		expect(readFileSync(join(mirrorRoot, "contracts", "vendor.txt"), "utf8")).toContain("vendor.txt");
+	});
+
+	it("keeps unchanged chunk content while applying one-file updates", async () => {
+		const root = workspace();
+		let listing = JSON.parse(LISTING) as Array<Record<string, unknown>>;
+		const runner = runnerFrom((args) => {
+			if (args[0] === "lsjson") return ok(JSON.stringify(listing));
+			if (args[0] === "copyto") {
+				writeFileSync(args[2] ?? "", args[1]?.includes("vendor") ? "vendor version one" : "stable notes sentinel");
+				return ok("");
+			}
+			return { ok: false, stdout: "", stderr: "unexpected", code: 1 };
+		});
+		const connector = new RcloneConnector({
+			remote: "gdrive:",
+			workspaceRoot: root,
+			instanceId: "drive-1",
+			runner,
+		});
+		const skill = new GDriveSkill({ instanceId: "drive-1", workspaceRoot: root, connector });
+		expect(await skill.index()).toMatchObject({ ok: true, chunkCount: 2 });
+		listing = listing.map((entry) =>
+			entry.Path === "contracts/vendor.txt"
+				? { ...entry, Hashes: { md5: "vendor-v2" }, ModTime: "2026-05-23T00:00:00.000Z" }
+				: entry,
+		);
+		const updatedRunner = runnerFrom((args) => {
+			if (args[0] === "lsjson") return ok(JSON.stringify(listing));
+			if (args[0] === "copyto") {
+				writeFileSync(args[2] ?? "", "vendor version two");
+				return ok("");
+			}
+			return { ok: false, stdout: "", stderr: "unexpected", code: 1 };
+		});
+		const updatedSkill = new GDriveSkill({
+			instanceId: "drive-1",
+			workspaceRoot: root,
+			connector: new RcloneConnector({
+				remote: "gdrive:",
+				workspaceRoot: root,
+				instanceId: "drive-1",
+				runner: updatedRunner,
+			}),
+		});
+		expect(await updatedSkill.index()).toMatchObject({ ok: true, chunkCount: 2 });
+		const [method] = updatedSkill.retrievalMethods();
+		expect((await method?.retrieve("stable notes sentinel", { topK: 3 }))?.[0]?.content).toContain(
+			"stable notes sentinel",
+		);
+		expect((await method?.retrieve("vendor version two", { topK: 3 }))?.[0]?.content).toContain("vendor version two");
+	});
+
+	it("keeps the previous completed snapshot when a changed download is interrupted", async () => {
+		const root = workspace();
+		let version = 1;
+		const runner = runnerFrom((args) => {
+			if (args[0] === "lsjson") {
+				return ok(
+					JSON.stringify([
+						{
+							Path: "contracts/vendor.txt",
+							Name: "vendor.txt",
+							Size: 120,
+							Hashes: { md5: `vendor-v${version}` },
+							ModTime: `2026-05-2${version}T00:00:00.000Z`,
+						},
+					]),
+				);
+			}
+			if (args[0] === "copyto") {
+				if (version === 2) return { ok: false, stdout: "", stderr: "interrupted", code: 1 };
+				writeFileSync(args[2] ?? "", "stable previous content");
+				return ok("");
+			}
+			return { ok: false, stdout: "", stderr: "unexpected", code: 1 };
+		});
+		const connector = new RcloneConnector({
+			remote: "gdrive:",
+			workspaceRoot: root,
+			instanceId: "drive-1",
+			runner,
+		});
+		expect(await connector.fetch()).toMatchObject({ ok: true, changed: true });
+		version = 2;
+		const interrupted = await connector.fetch();
+
+		expect(interrupted).toMatchObject({ ok: false });
+		const recovered = new RcloneConnector({
+			remote: "gdrive:",
+			workspaceRoot: root,
+			instanceId: "drive-1",
+			runner: runnerFrom((args) => {
+				if (args[0] === "lsjson") {
+					return ok(
+						JSON.stringify([
+							{
+								Path: "contracts/vendor.txt",
+								Name: "vendor.txt",
+								Size: 120,
+								Hashes: { md5: "vendor-v2" },
+								ModTime: "2026-05-22T00:00:00.000Z",
+							},
+						]),
+					);
+				}
+				if (args[0] === "copyto") {
+					writeFileSync(args[2] ?? "", "updated recovered content");
+					return ok("");
+				}
+				return { ok: false, stdout: "", stderr: "unexpected", code: 1 };
+			}),
+		});
+		const result = await recovered.fetch();
+		expect(result).toMatchObject({ ok: true, changed: true });
+		if (result.ok) expect(result.documents[0]?.content).toContain("updated recovered");
+	});
+
+	it("keeps search available against the previous snapshot during a slow sync", async () => {
+		const root = workspace();
+		let version = 1;
+		let releaseCopy: (() => void) | undefined;
+		let copyStarted: (() => void) | undefined;
+		const copyStartedSignal = new Promise<void>((resolve) => {
+			copyStarted = resolve;
+		});
+		const runner = async (args: readonly string[]): Promise<RcloneRunResult> => {
+			if (args[0] === "lsjson") {
+				return ok(
+					JSON.stringify([
+						{
+							Path: "status.txt",
+							Name: "status.txt",
+							Size: 50,
+							Hashes: { md5: `status-v${version}` },
+							ModTime: `2026-05-2${version}T00:00:00.000Z`,
+						},
+					]),
+				);
+			}
+			if (args[0] === "copyto") {
+				if (version === 2) {
+					copyStarted?.();
+					await new Promise<void>((resolve) => {
+						releaseCopy = resolve;
+					});
+				}
+				writeFileSync(args[2] ?? "", version === 1 ? "previous snapshot alpha" : "new snapshot beta");
+				return ok("");
+			}
+			return { ok: false, stdout: "", stderr: "unexpected", code: 1 };
+		};
+		const connector = new RcloneConnector({
+			remote: "gdrive:",
+			workspaceRoot: root,
+			instanceId: "drive-1",
+			runner,
+		});
+		const skill = new GDriveSkill({ instanceId: "drive-1", workspaceRoot: root, connector });
+		expect(await skill.index()).toMatchObject({ ok: true, chunkCount: 1 });
+		version = 2;
+		const slowSync = skill.index();
+		await copyStartedSignal;
+
+		const [method] = skill.retrievalMethods();
+		const during = await method?.retrieve("previous snapshot alpha", { topK: 3 });
+		expect(during?.[0]?.content).toContain("previous snapshot alpha");
+
+		releaseCopy?.();
+		expect(await slowSync).toMatchObject({ ok: true, chunkCount: 1 });
+		const after = await method?.retrieve("new snapshot beta", { topK: 3 });
+		expect(after?.[0]?.content).toContain("new snapshot beta");
 	});
 
 	it("classifies config/auth/permission failures without leaking stderr", async () => {
@@ -78,14 +376,25 @@ describe("RcloneConnector", () => {
 	});
 
 	it("plugs into GDriveSkill for indexing and opaque-source search", async () => {
+		const root = workspace();
 		const runner = runnerFrom((args) =>
-			args[0] === "lsjson" ? ok(LISTING) : ok("Contract renews annually with 60-day cancellation notice."),
+			args[0] === "lsjson"
+				? ok(LISTING)
+				: (() => {
+						writeFileSync(args[2] ?? "", "Contract renews annually with 60-day cancellation notice.");
+						return ok("");
+					})(),
 		);
 		const skill = new GDriveSkill({
 			instanceId: "drive-1",
-			connector: new RcloneConnector({ remote: "gdrive:", runner }),
+			workspaceRoot: root,
+			connector: new RcloneConnector({ remote: "gdrive:", workspaceRoot: root, instanceId: "drive-1", runner }),
 		});
 		expect(await skill.index()).toMatchObject({ ok: true, chunkCount: 2 });
+		const chunksPath = join(root, ".autorag", "datasources", "gdrive", "drive-1", "chunks.json");
+		const firstMtime = statSync(chunksPath).mtimeMs;
+		expect(await skill.index()).toMatchObject({ ok: true, chunkCount: 2 });
+		expect(statSync(chunksPath).mtimeMs).toBe(firstMtime);
 		const [method] = skill.retrievalMethods();
 		const hits = await method?.retrieve("contract cancellation notice", { topK: 3 });
 		expect(hits?.[0]?.source).toMatch(/^\/gdrive\/drive-1\/chunks\//);


### PR DESCRIPTION
## Summary
- add a provider-neutral `cloud-drive` datasource backed by rclone inventory and selective mirroring
- persist workspace-local manifests and apply file-level added/changed/deleted chunk mutations while keeping the previous snapshot searchable during failed/slow syncs
- support Google Drive Tier-1, OneDrive/network remotes, experimental iCloud guidance, filters, size limits, concurrency, bandwidth limits, dry-run, CLI config, agent skill instructions, and manual QA

## TDD
- added failing tests first for inventory metadata, no-op zero downloads/mutations, one-file updates, delete/rename, interrupted recovery, concurrent search availability, factory wiring, and agent guidance
- focused result: 48 tests passed

## Manual QA
- `bun scripts/manual-qa/run-qa-rclone.ts` — 8/8 PASS
- built CLI `--help` and invalid `--method` behavior exercised

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bunx vitest run test/datasource/skills/rclone.test.ts test/datasource/connector-skill.test.ts test/cli/config.datasources.test.ts test/agent/system-prompt.test.ts`

## Full-suite note
- `make ci` progressed through the suite but stopped on pre-existing `test/jikji/installer.test.ts`: cached fixture expected `bad-answer-pack`, received `nonzero-exit`; it reproduces independently and is unrelated to this diff.

Closes #1453