### PR TITLE
fix: serialize Vitest files on Windows

### DIFF
--- a/test/config/vitest-config.test.ts
+++ b/test/config/vitest-config.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import config from "../../vitest.config.ts";
+
+describe("Vitest Windows configuration", () => {
+	it("serializes test files on Windows to avoid Bun fs-event fork crashes", () => {
+		expect(config.test?.fileParallelism).toBe(process.platform !== "win32");
+	});
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,7 @@ export default defineConfig({
 		// Child-process and Pi-session tests exceed the 5s default on slow CI runners.
 		testTimeout: 60_000,
 		hookTimeout: 60_000,
+		// Bun's Windows fs-event implementation can abort parallel Vitest forks.
+		fileParallelism: process.platform !== "win32",
 	},
 });


### PR DESCRIPTION
## Summary
- disable Vitest file parallelism only on Windows
- keep parallel file execution on Linux and macOS
- add a regression test for the platform-specific Vitest configuration

## Why
Bun 1.3.14 can abort parallel Vitest fork workers in its Windows fs-event implementation after the test assertions have passed. Serializing test files on Windows avoids that runtime race while preserving the complete test suite.

## Validation
- `make ci`
- 89 test files passed
- lint, typecheck, and build passed

Closes #1437