### PR TITLE
feat: route BM25 retrieval through MinSync 0.4

### DIFF
--- a/scripts/run-test-files.mjs
+++ b/scripts/run-test-files.mjs
@@ -18,15 +18,11 @@ function collectTestFiles(directory) {
 }
 
 const testFiles = collectTestFiles(testRoot).sort();
-for (const testFile of testFiles) {
-	const displayPath = relative(root, testFile);
-	console.log(`\n=== ${displayPath} ===`);
-	const result = spawnSync(process.execPath, [vitest, "run", testFile], {
-		cwd: root,
-		stdio: "inherit",
-	});
-	if (result.error) throw result.error;
-	if (result.status !== 0) process.exit(result.status ?? 1);
-}
+const result = spawnSync(process.platform === "win32" ? "bun.exe" : "bun", [vitest, "run", ...testFiles], {
+	cwd: root,
+	stdio: "inherit",
+});
+if (result.error) throw result.error;
+if (result.status !== 0) process.exit(result.status ?? 1);
 
 console.log(`\nAll ${testFiles.length} test files passed.`);

--- a/scripts/run-test-files.mjs
+++ b/scripts/run-test-files.mjs
@@ -18,11 +18,15 @@ function collectTestFiles(directory) {
 }
 
 const testFiles = collectTestFiles(testRoot).sort();
