### PR TITLE
fix: abort searches that exceed the configured timeout

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -202,6 +202,8 @@ export interface AutoRAGAgentOptions {
 	excludeExactDuplicates?: boolean;
 	datasourceSkills?: readonly DatasourceSkill[];
 	datasourceAccess?: DatasourceAccessContextOptions;
+	/** Maximum time a model/tool search may run before it is aborted. */
+	searchTimeoutMs?: number;
 }
 
 export interface AutoRAGSearchSession {
@@ -272,10 +274,15 @@ export class AutoRAGAgent {
 	private readonly excludeExactDuplicates: boolean;
 	private readonly baseSystemPromptConfig: SystemPromptConfig;
 	private readonly droppedCallerToolNames: readonly string[];
+	private readonly searchTimeoutMs: number;
 
 	constructor(options: AutoRAGAgentOptions) {
 		const { manifestDir, memoryPath } = options;
 		this.configuredModel = options.model;
+		this.searchTimeoutMs = options.searchTimeoutMs ?? 10 * 60 * 1000;
+		if (!Number.isFinite(this.searchTimeoutMs) || this.searchTimeoutMs <= 0) {
+			throw new Error("searchTimeoutMs must be a positive finite number");
+		}
 		this.apiKey = options.apiKey;
 		this.providerApiKeys = options.providerApiKeys;
 		const manifests = manifestDir ? loadManifests(manifestDir) : [];
@@ -648,7 +655,21 @@ export class AutoRAGAgent {
 			);
 			this.activeSession = session;
 			unsubscribers = this.configureSearchSession(session);
-			await session.prompt(this.buildSearchPrompt(trimmedQuery, options));
+			let timeout: NodeJS.Timeout | undefined;
+			try {
+				await Promise.race([
+					session.prompt(this.buildSearchPrompt(trimmedQuery, options)),
+					new Promise<never>((_, reject) => {
+						timeout = setTimeout(() => {
+							void Promise.resolve(session?.abort());
+							reject(new Error(`search timed out after ${this.searchTimeoutMs}ms`));
+						}, this.searchTimeoutMs);
+						timeout.unref();
+					}),
+				]);
+			} finally {
+				if (timeout !== undefined) clearTimeout(timeout);
+			}
 
 			if (captured === undefined) {
 				throw new Error("AutoRAG agent completed without emitting structured results");

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -204,6 +204,8 @@ export interface AutoRAGAgentOptions {
 	datasourceAccess?: DatasourceAccessContextOptions;
 	/** Maximum time a model/tool search may run before it is aborted. */
 	searchTimeoutMs?: number;
+	/** Maximum number of retrieval/tool executions allowed in one search. */
+	maxSearchToolCalls?: number;
 }
 
 export interface AutoRAGSearchSession {
@@ -275,13 +277,19 @@ export class AutoRAGAgent {
 	private readonly baseSystemPromptConfig: SystemPromptConfig;
 	private readonly droppedCallerToolNames: readonly string[];
 	private readonly searchTimeoutMs: number;
+	private readonly maxSearchToolCalls: number;
+	private searchToolCallCount = 0;
 
 	constructor(options: AutoRAGAgentOptions) {
 		const { manifestDir, memoryPath } = options;
 		this.configuredModel = options.model;
 		this.searchTimeoutMs = options.searchTimeoutMs ?? 10 * 60 * 1000;
+		this.maxSearchToolCalls = options.maxSearchToolCalls ?? 32;
 		if (!Number.isFinite(this.searchTimeoutMs) || this.searchTimeoutMs <= 0) {
 			throw new Error("searchTimeoutMs must be a positive finite number");
+		}
+		if (!Number.isInteger(this.maxSearchToolCalls) || this.maxSearchToolCalls <= 0) {
+			throw new Error("maxSearchToolCalls must be a positive integer");
 		}
 		this.apiKey = options.apiKey;
 		this.providerApiKeys = options.providerApiKeys;
@@ -525,6 +533,10 @@ export class AutoRAGAgent {
 	private recordSearchToolEvent(event: AgentEvent): void {
 		if (event.type !== "tool_execution_end" || !this.lastQuery) return;
 		if (!(SEARCH_TOOLS as readonly string[]).includes(event.toolName)) return;
+		this.searchToolCallCount += 1;
+		if (this.searchToolCallCount >= this.maxSearchToolCalls) {
+			void this.activeSession?.abort();
+		}
 		const details = event.result.details as { method?: string } | undefined;
 		this.memory.recordWeakSignal(this.lastQuery, details?.method ?? event.toolName, "followup");
 		this.memory.save();
@@ -630,6 +642,7 @@ export class AutoRAGAgent {
 		options = this.normalizeRetrievalOptions(options);
 
 		this.activeRun = true;
+		this.searchToolCallCount = 0;
 		this.lastQuery = trimmedQuery;
 		this.lastSessionId = sessionId;
 		let captured: AutoRAGResultsDetails | undefined;

--- a/test/agent/agent.test.ts
+++ b/test/agent/agent.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { Type } from "typebox";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AutoRAGAgent } from "../../src/agent/agent.ts";
 import { buildSystemPrompt } from "../../src/agent/system-prompt.ts";
 import { RetrievalMemory } from "../../src/memory/memory.ts";
@@ -48,6 +48,10 @@ function internals(agent: AutoRAGAgent): AgentInternals {
 	return agent as unknown as AgentInternals;
 }
 
+function fakeModel() {
+	return { id: "test-model", provider: "test-provider", api: "test-api" } as never;
+}
+
 describe("AutoRAGAgent", () => {
 	it("rejects a non-positive search timeout", () => {
 		expect(
@@ -69,6 +73,70 @@ describe("AutoRAGAgent", () => {
 					maxSearchToolCalls: 1.5,
 				}),
 		).toThrow("maxSearchToolCalls must be a positive integer");
+	});
+
+	it("aborts and rejects when a search exceeds its timeout", async () => {
+		vi.useFakeTimers();
+		try {
+			let abortCalls = 0;
+			const session = {
+				agent: { subscribe: () => () => {} },
+				prompt: async () => await new Promise<void>(() => {}),
+				abort: async () => {
+					abortCalls += 1;
+				},
+				dispose: () => {},
+			};
+			const agent = new AutoRAGAgent({
+				model: fakeModel(),
+				searchPaths: [FIXTURE_DIR],
+				memoryPath: join(tmpDir, "memory.json"),
+				searchTimeoutMs: 100,
+			});
+			(agent as unknown as { createSearchSession: () => typeof session }).createSearchSession = () => session;
+
+			const search = agent.searchDocuments("timeout query");
+			const rejection = expect(search).rejects.toThrow("search timed out after 100ms");
+			await vi.advanceTimersByTimeAsync(100);
+
+			await rejection;
+			expect(abortCalls).toBe(1);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("aborts a search after the configured retrieval tool-call limit", async () => {
+		let abortCalls = 0;
+		const session = {
+			agent: {
+				subscribe: (listener: (event: unknown) => void) => {
+					listener({
+						type: "tool_execution_end",
+						toolName: "search_bm25_documents",
+						result: { details: { method: "bm25" } },
+					});
+					return () => {};
+				},
+			},
+			prompt: async () => {},
+			abort: async () => {
+				abortCalls += 1;
+			},
+			dispose: () => {},
+		};
+		const agent = new AutoRAGAgent({
+			model: fakeModel(),
+			searchPaths: [FIXTURE_DIR],
+			memoryPath: join(tmpDir, "memory.json"),
+			maxSearchToolCalls: 1,
+		});
+		(agent as unknown as { createSearchSession: () => typeof session }).createSearchSession = () => session;
+
+		await expect(agent.searchDocuments("cap query")).rejects.toThrow(
+			"AutoRAG agent completed without emitting structured results",
+		);
+		expect(abortCalls).toBe(1);
 	});
 
 	it("creates with default config", () => {

--- a/test/agent/agent.test.ts
+++ b/test/agent/agent.test.ts
@@ -60,6 +60,17 @@ describe("AutoRAGAgent", () => {
 		).toThrow("searchTimeoutMs must be a positive finite number");
 	});
 
+	it("rejects a non-positive tool-call limit", () => {
+		expect(
+			() =>
+				new AutoRAGAgent({
+					searchPaths: [FIXTURE_DIR],
+					memoryPath: join(tmpDir, "memory.json"),
+					maxSearchToolCalls: 1.5,
+				}),
+		).toThrow("maxSearchToolCalls must be a positive integer");
+	});
+
 	it("creates with default config", () => {
 		const agent = new AutoRAGAgent({
 			searchPaths: [FIXTURE_DIR],

--- a/test/agent/agent.test.ts
+++ b/test/agent/agent.test.ts
@@ -49,6 +49,17 @@ function internals(agent: AutoRAGAgent): AgentInternals {
 }
 
 describe("AutoRAGAgent", () => {
+	it("rejects a non-positive search timeout", () => {
+		expect(
+			() =>
+				new AutoRAGAgent({
+					searchPaths: [FIXTURE_DIR],
+					memoryPath: join(tmpDir, "memory.json"),
+					searchTimeoutMs: 0,
+				}),
+		).toThrow("searchTimeoutMs must be a positive finite number");
+	});
+
 	it("creates with default config", () => {
 		const agent = new AutoRAGAgent({
 			searchPaths: [FIXTURE_DIR],


### PR DESCRIPTION
## Summary
- add a configurable overall timeout for `searchDocuments()` (default: 10 minutes)
- abort the active Pi session when the timeout fires
- cap retrieval/tool executions per search (default: 32)
- validate both safety bounds and preserve the existing failure/cleanup path

## Issue
Closes #1475

## Validation
- `bun test test/observability/run-log.test.ts` — passed
- `bun test test/agent/agent.test.ts` — blocked locally because dependencies such as `typebox` are not installed
- `bun test` — repository baseline CI passed remotely for build and macOS/Windows compatibility; local run had missing dependencies and pre-existing Bun/Vitest timer API failures
- `bun run typecheck` / Biome — blocked locally because dependencies/tools are unavailable
- `git diff --check` — passed

`bun install --frozen-lockfile` was attempted but rejected because the repository lockfile is not synchronized with the package manifest; no lockfile changes were made.