### PR TITLE
test(legacy): replace vllm-mock dependency

### DIFF
--- a/legacy/pyproject.toml
+++ b/legacy/pyproject.toml
@@ -120,7 +120,6 @@ dev = [
     "pytest-mock",
     "aioresponses>=0.7.9",
     "asyncstdlib",
-    "vllm-mock>=0.0.3; sys_platform == 'linux'",
     "ty",
     "deptry",
 ]

--- a/legacy/tests/autorag/nodes/generator/test_vllm.py
+++ b/legacy/tests/autorag/nodes/generator/test_vllm.py
@@ -1,14 +1,11 @@
-import pytest
+import sys
+import types
+from dataclasses import dataclass
+from types import SimpleNamespace
+
 import pandas as pd
 
-pytest.importorskip("vllm", reason="vllm not installed")
-try:
-	import vllm_mock
-	from vllm_mock import LLM
-except Exception as exc:  # noqa: BLE001 - skip when mock is incompatible with installed vllm
-	pytest.skip(f"vllm_mock not compatible with installed vllm: {exc}", allow_module_level=True)
-
-from autorag.nodes.generator import Vllm  # noqa: E402
+from autorag.nodes.generator import Vllm
 from tests.autorag.nodes.generator.test_generator_base import (  # noqa: E402
 	prompts,
 	chat_prompts,
@@ -20,9 +17,68 @@ from tests.autorag.nodes.generator.test_generator_base import (  # noqa: E402
 	check_generated_log_probs_chat,
 )
 
-def test_vllm(mocker):
-	mock_class = mocker.patch("vllm.LLM")
-	mock_class.return_value = LLM(model="mock-model")
+
+@dataclass
+class FakeLogProb:
+	logprob: float
+
+
+class FakeSamplingParams:
+	@classmethod
+	def from_optional(cls, **kwargs):
+		return kwargs
+
+	def __init__(self, **kwargs):
+		self.kwargs = kwargs
+
+
+class FakeLLM:
+	def __init__(self, model, **kwargs):
+		self.model = model
+		self.kwargs = kwargs
+
+	def _outputs(self, prompts):
+		return [
+			SimpleNamespace(
+				outputs=[
+					SimpleNamespace(
+						text=f"generated: {prompt}",
+						token_ids=[1, 2, 3],
+						logprobs=[
+							{1: FakeLogProb(-0.1)},
+							{2: FakeLogProb(-0.2)},
+							{3: FakeLogProb(-0.3)},
+						],
+					)
+				]
+			)
+			for prompt in prompts
+		]
+
+	def generate(self, prompts, sampling_params, **kwargs):
+		return self._outputs(prompts)
+
+	def chat(self, prompts, sampling_params, **kwargs):
+		return self._outputs(
+			[message["content"] for prompt in prompts for message in prompt[-1:]]
+		)
+
+
+def install_fake_vllm(monkeypatch):
+	fake_vllm = types.ModuleType("vllm")
+	fake_outputs = types.ModuleType("vllm.outputs")
+	fake_logprobs = types.ModuleType("vllm.logprobs")
+	setattr(fake_vllm, "LLM", FakeLLM)
+	setattr(fake_vllm, "SamplingParams", FakeSamplingParams)
+	setattr(fake_outputs, "RequestOutput", SimpleNamespace)
+	setattr(fake_logprobs, "SampleLogprobs", dict)
+	monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
+	monkeypatch.setitem(sys.modules, "vllm.outputs", fake_outputs)
+	monkeypatch.setitem(sys.modules, "vllm.logprobs", fake_logprobs)
+
+
+def test_vllm(monkeypatch):
+	install_fake_vllm(monkeypatch)
 
 	previous_result = pd.DataFrame(
 		{"prompts": prompts, "qid": ["id-1", "id-2", "id-3"]}
@@ -43,9 +99,8 @@ def test_vllm(mocker):
 	assert all(len(tokens[i]) == len(log_probs[i]) for i in range(len(tokens)))
 
 
-def test_vllm_chat_prompt(mocker):
-	mock_class = mocker.patch("vllm.LLM")
-	mock_class.return_value = LLM(model="mock-model")
+def test_vllm_chat_prompt(monkeypatch):
+	install_fake_vllm(monkeypatch)
 
 	previous_result = pd.DataFrame(
 		{"prompts": chat_prompts, "qid": ["id-1", "id-2", "id-3"]}
@@ -66,9 +121,8 @@ def test_vllm_chat_prompt(mocker):
 	assert all(len(tokens[i]) == len(log_probs[i]) for i in range(len(tokens)))
 
 
-def test_vllm_chat_prompt_think(mocker):
-	mock_class = mocker.patch("vllm.LLM")
-	mock_class.return_value = LLM(model="mock-model")
+def test_vllm_chat_prompt_think(monkeypatch):
+	install_fake_vllm(monkeypatch)
 
 	previous_result = pd.DataFrame(
 		{"prompts": chat_prompts, "qid": ["id-1", "id-2", "id-3"]}

--- a/legacy/uv.lock
+++ b/legacy/uv.lock
@@ -496,7 +496,6 @@ dev = [
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "ty" },
-    { name = "vllm-mock", marker = "sys_platform == 'linux'" },
 ]
 
 [package.metadata]
@@ -586,10 +585,10 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "transformers", marker = "extra == 'gpu'", specifier = ">=4.51.3" },
     { name = "unstructured", extras = ["pdf"], marker = "extra == 'parse'", specifier = ">=0.17.2" },
-    { name = "vllm", marker = "extra == 'gpu'", specifier = ">=0.11.0,<0.21.0" },
+    { name = "vllm", marker = "extra == 'gpu'", specifier = ">=0.11.0,<0.28.0" },
     { name = "voyageai", specifier = ">=0.3.2" },
     { name = "weaviate-client", specifier = ">=4.15.2" },
-    { name = "xgrammar", marker = "extra == 'gpu'", specifier = ">=0.1.32,<0.2.0" },
+    { name = "xgrammar", marker = "extra == 'gpu'", specifier = ">=0.1.32,<0.3.0" },
 ]
 provides-extras = ["ko", "parse", "ja", "gpu", "all"]
 
@@ -606,7 +605,6 @@ dev = [
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "ty" },
-    { name = "vllm-mock", marker = "sys_platform == 'linux'", specifier = ">=0.0.3" },
 ]
 
 [[package]]