-const result = spawnSync(process.platform === "win32" ? "bun.exe" : "bun", [vitest, "run", ...testFiles], {
-	cwd: root,
-	stdio: "inherit",
-});
-if (result.error) throw result.error;
-if (result.status !== 0) process.exit(result.status ?? 1);
+for (const testFile of testFiles) {
+	const displayPath = relative(root, testFile);
+	console.log(`\n=== ${displayPath} ===`);
+	const result = spawnSync(process.execPath, [vitest, "run", testFile], {
+		cwd: root,
+		stdio: "inherit",
+	});
+	if (result.error) throw result.error;
+	if (result.status !== 0) process.exit(result.status ?? 1);
+}
 
 console.log(`\nAll ${testFiles.length} test files passed.`);

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -310,7 +310,7 @@ export class AutoRAGAgent {
 			this.methodRegistry.register(this.minSyncMethod);
 		}
 		if (options.bm25 !== false) {
-			const bm25Opts = options.bm25 ?? { autoInstall: false };
+			const bm25Opts = { autoInstall: false, ...(options.bm25 ?? {}) };
 			this.bm25Method =
 				options.minSync === false || hasLegacyBM25Options(bm25Opts)
 					? new BM25Method({ ...bm25Opts, root: this.workspaceProjectRoot } as BM25MethodOptions)

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -312,7 +312,7 @@ export class AutoRAGAgent {
 		if (options.bm25 !== false) {
 			const bm25Opts = options.bm25 ?? {};
 			this.bm25Method =
-				options.minSync === false
+				options.minSync === false || hasLegacyBM25Options(bm25Opts)
 					? new BM25Method({ ...bm25Opts, root: this.workspaceProjectRoot } as BM25MethodOptions)
 					: new MinSyncBM25Method({ ...bm25Opts, root: this.workspaceProjectRoot } as MinSyncBM25MethodOptions);
 			this.methodRegistry.register(this.bm25Method);
@@ -1437,6 +1437,10 @@ export class AutoRAGAgent {
 			this.datasourceVirtualScopePrefixes,
 		);
 	}
+}
+
+function hasLegacyBM25Options(options: object): boolean {
+	return ["indexPath", "fallback", "forceEngine", "importBinding"].some((key) => Object.hasOwn(options, key));
 }
 
 function toSearchDiagnostic(diagnostic: ParsedMirrorDiagnostic): SearchDocumentDiagnostic {

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -310,7 +310,7 @@ export class AutoRAGAgent {
 			this.methodRegistry.register(this.minSyncMethod);
 		}
 		if (options.bm25 !== false) {
-			const bm25Opts = options.bm25 ?? {};
+			const bm25Opts = options.bm25 ?? { autoInstall: false };
 			this.bm25Method =
 				options.minSync === false || hasLegacyBM25Options(bm25Opts)
 					? new BM25Method({ ...bm25Opts, root: this.workspaceProjectRoot } as BM25MethodOptions)

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -305,7 +305,7 @@ export class AutoRAGAgent {
 		this.excludeExactDuplicates = options.excludeExactDuplicates ?? true;
 
 		if (options.minSync !== false) {
-			const minSyncOpts = options.minSync ?? { autoInstall: true };
+			const minSyncOpts = options.minSync ?? { autoInstall: false };
 			this.minSyncMethod = new MinSyncVectorMethod({ ...minSyncOpts, root: this.workspaceProjectRoot });
 			this.methodRegistry.register(this.minSyncMethod);
 		}

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -31,7 +31,13 @@ import { createCheckMemoryTool } from "../memory/check-memory-tool.ts";
 import type { ResultFeedback } from "../memory/memory.ts";
 import { RetrievalMemory } from "../memory/memory.ts";
 import { renderMemoryContext } from "../memory/renderer.ts";
-import { type MinSyncSyncResult, MinSyncVectorMethod, type MinSyncVectorMethodOptions } from "../minsync/index.ts";
+import {
+	MinSyncBM25Method,
+	type MinSyncBM25MethodOptions,
+	type MinSyncSyncResult,
+	MinSyncVectorMethod,
+	type MinSyncVectorMethodOptions,
+} from "../minsync/index.ts";
 import { PARSED_MIRROR_SUBDIR } from "../mirror/paths.ts";
 import {
 	detectMirrorStaleness,
@@ -194,7 +200,7 @@ export interface AutoRAGAgentOptions {
 	workspacePath?: string;
 	tools?: AgentTool[];
 	minSync?: Omit<MinSyncVectorMethodOptions, "root"> | false;
-	bm25?: Omit<BM25MethodOptions, "root"> | false;
+	bm25?: Omit<MinSyncBM25MethodOptions, "root"> | Omit<BM25MethodOptions, "root"> | false;
 	jikji?: JikjiOptions;
 	autoRefresh?: AutoRefreshOptions;
 	parserOptions?: DefaultParserRegistryOptions;
@@ -262,7 +268,7 @@ export class AutoRAGAgent {
 	private readonly datasourceFilter = new DatasourceResultFilter();
 
 	private readonly minSyncMethod: MinSyncVectorMethod | undefined;
-	private readonly bm25Method: BM25Method | undefined;
+	private readonly bm25Method: MinSyncBM25Method | BM25Method | undefined;
 	private readonly jikjiClient: JikjiClient | undefined;
 	private readonly datasourceSkills: readonly DatasourceSkill[];
 	private readonly datasourceAccessOptions: DatasourceAccessContextOptions;
@@ -305,7 +311,10 @@ export class AutoRAGAgent {
 		}
 		if (options.bm25 !== false) {
 			const bm25Opts = options.bm25 ?? {};
-			this.bm25Method = new BM25Method({ ...bm25Opts, root: this.workspaceProjectRoot });
+			this.bm25Method =
+				options.minSync === false
+					? new BM25Method({ ...bm25Opts, root: this.workspaceProjectRoot } as BM25MethodOptions)
+					: new MinSyncBM25Method({ ...bm25Opts, root: this.workspaceProjectRoot } as MinSyncBM25MethodOptions);
 			this.methodRegistry.register(this.bm25Method);
 		}
 		for (const skill of this.datasourceSkills) {
@@ -846,8 +855,8 @@ export class AutoRAGAgent {
 		};
 		try {
 			const summary = needsParsed ? await this.syncParsedMirrors(force) : await this.scanMirrorStaleness();
-			const bm25 = wants("bm25") ? await this.syncBM25() : undefined;
 			const minsync = wants("minsync") ? await this.syncMinSync() : undefined;
+			const bm25 = wants("bm25") ? await this.syncBM25(minsync) : undefined;
 			const datasources = wants("datasources") ? await this.indexDatasources() : [];
 			const jikji = wants("jikji") ? await this.executeJikjiPrepare() : undefined;
 			this.retrievalScopeBindings = buildRetrievalScopeBindings(
@@ -1070,8 +1079,12 @@ export class AutoRAGAgent {
 		return { excluded };
 	}
 
-	async syncBM25(): Promise<BM25SyncResult | undefined> {
-		return this.bm25Method?.sync();
+	async syncBM25(minsync?: MinSyncSyncResult): Promise<BM25SyncResult | undefined> {
+		if (this.bm25Method === undefined) return undefined;
+		if (this.bm25Method instanceof MinSyncBM25Method) {
+			return this.bm25Method.syncFromMinSync(minsync ?? (await this.bm25Method.sync()));
+		}
+		return this.bm25Method.sync();
 	}
 
 	async syncMinSync(): Promise<MinSyncSyncResult | undefined> {

--- a/src/agent/search-bm25-tool.ts
+++ b/src/agent/search-bm25-tool.ts
@@ -1,6 +1,6 @@
 import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 import { Type } from "typebox";
-import type { BM25Method, BM25Status } from "../retrieval/methods/bm25.ts";
+import type { BM25Status } from "../retrieval/methods/bm25.ts";
 import { BM25UnavailableError } from "../retrieval/methods/bm25.ts";
 import type { RetrievalResult } from "../retrieval/types.ts";
 
@@ -20,15 +20,20 @@ export interface SearchBM25DocumentsDetails {
 	readonly engine: BM25Status["engine"];
 }
 
+export interface BM25SearchMethod {
+	getStatus(): BM25Status;
+	retrieve(query: string, options: { topK?: number; scope?: string }): Promise<RetrievalResult[]>;
+}
+
 export function createSearchBM25DocumentsTool(
-	getMethod: () => BM25Method | undefined,
+	getMethod: () => BM25SearchMethod | undefined,
 	resolveScope: (scope: string | undefined) => string | undefined = (scope) => scope,
 ): AgentTool<typeof searchBM25Schema, SearchBM25DocumentsDetails> {
 	return {
 		name: SEARCH_BM25_DOCUMENTS_TOOL_NAME,
 		label: "Search BM25 Documents",
 		description:
-			"Search parsed document mirrors with lexical BM25 ranking. Use for exact terms, repeated terms, headings, identifiers, and folder-scoped document search.",
+			"Search parsed document mirrors with MinSync 0.4.0 lexical BM25 ranking. Use for exact terms, repeated terms, headings, identifiers, and folder-scoped document search.",
 		parameters: searchBM25Schema,
 		async execute(_toolCallId, params): Promise<AgentToolResult<SearchBM25DocumentsDetails>> {
 			const method = getMethod();

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -30,7 +30,7 @@ export function buildSystemPrompt(config: SystemPromptConfig): string {
 		),
 		toolLine(config, "jikji_find", "optional local discovery through Jikji answer packs"),
 		toolLine(config, "search_all_documents", "fan out across every configured retrieval method and merge results"),
-		toolLine(config, "search_bm25_documents", "lexical BM25 search over parsed document mirrors"),
+		toolLine(config, "search_bm25_documents", "MinSync-backed lexical BM25 search over parsed document mirrors"),
 		toolLine(config, "search_minsync_documents", "semantic MinSync search over parsed document mirrors"),
 		toolLine(
 			config,
@@ -91,7 +91,7 @@ Your job is to retrieve candidates, read the relevant source material directly, 
 ## Workflow
 
 1. **PLAN** — Understand the query, inspect retrieval memory when useful, and choose suitable retrieval methods.
-2. **RETRIEVE** — Use BM25, MinSync, combined retrieval, Jikji, datasource search, or direct filesystem discovery as appropriate.
+2. **RETRIEVE** — Use MinSync BM25, MinSync vector, combined retrieval, Jikji, datasource search, or direct filesystem discovery as appropriate.
 3. **READ** — Use \`bash\` to open and verify relevant local files. Do not curate from search snippets alone when source files are available.
 4. **JUDGE** — Evaluate relevance, sufficiency, conflicts, uncertainty, and temporal context.
 5. **CURATE** — Produce concise numbered knowledge units grounded in source evidence.
@@ -105,7 +105,7 @@ ${noSearchTools}
 
 - Start with the most specific exact term, identifier, filename glob, or regex that preserves the query intent.
 - Use \`search_all_documents\` when multiple configured retrieval methods can help.
-- Use BM25 for exact terminology and MinSync for semantic similarity.
+- Use MinSync-backed BM25 for exact terminology and MinSync vector search for semantic similarity.
 - Use \`bash\` with find/grep to discover files and cat/head/sed to read enough surrounding context.
 - If results are empty, follow this Fallback Chain: simplify the query, broaden file discovery, try synonyms, then inspect likely directories.
 - Cross-check important claims against the original source and preserve real source paths.

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -3,17 +3,16 @@ import { join, resolve, sep } from "node:path";
 import { AutoRAGAgent, type AutoRAGRefreshResult, type RefreshMethod } from "../../agent/agent.ts";
 import { MINSYNC_SUBDIR } from "../../minsync/paths.ts";
 import { PARSED_MIRROR_SUBDIR } from "../../mirror/paths.ts";
-import { BM25_SUBDIR } from "../../retrieval/methods/bm25.ts";
 import { buildAgentOptions, type CliConfig, resolveConfig } from "../config.ts";
 import { renderError, renderIndex } from "../output.ts";
 import { parseMethodFlag } from "./refresh.ts";
 import type { CommandContext } from "./types.ts";
 
-const ALL_RESET_TARGETS = [PARSED_MIRROR_SUBDIR, BM25_SUBDIR, MINSYNC_SUBDIR] as const;
-const ALL_RESET_TARGET_NAMES = ["parsed", "bm25", "minsync"] as const;
+const ALL_RESET_TARGETS = [PARSED_MIRROR_SUBDIR, MINSYNC_SUBDIR] as const;
+const ALL_RESET_TARGET_NAMES = ["parsed", "minsync"] as const;
 
 /**
- * Run the `autorag index` command. `reset` removes the parsed mirror, BM25,
+ * Run the `autorag index` command. `reset` removes the parsed mirror
  * and MinSync index directories under `.autorag` (preserving `bin`,
  * `datasources`, and the memory file). `rebuild` resets then re-runs a forced
  * refresh. Returns 0 on success, 2 for usage/decline errors, 1 for runtime
@@ -112,7 +111,7 @@ export async function runIndex(ctx: CommandContext): Promise<number> {
  * all three index dirs are reset and a full refresh runs.
  *
  * Mapping:
- * - `bm25` → reset BM25_SUBDIR, refresh with bm25 (+ parsed, since bm25 needs it)
+ * - `bm25` → refresh with bm25 (+ parsed, since MinSync BM25 needs it)
  * - `minsync` → reset MINSYNC_SUBDIR, refresh with minsync (+ parsed)
  * - `parsed` → reset PARSED_MIRROR_SUBDIR, refresh with parsed only
  * - `all` or undefined → all three dirs + full refresh
@@ -139,8 +138,7 @@ function resolveResetScope(methods: readonly RefreshMethod[] | undefined): {
 			subdirs.push(PARSED_MIRROR_SUBDIR);
 			names.push("parsed");
 		} else if (m === "bm25") {
-			subdirs.push(BM25_SUBDIR);
-			names.push("bm25");
+			// BM25 is a MinSync mode and has no separate index directory.
 		} else if (m === "minsync") {
 			subdirs.push(MINSYNC_SUBDIR);
 			names.push("minsync");
@@ -148,8 +146,8 @@ function resolveResetScope(methods: readonly RefreshMethod[] | undefined): {
 		// datasources/jikji have no reset dir but are valid refresh methods.
 	}
 	return {
-		targetNames: names.length > 0 ? names : ALL_RESET_TARGET_NAMES,
-		targetSubdirs: subdirs.length > 0 ? subdirs : ALL_RESET_TARGETS,
+		targetNames: names,
+		targetSubdirs: subdirs,
 		refreshMethods: refresh,
 	};
 }

--- a/src/minsync/client.ts
+++ b/src/minsync/client.ts
@@ -10,6 +10,8 @@ export interface MinSyncClientOptions {
 	readonly embedder?: MinSyncEmbedderConfig;
 }
 
+export type MinSyncQueryMode = "vector" | "bm25" | "hybrid";
+
 const API_KEY_ENV_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 export class MinSyncClient {
@@ -92,11 +94,11 @@ export class MinSyncClient {
 		return { ok: true, synced: readSyncedCount(result.stdout), workspacePath: this.workspacePath };
 	}
 
-	async query(text: string, topK: number): Promise<readonly MinSyncQueryHit[]> {
+	async query(text: string, topK: number, mode: MinSyncQueryMode = "vector"): Promise<readonly MinSyncQueryHit[]> {
 		if (!existsSync(this.binaryPath)) return [];
 		const result = await spawnProcess(
 			this.binaryPath,
-			["query", "--format", "json", "-k", String(topK), text],
+			["query", "--format", "json", "-k", String(topK), "--mode", mode, text],
 			this.workspacePath,
 		);
 		if (!result.ok) return [];

--- a/src/minsync/index.ts
+++ b/src/minsync/index.ts
@@ -1,4 +1,4 @@
-export { MinSyncClient, type MinSyncClientOptions } from "./client.ts";
+export { MinSyncClient, type MinSyncClientOptions, type MinSyncQueryMode } from "./client.ts";
 export {
 	MINSYNC_CONFIG_DIR,
 	MINSYNC_CONFIG_FILE,
@@ -11,12 +11,18 @@ export {
 	executableName,
 	fetchLatestMinSyncRelease,
 	type InstalledMinSyncBinary,
+	MINSYNC_VERSION,
 	type MinSyncRelease,
 	type MinSyncReleaseAsset,
 	MinSyncReleaseError,
 	selectReleaseAsset,
 } from "./installer.ts";
-export { MinSyncVectorMethod, type MinSyncVectorMethodOptions } from "./method.ts";
+export {
+	MinSyncBM25Method,
+	type MinSyncBM25MethodOptions,
+	MinSyncVectorMethod,
+	type MinSyncVectorMethodOptions,
+} from "./method.ts";
 export { MINSYNC_FILES_SUBDIR, MINSYNC_SUBDIR, minSyncDocumentPath, minSyncWorkspaceRoot } from "./paths.ts";
 export type { MinSyncEmbedderConfig, MinSyncOptions, MinSyncQueryHit, MinSyncSyncResult } from "./types.ts";
 export {

--- a/src/minsync/installer.ts
+++ b/src/minsync/installer.ts
@@ -63,6 +63,7 @@ async function installMinSyncFromCargo(
 	destination: string,
 ): Promise<InstalledMinSyncBinary> {
 	const cargoRoot = join(options.root, ".autorag", "minsync-cargo");
+	mkdirSync(dirname(destination), { recursive: true });
 	mkdirSync(cargoRoot, { recursive: true });
 	const result = await spawnProcess(
 		"cargo",

--- a/src/minsync/installer.ts
+++ b/src/minsync/installer.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { createWriteStream, existsSync, mkdirSync, renameSync, rmSync } from "node:fs";
+import { copyFileSync, createWriteStream, existsSync, mkdirSync, renameSync, rmSync } from "node:fs";
 import { chmod, mkdtemp } from "node:fs/promises";
 import { get } from "node:https";
 import { tmpdir } from "node:os";
@@ -9,6 +9,7 @@ import { spawnProcess } from "./process.ts";
 
 const LATEST_RELEASE_URL = "https://api.github.com/repos/NomaDamas/MinSync/releases/latest";
 const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/;
+export const MINSYNC_VERSION = "0.4.0";
 
 export interface MinSyncReleaseAsset {
 	readonly name: string;
@@ -37,15 +38,46 @@ export interface EnsureMinSyncBinaryOptions {
 export async function ensureMinSyncBinary(options: EnsureMinSyncBinaryOptions): Promise<InstalledMinSyncBinary> {
 	const binaryPath = join(options.root, ".autorag", "bin", executableName(options.platform ?? process.platform));
 	if (existsSync(binaryPath)) return { binaryPath, version: "cached" };
-	const releaseProvider = options.releaseProvider ?? fetchLatestMinSyncRelease;
+	if (options.releaseProvider === undefined) {
+		return installMinSyncFromCargo(options, binaryPath);
+	}
+	const releaseProvider = options.releaseProvider;
 	const release = await releaseProvider();
-	const asset = selectReleaseAsset(release, options.platform ?? process.platform, options.arch ?? process.arch);
+	let asset: MinSyncReleaseAsset;
+	try {
+		asset = selectReleaseAsset(release, options.platform ?? process.platform, options.arch ?? process.arch);
+	} catch (error) {
+		if (!(error instanceof MinSyncReleaseError) || !error.message.startsWith("No MinSync")) throw error;
+		return installMinSyncFromCargo(options, binaryPath);
+	}
 	requireSha256(asset);
 	const assetInstaller = options.assetInstaller ?? installReleaseAsset;
 	mkdirSync(dirname(binaryPath), { recursive: true });
 	await assetInstaller(asset, binaryPath);
 	await chmod(binaryPath, 0o755);
 	return { binaryPath, version: release.tagName };
+}
+
+async function installMinSyncFromCargo(
+	options: EnsureMinSyncBinaryOptions,
+	destination: string,
+): Promise<InstalledMinSyncBinary> {
+	const cargoRoot = join(options.root, ".autorag", "minsync-cargo");
+	mkdirSync(cargoRoot, { recursive: true });
+	const result = await spawnProcess(
+		"cargo",
+		["install", "minsync", "--version", MINSYNC_VERSION, "--locked", "--root", cargoRoot],
+		options.root,
+	);
+	if (!result.ok) {
+		throw new MinSyncReleaseError(result.stderr || `Could not install MinSync ${MINSYNC_VERSION} from crates.io`);
+	}
+	const installedBinary = join(cargoRoot, "bin", executableName(options.platform ?? process.platform));
+	if (!existsSync(installedBinary)) {
+		throw new MinSyncReleaseError(`Cargo did not produce the MinSync ${MINSYNC_VERSION} binary`);
+	}
+	copyFileSync(installedBinary, destination);
+	return { binaryPath: destination, version: MINSYNC_VERSION };
 }
 
 export async function fetchLatestMinSyncRelease(): Promise<MinSyncRelease> {

--- a/src/minsync/method.ts
+++ b/src/minsync/method.ts
@@ -1,5 +1,6 @@
 import { accessSync, constants, existsSync } from "node:fs";
 import { basename, delimiter, join } from "node:path";
+import type { BM25Status, BM25SyncResult } from "../retrieval/methods/bm25.ts";
 import { matchesVirtualPathScope } from "../retrieval/scope.ts";
 import type {
 	RetrievalMethod,
@@ -7,6 +8,7 @@ import type {
 	RetrievalOptions,
 	RetrievalResult,
 } from "../retrieval/types.ts";
+import type { MinSyncQueryMode } from "./client.ts";
 import { MinSyncClient } from "./client.ts";
 import { type EnsureMinSyncBinaryOptions, ensureMinSyncBinary, executableName } from "./installer.ts";
 import { minSyncWorkspaceRoot } from "./paths.ts";
@@ -20,6 +22,18 @@ export interface MinSyncVectorMethodOptions {
 	readonly installer?: Omit<EnsureMinSyncBinaryOptions, "root">;
 	readonly autoInstall?: boolean;
 	readonly embedder?: MinSyncEmbedderConfig;
+	readonly mode?: MinSyncQueryMode;
+}
+
+export interface MinSyncBM25MethodOptions extends Omit<MinSyncVectorMethodOptions, "mode"> {
+	/** @deprecated Ignored; MinSync owns the index location. */
+	readonly indexPath?: string;
+	/** @deprecated Ignored; MinSync owns fallback behavior. */
+	readonly fallback?: "typescript" | "disabled";
+	/** @deprecated Ignored; MinSync owns the search engine. */
+	readonly forceEngine?: "tantivy" | "typescript-fallback";
+	/** @deprecated Ignored; native Tantivy injection is no longer supported. */
+	readonly importBinding?: () => Promise<unknown>;
 }
 
 /** Degrade result returned when no binary can be resolved. */
@@ -52,6 +66,7 @@ export class MinSyncVectorMethod implements RetrievalMethod {
 	private readonly installer: Omit<EnsureMinSyncBinaryOptions, "root"> | undefined;
 	private readonly autoInstall: boolean;
 	private readonly embedder: MinSyncEmbedderConfig | undefined;
+	private readonly mode: MinSyncQueryMode;
 
 	constructor(options: MinSyncVectorMethodOptions) {
 		this.root = options.root;
@@ -60,15 +75,26 @@ export class MinSyncVectorMethod implements RetrievalMethod {
 		this.installer = options.installer;
 		this.autoInstall = options.autoInstall ?? true;
 		this.embedder = options.embedder;
+		this.mode = options.mode ?? "vector";
 	}
 
 	describe(): RetrievalMethodDescriptor {
 		return {
 			name: "minsync",
-			type: "vector",
-			description: "MinSync-backed semantic vector retrieval over parsed markdown mirrors",
+			type: this.mode === "bm25" ? "bm25" : this.mode === "hybrid" ? "hybrid" : "vector",
+			description:
+				this.mode === "bm25"
+					? "MinSync-backed BM25 lexical retrieval over parsed markdown mirrors"
+					: this.mode === "hybrid"
+						? "MinSync-backed hybrid retrieval over parsed markdown mirrors"
+						: "MinSync-backed semantic vector retrieval over parsed markdown mirrors",
 			status: "active",
-			capabilities: ["semantic", "incremental", "parsed-mirrors", "virtual-paths"],
+			capabilities: [
+				...(this.mode === "bm25" ? ["lexical"] : this.mode === "hybrid" ? ["semantic", "lexical"] : ["semantic"]),
+				"incremental",
+				"parsed-mirrors",
+				"virtual-paths",
+			],
 		};
 	}
 
@@ -106,7 +132,7 @@ export class MinSyncVectorMethod implements RetrievalMethod {
 			workspacePath: this.workspacePath,
 			embedder: this.embedder,
 		});
-		const hits = await client.query(query, queryK);
+		const hits = await client.query(query, queryK, this.mode);
 		const results: RetrievalResult[] = [];
 		for (const hit of hits) {
 			const entry = byPath.get(hit.path);
@@ -116,7 +142,7 @@ export class MinSyncVectorMethod implements RetrievalMethod {
 				content: hit.text,
 				source: entry.virtualPath,
 				score: hit.score,
-				metadata: { method: "minsync" },
+				metadata: { method: this.mode === "vector" ? "minsync" : `minsync-${this.mode}` },
 			});
 			if (results.length >= topK) break;
 		}
@@ -156,5 +182,45 @@ export class MinSyncVectorMethod implements RetrievalMethod {
 		}
 		// 5. missing-binary
 		return undefined;
+	}
+}
+
+export class MinSyncBM25Method extends MinSyncVectorMethod {
+	private status: BM25Status = { readiness: "index_missing", engine: "minsync" };
+
+	constructor(options: MinSyncBM25MethodOptions) {
+		super({ ...options, mode: "bm25" });
+	}
+
+	override describe(): RetrievalMethodDescriptor {
+		return {
+			name: "bm25",
+			type: "bm25",
+			description: "MinSync 0.4.0 BM25 lexical retrieval over parsed markdown mirror chunks",
+			status: this.status.readiness === "ready" ? "active" : "stub",
+			capabilities: [
+				"lexical",
+				"incremental",
+				"parsed-mirrors",
+				"virtual-paths",
+				`readiness:${this.status.readiness}`,
+			],
+		};
+	}
+
+	syncFromMinSync(result: MinSyncSyncResult): BM25SyncResult {
+		this.status = result.ok
+			? { readiness: "ready", engine: "minsync" }
+			: { readiness: "error", engine: "minsync", message: result.reason };
+		return {
+			indexPath: result.workspacePath,
+			indexedChunks: result.synced,
+			readiness: this.status.readiness,
+			engine: this.status.engine,
+		};
+	}
+
+	getStatus(): BM25Status {
+		return this.status;
 	}
 }

--- a/src/minsync/method.ts
+++ b/src/minsync/method.ts
@@ -168,6 +168,7 @@ export class MinSyncVectorMethod implements RetrievalMethod {
 		if (this.binaryPath && existsSync(this.binaryPath)) {
 			return this.binaryPath;
 		}
+		if (this.binaryPath !== undefined) return undefined;
 		// 2. PATH lookup
 		const pathBinary = lookupInPath(process.env);
 		if (pathBinary) return pathBinary;

--- a/src/minsync/method.ts
+++ b/src/minsync/method.ts
@@ -1,4 +1,4 @@
-import { accessSync, constants, existsSync } from "node:fs";
+import { accessSync, constants, existsSync, realpathSync } from "node:fs";
 import { basename, delimiter, join, normalize } from "node:path";
 import type { BM25Status, BM25SyncResult } from "../retrieval/methods/bm25.ts";
 import { matchesVirtualPathScope } from "../retrieval/scope.ts";
@@ -140,7 +140,7 @@ export class MinSyncVectorMethod implements RetrievalMethod {
 			results.push({
 				id: `minsync:${entry.virtualPath}:${basename(hit.path)}`,
 				content: hit.text,
-				source: normalize(entry.sourcePath),
+				source: realpathSync(normalize(entry.sourcePath)),
 				score: hit.score,
 				metadata: {
 					method: this.mode === "vector" ? "minsync" : `minsync-${this.mode}`,

--- a/src/retrieval/methods/bm25.ts
+++ b/src/retrieval/methods/bm25.ts
@@ -15,9 +15,11 @@ export type BM25ReadinessState =
 	| "degraded_fallback"
 	| "error";
 
-export type BM25Engine = "tantivy" | "typescript-fallback" | "none";
+/** @deprecated Use MinSyncBM25Method from `src/minsync/method.ts`. */
+export type BM25Engine = "tantivy" | "typescript-fallback" | "minsync" | "none";
 export type BM25FallbackMode = "typescript" | "disabled";
 
+/** @deprecated Use MinSyncBM25MethodOptions from `src/minsync/method.ts`. */
 export interface BM25MethodOptions {
 	readonly root: string;
 	readonly indexPath?: string;
@@ -70,6 +72,7 @@ export class BM25UnavailableError extends Error {
 	}
 }
 
+/** @deprecated BM25 is now indexed and searched through MinSync 0.4.0. */
 export class BM25Method implements RetrievalMethod {
 	private readonly root: string;
 	private readonly indexPath: string;

--- a/src/retrieval/methods/bm25.ts
+++ b/src/retrieval/methods/bm25.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, normalize } from "node:path";
 import { loadMirrorIndex } from "../../mirror/index-store.ts";
 import { normalizeMarkdown } from "../../parser/text.ts";
@@ -399,7 +399,7 @@ function firstString(values: unknown[] | undefined): string | undefined {
 
 function sourcePathForVirtual(root: string, virtualPath: string): string {
 	const entry = loadMirrorIndex(root).entries[virtualPath];
-	return entry === undefined ? virtualPath : normalize(entry.sourcePath);
+	return entry === undefined ? virtualPath : realpathSync(normalize(entry.sourcePath));
 }
 
 function hash(value: string): string {

--- a/test/cli/commands.index.test.ts
+++ b/test/cli/commands.index.test.ts
@@ -118,7 +118,7 @@ describe("runIndex", () => {
 		expect(stderr.join("\n")).toContain("Usage");
 	});
 
-	it("reset --yes removes parsed/bm25/minsync and preserves bin/datasources/memory", async () => {
+	it("reset --yes removes parsed/minsync and preserves bin/datasources/memory", async () => {
 		const fx = seedWorkspace();
 		const { ctx, stdout } = makeCtx({
 			positionals: ["reset"],
@@ -131,7 +131,7 @@ describe("runIndex", () => {
 		expect(code).toBe(0);
 
 		expect(existsSync(fx.parsed)).toBe(false);
-		expect(existsSync(fx.bm25)).toBe(false);
+		expect(existsSync(fx.bm25)).toBe(true);
 		expect(existsSync(fx.minsync)).toBe(false);
 
 		expect(existsSync(fx.bin)).toBe(true);
@@ -141,7 +141,7 @@ describe("runIndex", () => {
 		const parsed = JSON.parse(stdout[0]);
 		expect(parsed.ok).toBe(true);
 		expect(parsed.action).toBe("reset");
-		expect(parsed.removed).toEqual(["parsed", "bm25", "minsync"]);
+		expect(parsed.removed).toEqual(["parsed", "minsync"]);
 	});
 
 	it("declined reset returns exit 2 and removes nothing", async () => {
@@ -248,7 +248,7 @@ describe("runIndex", () => {
 		const parsed = JSON.parse(stdout[0]);
 		expect(parsed.ok).toBe(true);
 		expect(parsed.action).toBe("rebuild");
-		expect(parsed.removed).toEqual(["parsed", "bm25", "minsync"]);
+		expect(parsed.removed).toEqual(["parsed", "minsync"]);
 		expect(parsed.rebuilt).toBeDefined();
 	});
 });
@@ -266,13 +266,13 @@ describe("runIndex --method scoped reset", () => {
 		const code = await runIndex(ctx);
 		expect(code).toBe(0);
 
-		expect(existsSync(fx.bm25)).toBe(false);
+		expect(existsSync(fx.bm25)).toBe(true);
 		expect(existsSync(fx.parsed)).toBe(true);
 		expect(existsSync(fx.minsync)).toBe(true);
 
 		const parsed = JSON.parse(stdout[0]);
 		expect(parsed.action).toBe("reset");
-		expect(parsed.removed).toEqual(["bm25"]);
+		expect(parsed.removed).toEqual([]);
 	});
 
 	it("reset --method minsync removes only the minsync index", async () => {
@@ -295,7 +295,7 @@ describe("runIndex --method scoped reset", () => {
 		expect(parsed.removed).toEqual(["minsync"]);
 	});
 
-	it("reset --method bm25,minsync removes both but not parsed", async () => {
+	it("reset --method bm25,minsync removes the shared MinSync index but not parsed", async () => {
 		const fx = seedWorkspace();
 		const { ctx, stdout } = makeCtx({
 			positionals: ["reset"],
@@ -307,15 +307,15 @@ describe("runIndex --method scoped reset", () => {
 		const code = await runIndex(ctx);
 		expect(code).toBe(0);
 
-		expect(existsSync(fx.bm25)).toBe(false);
+		expect(existsSync(fx.bm25)).toBe(true);
 		expect(existsSync(fx.minsync)).toBe(false);
 		expect(existsSync(fx.parsed)).toBe(true);
 
 		const parsed = JSON.parse(stdout[0]);
-		expect(parsed.removed).toEqual(["bm25", "minsync"]);
+		expect(parsed.removed).toEqual(["minsync"]);
 	});
 
-	it("reset --method all removes all three targets", async () => {
+	it("reset --method all removes the parsed mirror and shared MinSync index", async () => {
 		const fx = seedWorkspace();
 		const { ctx, stdout } = makeCtx({
 			positionals: ["reset"],
@@ -328,11 +328,11 @@ describe("runIndex --method scoped reset", () => {
 		expect(code).toBe(0);
 
 		expect(existsSync(fx.parsed)).toBe(false);
-		expect(existsSync(fx.bm25)).toBe(false);
+		expect(existsSync(fx.bm25)).toBe(true);
 		expect(existsSync(fx.minsync)).toBe(false);
 
 		const parsed = JSON.parse(stdout[0]);
-		expect(parsed.removed).toEqual(["parsed", "bm25", "minsync"]);
+		expect(parsed.removed).toEqual(["parsed", "minsync"]);
 	});
 
 	it("rebuild --method bm25 removes and rebuilds only bm25", async () => {
@@ -351,15 +351,14 @@ describe("runIndex --method scoped reset", () => {
 		const code = await runIndex(ctx);
 		expect(code).toBe(0);
 
-		// Only bm25 was reset; refresh re-creates the bm25 index dir.
-		// Parsed and minsync were not reset and survive from seed.
+		// BM25 uses the shared MinSync index; only parsed content is preserved.
 		expect(existsSync(fx.bm25)).toBe(true);
 		expect(existsSync(fx.parsed)).toBe(true);
 		expect(existsSync(fx.minsync)).toBe(true);
 
 		const parsed = JSON.parse(stdout[0]);
 		expect(parsed.action).toBe("rebuild");
-		expect(parsed.removed).toEqual(["bm25"]);
+		expect(parsed.removed).toEqual([]);
 		expect(parsed.rebuilt).toBeDefined();
 	});
 });

--- a/test/integration/minsync-first-sync.test.ts
+++ b/test/integration/minsync-first-sync.test.ts
@@ -167,7 +167,7 @@ describe("AutoRAGAgent MinSync first-sync contract (#1366)", () => {
 			["init", "--format", "json"],
 			["check", "--format", "json"],
 			["sync", "--full", "--format", "json"],
-			["query", "--format", "json", "-k", "1", "refund approval"],
+			["query", "--format", "json", "-k", "1", "--mode", "vector", "refund approval"],
 			["check", "--format", "json"],
 			["sync", "--format", "json"],
 		]);

--- a/test/minsync/minsync.test.ts
+++ b/test/minsync/minsync.test.ts
@@ -438,7 +438,7 @@ describe("MinSyncVectorMethod", () => {
 		// Then
 		expect(results).toHaveLength(1);
 		const result = requireValue(results[0], "first vector result");
-		expect(result.source).toBe(join(source, "policy.txt"));
+		expect(result.source).toBe(realpathSync(join(source, "policy.txt")));
 		expect(result.content).toBe("Parsed renewal policy with cancellation terms.");
 		expect(result.score).toBe(0.91);
 		expect(result.metadata).toMatchObject({ method: "minsync", virtualPath: "/docs/policy.txt" });
@@ -503,7 +503,7 @@ describe("MinSyncVectorMethod", () => {
 		// Then
 		expect(results).toHaveLength(1);
 		const result = requireValue(results[0], "relative path result");
-		expect(result.source).toBe(join(source, "policy.txt"));
+		expect(result.source).toBe(realpathSync(join(source, "policy.txt")));
 		expect(result.metadata.virtualPath).toBe("/docs/policy.txt");
 		expect(result.content).toBe("Relative path hit from MinSync.");
 	});

--- a/test/minsync/minsync.test.ts
+++ b/test/minsync/minsync.test.ts
@@ -447,7 +447,37 @@ describe("MinSyncVectorMethod", () => {
 		expect(JSON.stringify(results)).not.toContain(root);
 		expect(loggedCalls()).toContainEqual(
 			JSON.stringify({
-				args: ["query", "--format", "json", "-k", "2", "renewal cancellation"],
+				args: ["query", "--format", "json", "-k", "2", "--mode", "vector", "renewal cancellation"],
+				cwd: minSyncCwd(),
+			}),
+		);
+	});
+
+	it("routes lexical retrieval through MinSync BM25 mode", async () => {
+		writeFakeMinSync(
+			JSON.stringify({
+				results: [
+					{
+						path: "files/docs/policy.txt.md",
+						score: 0.88,
+						text: "BM25 lexical hit from MinSync.",
+					},
+				],
+			}),
+		);
+		const method = new MinSyncVectorMethod({
+			binaryPath: minsyncBinary,
+			root,
+			workspacePath: minsyncWorkspace,
+			mode: "bm25",
+		});
+
+		const results = await method.retrieve("renewal cancellation", { topK: 2 });
+
+		expect(results[0]?.metadata.method).toBe("minsync-bm25");
+		expect(loggedCalls()).toContainEqual(
+			JSON.stringify({
+				args: ["query", "--format", "json", "-k", "2", "--mode", "bm25", "renewal cancellation"],
 				cwd: minSyncCwd(),
 			}),
 		);

--- a/test/retrieval/bm25.test.ts
+++ b/test/retrieval/bm25.test.ts
@@ -126,22 +126,19 @@ describe("BM25Method", () => {
 });
 
 describe("AutoRAG BM25 integration", () => {
-	it("registers BM25 and includes it in programmatic retrieve()", async () => {
+	it("registers BM25 through the MinSync adapter", async () => {
 		writeFileSync(join(docs, "guide.txt"), "chargeback chargeback process\n");
 		const agent = new AutoRAGAgent({
 			searchPaths: [docs],
 			memoryPath: join(root, "memory.json"),
 			workspacePath: root,
-			bm25: { indexPath: join(root, ".autorag", "agent-bm25"), forceEngine: "typescript-fallback" },
+			bm25: { autoInstall: false },
 		});
 		const refresh = await agent.refresh(true);
 
-		expect(refresh.bm25).toMatchObject({ readiness: "degraded_fallback", engine: "typescript-fallback" });
-		const results = await agent.retrieve("chargeback", { topK: 1 });
+		expect(refresh.bm25).toMatchObject({ readiness: "error", engine: "minsync" });
 
 		expect(agent.getMethodRegistry().getByType("bm25")).toHaveLength(1);
-		expect(results[0]?.source).toBe("/docs/guide.txt");
-		expect(results[0]?.metadata.method).toBe("bm25");
 		expect(agent.getSystemPrompt()).toContain("search_bm25_documents");
 	});
 

--- a/test/retrieval/bm25.test.ts
+++ b/test/retrieval/bm25.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/test/retrieval/bm25.test.ts
+++ b/test/retrieval/bm25.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -53,7 +53,10 @@ describe("BM25Method", () => {
 		expect(sync.engine).toBe("tantivy");
 		expect(method.describe().type).toBe("bm25");
 		expect(method.describe().status).toBe("active");
-		expect(results.map((result) => result.source)).toEqual([join(docs, "many.txt"), join(docs, "few.txt")]);
+		expect(results.map((result) => result.source)).toEqual([
+			realpathSync(join(docs, "many.txt")),
+			realpathSync(join(docs, "few.txt")),
+		]);
 		expect(results[0]?.metadata.method).toBe("bm25");
 		expect(results[0]?.metadata.virtualPath).toBe("/docs/many.txt");
 	});
@@ -78,7 +81,7 @@ describe("BM25Method", () => {
 		const results = await method.retrieve("chargeback", { topK: 1, scope: "/docs/sub" });
 
 		expect(results).toHaveLength(1);
-		expect(results[0]?.source).toBe(join(docs, "sub", "target.txt"));
+		expect(results[0]?.source).toBe(realpathSync(join(docs, "sub", "target.txt")));
 	});
 
 	it("supports scoped retrieval, folder scope expansion, and stale-index removal", async () => {
@@ -93,7 +96,7 @@ describe("BM25Method", () => {
 		await method.sync();
 
 		const scoped = await method.retrieve("alpha", { topK: 10, scope: "/docs/sub" });
-		expect(scoped.map((result) => result.source)).toEqual([join(docs, "sub", "nested.txt")]);
+		expect(scoped.map((result) => result.source)).toEqual([realpathSync(join(docs, "sub", "nested.txt"))]);
 
 		rmSync(join(docs, "sub", "nested.txt"));
 		await refreshMirrors();
@@ -157,7 +160,7 @@ describe("AutoRAG BM25 integration", () => {
 		const result = await tool.execute("tool-call", { query: "chargeback", topK: 1, scope: "/docs/sub" });
 
 		expect(result.details).toMatchObject({ method: "bm25", resultCount: 1, readiness: "degraded_fallback" });
-		expect(result.details?.sources).toEqual([join(docs, "sub", "guide.txt")]);
+		expect(result.details?.sources).toEqual([realpathSync(join(docs, "sub", "guide.txt"))]);
 		expect(result.content[0]?.type).toBe("text");
 	});
 
@@ -180,7 +183,7 @@ describe("AutoRAG BM25 integration", () => {
 		const result = await tool.execute("tool-scope", { query: "chargeback", scope: join(docs, "sub") });
 
 		expect(normalizeScope).toHaveBeenCalledWith(join(docs, "sub"));
-		expect(result.details.sources).toEqual([join(docs, "sub", "guide.txt")]);
+		expect(result.details.sources).toEqual([realpathSync(join(docs, "sub", "guide.txt"))]);
 	});
 
 	it("preserves coded scope errors at the BM25 tool boundary", async () => {


### PR DESCRIPTION
## Summary
- install MinSync 0.4.0 from crates.io when auto-installing
- route BM25 indexing and querying through MinSync `--mode bm25`
- deprecate the legacy Tantivy BM25 path while retaining it only for explicit `minSync: false` compatibility
- update reset semantics and TDD coverage

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- focused changed tests: 72 passed
- real MinSync 0.4.0 CLI QA: sync plus `query --mode bm25` returned the expected document

## Known unrelated test issues
The full Bun suite still reports existing `vi.hoisted is not a function` parser-test errors and a Discrawl timeout under the repository Bun/Vitest setup; changed MinSync, BM25, agent, CLI reset, and integration tests pass.