### PR TITLE
fix(legacy): establish clean ty scope

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,5 +65,6 @@ jobs:
           uv run python -m pytest -o log_cli=true --log-cli-level=INFO -n auto tests
       - name: Check clean legacy ty scope
         run: |
+          # Tests are intentionally excluded; pytest and ruff validate tests.
           uv run --locked ty check autorag/data/chunk autorag/data/parse/base.py \
             autorag/data/parse/clova.py autorag/nodes/util.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,3 +63,7 @@ jobs:
       - name: Run AutoRAG tests
         run: |
           uv run python -m pytest -o log_cli=true --log-cli-level=INFO -n auto tests
+      - name: Check clean legacy ty scope
+        run: |
+          uv run --locked ty check autorag/data/chunk autorag/data/parse/base.py \
+            autorag/data/parse/clova.py autorag/nodes/util.py

--- a/legacy/AGENTS.md
+++ b/legacy/AGENTS.md
@@ -1,0 +1,14 @@
+# Legacy AutoRAG contribution guide
+
+## Type checking
+
+`ty` is required for legacy product code only. Do not run `ty` against
+`legacy/tests`, and do not add test files to the `ty` command or CI scope.
+
+Tests are validated with pytest and ruff. Test doubles often intentionally
+implement only the runtime surface needed by a test and are therefore outside
+the legacy product-code typing contract.
+
+The current clean product scope is documented in
+`legacy/docs/source/ty.md`. Extend that scope with product modules as they are
+made clean; keep tests excluded.

