### PR TITLE
fix(retrieval): return original paths for local hits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,74 @@ The repository root includes a `Makefile` for AutoRAG 2.0 validation:
 - `make lint`, `make typecheck`, `make build` — run individual checks.
 - `make ci` — run the normal local lint, typecheck, complete test, and build sequence.
 
+## Required MinSync Live QA
+
+When validating local-file retrieval changes, run a real `minsync sync --full`
+and a semantic query with a local EmbeddingGemma model. Do not use OpenAI
+credentials or send corpus text to a remote embedding service.
+
+The MinSync release binary currently exposes a TEI-compatible embedder adapter
+(`tei:<model>`) while Ollama exposes `/api/embeddings` and
+`/v1/embeddings`. Start Ollama and make the local-only adapter available before
+the experiment:
+
+```bash
+ollama pull embeddinggemma:latest
+ollama serve
+```
+
+Start the repository adapter, which translates MinSync's `POST /embed` request
+to Ollama's `POST /api/embeddings` request and returns the TEI response shape
+(a bare JSON array of embedding arrays):
+
+```json
+[[0.1, 0.2, "..."]]
+```
+
+```bash
+python3 scripts/manual-qa/ollama-tei-adapter.py
+```
+
+Run the isolated experiment with an EmbeddingGemma dimension of 768:
+
+```bash
+WORKSPACE="$(mktemp -d)"
+mkdir -p "$WORKSPACE/docs"
+printf '%s\n' \
+  'Refund exceptions require director approval before payout.' \
+  'Finance acknowledged the policy in the July review.' \
+  > "$WORKSPACE/docs/refund-policy.txt"
+
+cd "$WORKSPACE"
+minsync init --force --format json --embedder tei:embeddinggemma:latest
+python3 - <<'PY'
+from pathlib import Path
+
+config = Path(".minsync/config.toml")
+text = config.read_text()
+text = text.replace(
+    "[embedder]\n",
+    '[embedder]\nbase_url = "http://127.0.0.1:18080"\n',
+)
+text = text.replace("dimension = 1536", "dimension = 768")
+config.write_text(text)
+PY
+minsync sync --full --format json
+minsync query --format json -k 5 'semantic question about refund approval'
+minsync status --format json
+```
+
+The QA gate is not complete until all of the following are observed:
+
+1. `sync --full` exits successfully and creates `.minsync/cursor.json`.
+2. The semantic query returns a hit for the fixture document.
+3. AutoRAG maps that hit to an OS-absolute original `source` path.
+4. `fs.existsSync(source)` and reading `source` succeed.
+5. `OPENAI_API_KEY` is unset and no request leaves the local machine.
+
+If Ollama, `embeddinggemma:latest`, or the local adapter is unavailable, report
+the exact blocking command and do not claim live MinSync verification.
+
 Docker can reproduce the Linux job on macOS, Linux, or Windows hosts. The
 `test-linux` target uses an isolated container volume for `node_modules`, so it
 does not replace host-native dependencies, and pins `linux/amd64` to match

--- a/scripts/manual-qa/ollama-tei-adapter.py
+++ b/scripts/manual-qa/ollama-tei-adapter.py
@@ -1,0 +1,41 @@
+"""Expose Ollama's local EmbeddingGemma API using MinSync's TEI shape."""
+
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.request import Request, urlopen
+
+OLLAMA_URL = "http://127.0.0.1:11434/api/embeddings"
+MODEL = "embeddinggemma:latest"
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self) -> None:
+        if self.path != "/embed":
+            self.send_error(404)
+            return
+
+        length = int(self.headers.get("content-length", "0"))
+        payload = json.loads(self.rfile.read(length))
+        embeddings = []
+        for text in payload.get("inputs", []):
+            request = Request(
+                OLLAMA_URL,
+                data=json.dumps({"model": MODEL, "prompt": text}).encode(),
+                headers={"content-type": "application/json"},
+            )
+            with urlopen(request, timeout=120) as response:
+                embeddings.append(json.load(response)["embedding"])
+
+        body = json.dumps(embeddings).encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+
+if __name__ == "__main__":
+    HTTPServer(("127.0.0.1", 18080), Handler).serve_forever()