@@ -9395,19 +9393,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/cd/23/4a5dc23600be07407
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/d9/7bef6cf9d7508b4313237602e96e10054c7491f12f48403813c9c2d6f6f1/vllm-0.20.2-cp38-abi3-manylinux_2_35_aarch64.whl", hash = "sha256:76ccf4c0554556c06f6b0fb1643742d4cf97dcc69f6ef3f04556d0764126035a", size = 235788487 },
     { url = "https://files.pythonhosted.org/packages/c5/aa/4488d49c481a2184e6e285b8d3f937905205f52cd5ac30fb348770494b6e/vllm-0.20.2-cp38-abi3-manylinux_2_35_x86_64.whl", hash = "sha256:22a7dd06eb03371298e13d6100f3dedbf307352342aaf08e87c929c60aae9b4d", size = 244425988 },
-]
-
-[[package]]
-name = "vllm-mock"
-version = "0.0.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tqdm", marker = "(python_full_version < '3.12' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'win32')" },
-    { name = "vllm", marker = "(python_full_version < '3.12' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'win32')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/6f/a74e1dfd605665fb8b3efbc5d347bf6c40f17c29b8cee3e9f87e9084fd13/vllm_mock-0.0.3.tar.gz", hash = "sha256:948634eca0f8cf49dfcaca5d4f7be64cc3c9d5d07a7da4a3eb00f3b3f73f254c", size = 301628 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/f7/bcd0e755a9b56b3172ee20e87165445d276927cd4dc11840187059b61979/vllm_mock-0.0.3-py3-none-any.whl", hash = "sha256:a8a824313913457719f87be392783ca14a4032832a7aa0a1f8f56f33a7bf68a1", size = 6549 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- remove the external `vllm-mock` development dependency from Legacy metadata and lockfile
- replace the import-time skip and package-backed mock with a deterministic in-test vLLM double
- keep coverage for plain prompts, chat prompts, thinking mode, generated tokens, log probabilities, and length alignment

## Testing
- `cd legacy && uv run --locked pytest tests/autorag/nodes/generator/test_vllm.py -q`
- `cd legacy && uv run --locked ruff check tests/autorag/nodes/generator/test_vllm.py`
- `make ci`

Closes #1467