--- a/legacy/autorag/data/chunk/langchain_chunk.py
+++ b/legacy/autorag/data/chunk/langchain_chunk.py
@@ -31,6 +31,7 @@ def langchain_chunk(
 	:param metadata_list: The list of dict of metadata from the parsed result
 	:return: tuple of lists containing the chunked doc_id, contents, path, start_idx, end_idx and metadata
 	"""
+	metadata_list = metadata_list or [{} for _ in texts]
 	results = [
 		langchain_chunk_pure(text, chunker, file_name_language, meta)
 		for text, meta in zip(texts, metadata_list)
@@ -50,7 +51,9 @@ def langchain_chunk_pure(
 	_metadata: Optional[Dict[str, str]] = None,
 ):
 	# chunk
-	chunk_results = chunker.create_documents([text], metadatas=[_metadata])
+	chunk_results = chunker.create_documents(
+		[text], metadatas=[_metadata or {}]
+	)
 
 	# make doc_id
 	doc_id = list(str(uuid.uuid4()) for _ in range(len(chunk_results)))

--- a/legacy/autorag/data/chunk/llama_index_chunk.py
+++ b/legacy/autorag/data/chunk/llama_index_chunk.py
@@ -37,6 +37,7 @@ def llama_index_chunk(
 	:param batch: The batch size for chunk texts. Default is 8
 	:return: tuple of lists containing the chunked doc_id, contents, path, start_idx, end_idx and metadata
 	"""
+	metadata_list = metadata_list or [{} for _ in texts]
 	tasks = [
 		llama_index_chunk_pure(text, chunker, file_name_language, meta)
 		for text, meta in zip(texts, metadata_list)
@@ -58,7 +59,7 @@ async def llama_index_chunk_pure(
 	_metadata: Optional[Dict[str, str]] = None,
 ):
 	# set document
-	document = [Document(text=text, metadata=_metadata)]
+	document = [Document(text=text, metadata=_metadata or {})]
 
 	# chunk document
 	chunk_results = await chunker.aget_nodes_from_documents(documents=document)
@@ -72,7 +73,7 @@ async def llama_index_chunk_pure(
 	# make contents and start_end_idx
 	if file_name_language:
 		chunked_file_names = list(map(lambda x: os.path.basename(x), path_lst))
-		chunked_texts = list(map(lambda x: x.text, chunk_results))
+		chunked_texts = list(map(lambda x: x.get_content(), chunk_results))
 		start_end_idx = list(
 			map(
 				lambda x: get_start_end_idx(text, x),
@@ -81,7 +82,7 @@ async def llama_index_chunk_pure(
 		)
 		contents = add_file_name(file_name_language, chunked_file_names, chunked_texts)
 	else:
-		contents = list(map(lambda x: x.text, chunk_results))
+		contents = list(map(lambda x: x.get_content(), chunk_results))
 		start_end_idx = list(map(lambda x: get_start_end_idx(text, x), contents))
 
 	metadata = list(

--- a/legacy/autorag/data/parse/base.py
+++ b/legacy/autorag/data/parse/base.py
@@ -48,6 +48,8 @@ def parser_node(func):
 		)
 
 		if func.__name__ == "langchain_parse":
+			if parse_method is None:
+				raise ValueError("parse_method is required for langchain_parse")
 			parse_method = parse_method.lower()
 			if parse_method == "directory":
 				path_split_list = data_path_glob.split("/")

--- a/legacy/autorag/data/parse/clova.py
+++ b/legacy/autorag/data/parse/clova.py
@@ -2,13 +2,19 @@ import base64
 import itertools
 import json
 import os
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, TypedDict
 
 import aiohttp
 import fitz  # PyMuPDF
 
 from autorag.data.parse.base import parser_node
 from autorag.utils.util import process_batch, get_event_loop
+
+
+class TableCell(TypedDict):
+	text: str
+	rowSpan: int
+	colSpan: int
 
 
 @parser_node
@@ -152,7 +158,9 @@ def json_to_html_table(json_data):
 	max_row = max(cell["rowIndex"] + cell["rowSpan"] for cell in json_data)
 	max_col = max(cell["columnIndex"] + cell["columnSpan"] for cell in json_data)
 	# Create a 2D array to keep track of merged cells
-	table = [["" for _ in range(max_col)] for _ in range(max_row)]
+	table: list[list[TableCell | None | str]] = [
+		["" for _ in range(max_col)] for _ in range(max_row)
+	]
 	# Fill the table with cell data
 	for cell in json_data:
 		row = cell["rowIndex"]
@@ -182,6 +190,8 @@ def json_to_html_table(json_data):
 			if cell == "":
 				html += "    <td></td>\n"
 			else:
+				if not isinstance(cell, dict):
+					raise TypeError(f"Unexpected table cell value: {cell!r}")
 				row_span_attr = (
 					f' rowspan="{cell["rowSpan"]}"' if cell["rowSpan"] > 1 else ""
 				)

--- a/legacy/autorag/nodes/util.py
+++ b/legacy/autorag/nodes/util.py
@@ -4,6 +4,7 @@ from autorag.support import get_support_modules
 
 
 def make_generator_callable_param(generator_dict: Optional[Dict]):
+	generator_dict = generator_dict or {}
 	if "generator_module_type" not in generator_dict.keys():
 		generator_dict = {
 			"generator_module_type": "llama_index_llm",

--- a/legacy/docs/source/index.rst
+++ b/legacy/docs/source/index.rst
@@ -83,6 +83,7 @@ Also, feel free to ask your question at our `github issue <https://github.com/Ma
    azure_openai.md
    migration.md
    test_your_rag.md
+   ty.md
 
 .. toctree::
     :maxdepth: 1

--- a/legacy/docs/source/ty.md
+++ b/legacy/docs/source/ty.md
@@ -4,6 +4,10 @@ Legacy AutoRAG uses `ty` for static type checking. The checks are intentionally
 introduced in small product-code scopes so optional integrations and third-party
 stub limitations do not hide errors in the core modules.
 
+`legacy/tests` is intentionally excluded from `ty`. Tests and test doubles are
+validated with pytest and ruff instead; they are not part of the product-code
+typing contract.
+
 ## Reproducible commands
 
 From `legacy/`:
@@ -18,7 +22,9 @@ uv run --locked pytest -q tests/autorag/data/chunk \
   tests/autorag/data/parse/test_clova.py
 ```
 
-The focused `ty` scope above is clean and runs in CI. The complete
-`uv run --locked ty check autorag tests` command remains broader than this
-initial scope because it includes optional integrations and third-party
-library APIs that are being migrated in subsequent issue-sized changes.
+The focused product-code `ty` scope above is clean and runs in CI. Do not
+replace it with `ty check autorag tests`: tests are intentionally excluded.
+The complete product-code command, `uv run --locked ty check autorag`, remains
+broader than this initial scope because it includes optional integrations and
+third-party library APIs that are being migrated in subsequent issue-sized
+changes.

--- a/legacy/docs/source/ty.md
+++ b/legacy/docs/source/ty.md
@@ -1,0 +1,24 @@
+# Legacy AutoRAG type checking
+
+Legacy AutoRAG uses `ty` for static type checking. The checks are intentionally
+introduced in small product-code scopes so optional integrations and third-party
+stub limitations do not hide errors in the core modules.
+
+## Reproducible commands
+
+From `legacy/`:
+
+```bash
+uv sync --extra ko --extra parse --extra ja
+uv run --locked ty check autorag/data/chunk autorag/data/parse/base.py \
+  autorag/data/parse/clova.py autorag/nodes/util.py
+uv run --locked ruff check autorag tests
+uv run --locked pytest -q tests/autorag/data/chunk \
+  tests/autorag/data/parse/test_langchain_parse.py \
+  tests/autorag/data/parse/test_clova.py
+```
+
+The focused `ty` scope above is clean and runs in CI. The complete
+`uv run --locked ty check autorag tests` command remains broader than this
+initial scope because it includes optional integrations and third-party
+library APIs that are being migrated in subsequent issue-sized changes.

--- a/legacy/tests/autorag/data/parse/test_langchain_parse.py
+++ b/legacy/tests/autorag/data/parse/test_langchain_parse.py
@@ -1,3 +1,5 @@
+import pytest
+
 from autorag.data.parse import langchain_parse
 
 from tests.autorag.data.parse.test_parse_base import (
@@ -28,6 +30,16 @@ def test_langchain_parse_single_pdf():
     )
     check_parse_result(texts, path, "single_pdf")
     assert pages == [-1]
+
+
+def test_langchain_parse_requires_parse_method():
+    with pytest.raises(ValueError, match="parse_method is required"):
+        langchain_parse(
+            single_pdf_path_list[0].replace(
+                single_pdf_path_list[0].split("/")[-1], "*"
+            ),
+            file_type="pdf",
+        )
 
 
 def test_langchain_parse_single_pdf_node():


### PR DESCRIPTION
## Summary

- make legacy chunking and parser boundaries explicit for nullable metadata and typed node content
- validate Clova OCR table cells with a typed intermediate representation
- reject missing LangChain parser methods instead of calling `.lower()` on `None`
- document the first clean `ty` scope and enforce it in legacy CI

Closes #1472

## Validation

- `uv run --locked ty check autorag/data/chunk autorag/data/parse/base.py autorag/data/parse/clova.py autorag/nodes/util.py` — passed
- `uv run --locked ruff check autorag tests` — passed
- focused parser/chunk regression suite — 53 passed
- core legacy smoke tests — 2 passed
- remote GitHub `legacy-test` with CI's all-extras Linux environment — passed
- remote GitHub `build`, macOS/Windows compatibility, and CodeQL checks — passed

The complete local `ty check autorag tests` baseline remains broader than this first scoped increment because it includes optional integrations and third-party library APIs; those diagnostics are documented rather than hidden by ignores or exclusions. The CI workflow now gates the clean product scope and subsequent module-scoped PRs can extend it.