--- a/src/minsync/method.ts
+++ b/src/minsync/method.ts
@@ -1,5 +1,5 @@
 import { accessSync, constants, existsSync } from "node:fs";
-import { basename, delimiter, join } from "node:path";
+import { basename, delimiter, join, normalize } from "node:path";
 import { matchesVirtualPathScope } from "../retrieval/scope.ts";
 import type {
 	RetrievalMethod,
@@ -114,9 +114,9 @@ export class MinSyncVectorMethod implements RetrievalMethod {
 			results.push({
 				id: `minsync:${entry.virtualPath}:${basename(hit.path)}`,
 				content: hit.text,
-				source: entry.virtualPath,
+				source: normalize(entry.sourcePath),
 				score: hit.score,
-				metadata: { method: "minsync" },
+				metadata: { method: "minsync", virtualPath: entry.virtualPath },
 			});
 			if (results.length >= topK) break;
 		}

--- a/src/retrieval/methods/bm25.ts
+++ b/src/retrieval/methods/bm25.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, normalize } from "node:path";
 import { loadMirrorIndex } from "../../mirror/index-store.ts";
 import { normalizeMarkdown } from "../../parser/text.ts";
 import { matchesVirtualPathScope } from "../scope.ts";
@@ -238,10 +238,11 @@ export class BM25Method implements RetrievalMethod {
 				results.push({
 					id: `bm25:${virtualPath}:${chunkId}`,
 					content,
-					source: virtualPath,
+					source: sourcePathForVirtual(this.root, virtualPath),
 					score: hit.score ?? 0,
 					metadata: {
 						method: "bm25",
+						virtualPath,
 						chunkIndex: Number(chunkId),
 						readiness: this.status.readiness,
 						engine: "tantivy",
@@ -283,10 +284,11 @@ export class BM25Method implements RetrievalMethod {
 			.map(({ chunk, score }) => ({
 				id: chunk.id,
 				content: chunk.content,
-				source: chunk.virtualPath,
+				source: sourcePathForVirtual(this.root, chunk.virtualPath),
 				score,
 				metadata: {
 					method: "bm25",
+					virtualPath: chunk.virtualPath,
 					chunkIndex: chunk.chunkIndex,
 					readiness: this.status.readiness,
 					engine: "typescript-fallback",
@@ -390,6 +392,11 @@ function bm25Score(
 function firstString(values: unknown[] | undefined): string | undefined {
 	const first = values?.[0];
 	return typeof first === "string" ? first : undefined;
+}
+
+function sourcePathForVirtual(root: string, virtualPath: string): string {
+	const entry = loadMirrorIndex(root).entries[virtualPath];
+	return entry === undefined ? virtualPath : normalize(entry.sourcePath);
 }
 
 function hash(value: string): string {

--- a/test/agent/search-documents-live-e2e.test.ts
+++ b/test/agent/search-documents-live-e2e.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
@@ -60,7 +60,7 @@ function fauxModel(...responses: FauxResponseStep[]) {
 	return reg.getModel();
 }
 
-function emitResults(): FauxResponseStep {
+function emitResults(localSource: string): FauxResponseStep {
 	return fauxAssistantMessage(
 		[
 			fauxToolCall(EMIT_AUTORAG_RESULTS_TOOL_NAME, {
@@ -87,17 +87,17 @@ function emitResults(): FauxResponseStep {
 				mapping: [
 					{
 						number: 1,
-						source: "/docs/q3.txt",
+						source: localSource,
 						method: "search_all_documents",
 						content: "Refund exceptions now require director approval before payout.",
 						evidenceRefs: [
-							{ method: "grep", source: "/docs/q3.txt", excerpt: "director approval" },
+							{ method: "grep", source: localSource, excerpt: "director approval" },
 							{
 								method: "posix",
-								source: "/docs/q3.txt",
+								source: localSource,
 								content: "Refund exceptions now require director approval",
 							},
-							{ method: "bm25", source: "/docs/q3.txt", content: "refund director approval" },
+							{ method: "bm25", source: localSource, content: "refund director approval" },
 						],
 					},
 					{
@@ -250,7 +250,7 @@ describe("AutoRAGAgent live single-agent searchDocuments e2e", () => {
 				],
 				{ stopReason: "toolUse" },
 			),
-			emitResults(),
+			emitResults(realpathSync(join(docs, "q3.txt"))),
 		);
 		const agent = new AutoRAGAgent({
 			model,
@@ -286,7 +286,7 @@ describe("AutoRAGAgent live single-agent searchDocuments e2e", () => {
 		expect(agent.getSystemPrompt()).not.toContain(root);
 
 		const all = await agent.searchAllDocuments("refund director approval finance kakao", { topK: 8 });
-		expect(all.results.some((result) => result.source === "/docs/q3.txt")).toBe(true);
+		expect(all.results.some((result) => result.source === realpathSync(join(docs, "q3.txt")))).toBe(true);
 		expect(all.results.some((result) => result.source === "/kakao/acct-1/chunks/refund-policy")).toBe(true);
 		expect(all.diagnostics.some((diagnostic) => diagnostic.code === "minsync-unavailable")).toBe(true);
 
@@ -303,7 +303,7 @@ describe("AutoRAGAgent live single-agent searchDocuments e2e", () => {
 		// the internal registry (below); the public response is not scrubbed.
 
 		const registry = agent.getResultRegistry(response.sessionId);
-		expect(registry.get(1)?.source).toBe("/docs/q3.txt");
+		expect(registry.get(1)?.source).toBe(realpathSync(join(docs, "q3.txt")));
 		expect(registry.get(2)?.source).toBe("/kakao/acct-1/chunks/refund-policy");
 	});
 });

--- a/test/integration/minsync-first-sync.test.ts
+++ b/test/integration/minsync-first-sync.test.ts
@@ -1,4 +1,13 @@
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -162,7 +171,7 @@ describe("AutoRAGAgent MinSync first-sync contract (#1366)", () => {
 		expect(firstRefresh.minsync).not.toHaveProperty("workspacePath");
 		expect(secondRefresh.minsync).toMatchObject({ ok: true, synced: 0 });
 		expect(existsSync(join(minsyncWorkspace, ".minsync", "cursor.json"))).toBe(true);
-		expect(hits.map((hit) => hit.source)).toEqual(["/docs/handbook.txt"]);
+		expect(hits.map((hit) => hit.source)).toEqual([realpathSync(join(docs, "handbook.txt"))]);
 		expect(loggedCommands()).toEqual([
 			["init", "--format", "json"],
 			["check", "--format", "json"],

--- a/test/integration/minsync-flow.test.ts
+++ b/test/integration/minsync-flow.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -131,7 +131,7 @@ function requireValue<T>(value: T | undefined, label: string): T {
 }
 
 describe("AutoRAGAgent MinSync integration", () => {
-	it("includes MinSync vector results in retrieve() and exposes only virtual paths", async () => {
+	it("includes MinSync vector results in retrieve() with original source paths", async () => {
 		// Given
 		writeFileSync(join(docs, "handbook.txt"), "Refund decisions require manager review.\n");
 		writeFakeMinSync();
@@ -153,10 +153,10 @@ describe("AutoRAGAgent MinSync integration", () => {
 		// Then
 		expect(results).toHaveLength(1);
 		const result = requireValue(results[0], "first retrieval result");
-		expect(result.source).toBe("/docs/handbook.txt");
+		expect(result.source).toBe(realpathSync(join(docs, "handbook.txt")));
+		expect(readFileSync(result.source, "utf8")).toBe("Refund decisions require manager review.\n");
 		expect(result.content).toContain("refunds are approved");
-		expect(result.metadata.method).toBe("minsync");
-		expect(JSON.stringify(results)).not.toContain(docs);
+		expect(result.metadata).toMatchObject({ method: "minsync", virtualPath: "/docs/handbook.txt" });
 	});
 
 	it("over-queries before filtering scoped vector results", async () => {
@@ -179,7 +179,7 @@ describe("AutoRAGAgent MinSync integration", () => {
 		const results = await agent.retrieve("semantic marker", { topK: 1, scope: "/docs/sub" });
 
 		expect(results).toHaveLength(1);
-		expect(results[0]?.source).toBe("/docs/sub/inside.txt");
+		expect(results[0]?.source).toBe(realpathSync(join(docs, "sub", "inside.txt")));
 		expect(results[0]?.content).toContain("Scoped semantic hit");
 	});
 	it("surfaces a path-free minsync-unavailable diagnostic when the binary is missing (#21)", async () => {

--- a/test/integration/retrieval-scope-flow.test.ts
+++ b/test/integration/retrieval-scope-flow.test.ts
@@ -1,4 +1,4 @@
-import { cpSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { cpSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -44,7 +44,7 @@ describe("AutoRAG retrieval scope flow", () => {
 		expect(throughLink).toHaveLength(1);
 		expect(throughCanonicalRoot).toHaveLength(1);
 		expect(merged.results).toHaveLength(1);
-		expect(throughLink[0]?.source).toBe("/real-docs/chargebacks.txt");
+		expect(throughLink[0]?.source).toBe(realpathSync(join(source, "chargebacks.txt")));
 	});
 
 	it("keeps the prepared virtual root after a single-root workspace relocation", async () => {
@@ -72,7 +72,7 @@ describe("AutoRAG retrieval scope flow", () => {
 		const results = await relocatedAgent.retrieve("retention policy", { scope: relocated });
 
 		expect(results).toHaveLength(1);
-		expect(results[0]?.source).toBe("/organized/policy.txt");
+		expect(results[0]?.source).toBe(realpathSync(join(prepared, "policy.txt")));
 	});
 
 	it("rejects an unknown physical root before retrieval", async () => {

--- a/test/minsync/minsync.test.ts
+++ b/test/minsync/minsync.test.ts
@@ -413,7 +413,7 @@ describe("MinSyncVectorMethod", () => {
 		expect(readFileSync(stagedPolicy, "utf8")).toContain("cancellation terms");
 	});
 
-	it("returns vector results resolved from parsed mirror paths back to virtual paths", async () => {
+	it("returns vector results resolved to the original source file path", async () => {
 		// Given
 		writeFakeMinSync(
 			JSON.stringify({
@@ -438,13 +438,10 @@ describe("MinSyncVectorMethod", () => {
 		// Then
 		expect(results).toHaveLength(1);
 		const result = requireValue(results[0], "first vector result");
-		expect(result.source).toBe("/docs/policy.txt");
+		expect(result.source).toBe(join(source, "policy.txt"));
 		expect(result.content).toBe("Parsed renewal policy with cancellation terms.");
 		expect(result.score).toBe(0.91);
-		expect(result.metadata.method).toBe("minsync");
-		expect(Object.keys(result.metadata)).toEqual(["method"]);
-		expect(JSON.stringify(results)).not.toContain(source);
-		expect(JSON.stringify(results)).not.toContain(root);
+		expect(result.metadata).toMatchObject({ method: "minsync", virtualPath: "/docs/policy.txt" });
 		expect(loggedCalls()).toContainEqual(
 			JSON.stringify({
 				args: ["query", "--format", "json", "-k", "2", "renewal cancellation"],
@@ -453,7 +450,7 @@ describe("MinSyncVectorMethod", () => {
 		);
 	});
 
-	it("maps real MinSync relative file paths back to virtual paths", async () => {
+	it("maps real MinSync relative file paths to original source files", async () => {
 		// Given
 		writeFakeMinSync(
 			JSON.stringify([
@@ -476,7 +473,8 @@ describe("MinSyncVectorMethod", () => {
 		// Then
 		expect(results).toHaveLength(1);
 		const result = requireValue(results[0], "relative path result");
-		expect(result.source).toBe("/docs/policy.txt");
+		expect(result.source).toBe(join(source, "policy.txt"));
+		expect(result.metadata.virtualPath).toBe("/docs/policy.txt");
 		expect(result.content).toBe("Relative path hit from MinSync.");
 	});
 

--- a/test/retrieval/bm25.test.ts
+++ b/test/retrieval/bm25.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -53,9 +53,9 @@ describe("BM25Method", () => {
 		expect(sync.engine).toBe("tantivy");
 		expect(method.describe().type).toBe("bm25");
 		expect(method.describe().status).toBe("active");
-		expect(results.map((result) => result.source)).toEqual(["/docs/many.txt", "/docs/few.txt"]);
+		expect(results.map((result) => result.source)).toEqual([join(docs, "many.txt"), join(docs, "few.txt")]);
 		expect(results[0]?.metadata.method).toBe("bm25");
-		expect(JSON.stringify(results)).not.toContain(root);
+		expect(results[0]?.metadata.virtualPath).toBe("/docs/many.txt");
 	});
 
 	it("continues native Tantivy scanning until scoped hits are found", async () => {
@@ -78,7 +78,7 @@ describe("BM25Method", () => {
 		const results = await method.retrieve("chargeback", { topK: 1, scope: "/docs/sub" });
 
 		expect(results).toHaveLength(1);
-		expect(results[0]?.source).toBe("/docs/sub/target.txt");
+		expect(results[0]?.source).toBe(join(docs, "sub", "target.txt"));
 	});
 
 	it("supports scoped retrieval, folder scope expansion, and stale-index removal", async () => {
@@ -93,7 +93,7 @@ describe("BM25Method", () => {
 		await method.sync();
 
 		const scoped = await method.retrieve("alpha", { topK: 10, scope: "/docs/sub" });
-		expect(scoped.map((result) => result.source)).toEqual(["/docs/sub/nested.txt"]);
+		expect(scoped.map((result) => result.source)).toEqual([join(docs, "sub", "nested.txt")]);
 
 		rmSync(join(docs, "sub", "nested.txt"));
 		await refreshMirrors();
@@ -140,7 +140,7 @@ describe("AutoRAG BM25 integration", () => {
 		const results = await agent.retrieve("chargeback", { topK: 1 });
 
 		expect(agent.getMethodRegistry().getByType("bm25")).toHaveLength(1);
-		expect(results[0]?.source).toBe("/docs/guide.txt");
+		expect(results[0]?.source).toBe(realpathSync(join(docs, "guide.txt")));
 		expect(results[0]?.metadata.method).toBe("bm25");
 		expect(agent.getSystemPrompt()).toContain("search_bm25_documents");
 	});
@@ -160,7 +160,7 @@ describe("AutoRAG BM25 integration", () => {
 		const result = await tool.execute("tool-call", { query: "chargeback", topK: 1, scope: "/docs/sub" });
 
 		expect(result.details).toMatchObject({ method: "bm25", resultCount: 1, readiness: "degraded_fallback" });
-		expect(result.details?.sources).toEqual(["/docs/sub/guide.txt"]);
+		expect(result.details?.sources).toEqual([join(docs, "sub", "guide.txt")]);
 		expect(result.content[0]?.type).toBe("text");
 	});
 
@@ -183,7 +183,7 @@ describe("AutoRAG BM25 integration", () => {
 		const result = await tool.execute("tool-scope", { query: "chargeback", scope: join(docs, "sub") });
 
 		expect(normalizeScope).toHaveBeenCalledWith(join(docs, "sub"));
-		expect(result.details.sources).toEqual(["/docs/sub/guide.txt"]);
+		expect(result.details.sources).toEqual([join(docs, "sub", "guide.txt")]);
 	});
 
 	it("preserves coded scope errors at the BM25 tool boundary", async () => {


### PR DESCRIPTION
## Summary
- return original absolute source paths for local MinSync and BM25 hits
- preserve virtual paths in `metadata.virtualPath` for scope/index identity
- update retrieval, integration, and live QA expectations to verify returned paths can open the original file

## Issue
Closes #1471

## Validation
- `make test` (84 test files passed)
- focused MinSync/BM25/live integration tests (51 passed)
- `bunx biome check` on changed files
- `bun run typecheck`
- `bun run build`

The installed `minsync` command on this workstation is unavailable because its Python module is missing, so live QA used the repository MinSync CLI fixture through the real AutoRAG integration surface.