### PR TITLE
feat: support local Slack wiretap and datasource descriptions

### DIFF
--- a/docs/datasource-skills.md
+++ b/docs/datasource-skills.md
@@ -45,6 +45,32 @@ Every datasource entry can use a reusable template with a connection alias:
 }
 ```
 
+### Operator-authored datasource descriptions
+
+Each configured connection may include an optional `description`. This text is
+trusted operator context shown in the datasource descriptor and progressive
+disclosure skill manifest. It helps the librarian understand how a connection
+is normally used without changing its access policy.
+
+```json
+{
+  "datasources": {
+    "personal-google-drive": {
+      "type": "cloud-drive",
+      "instanceId": "personal",
+      "description": "Project contracts and government-support documents. Prefer this connection for current agreements; treat Archive/ as historical.",
+      "connector": {
+        "provider": "google-drive",
+        "remote": "personal-gdrive:"
+      }
+    }
+  }
+}
+```
+
+Descriptions are user-supplied, are not inferred automatically, and cannot
+grant access or widen `datasourceAccess.allowedScopes`.
+
 The key is the independent datasource ID and becomes an independently
 loadable `datasource-<alias>` skill. Its source scope, diagnostics, method
 names, local storage/cache namespace, and access policy are rewritten under
@@ -90,6 +116,42 @@ A skill can publish `instances`, for example:
 - Notion workspace -> database/page tree
 
 Every instance maps to a datasource root like `/kakao/personal` or `/slack/workspace/channel`.
+
+## Slack via slacrawl
+
+Slack can use the local Slack Desktop cache through `slacrawl`'s `wiretap`
+source; this path does not require a Slack token. API/bot/user tokens are only
+needed for server-side history, missing cache data, broader thread coverage,
+or DM/MPIM access.
+
+```json
+{
+  "datasources": {
+    "slack-local": {
+      "type": "slack",
+      "instanceId": "local",
+      "description": "Recent work conversations available in this Mac's Slack Desktop cache.",
+      "connector": {
+        "configPath": "~/.slacrawl/config.toml",
+        "syncSource": "wiretap",
+        "timeoutMs": 120000
+      }
+    }
+  },
+  "datasourceAccess": {
+    "allowedTags": ["slack", "chat"],
+    "allowedScopes": ["/slack-local/local/**"]
+  }
+}
+```
+
+Initialize and refresh the local mirror with:
+
+```bash
+slacrawl init -db ~/.slacrawl/slacrawl.db -workspace local
+slacrawl sync --source wiretap
+autorag refresh --method datasources
+```
 
 ## Cloud drives via rclone
 

--- a/src/datasource/described-skill.ts
+++ b/src/datasource/described-skill.ts
@@ -1,0 +1,52 @@
+import type { RetrievalMethod } from "../retrieval/types.ts";
+import type {
+	DatasourceIndexResult,
+	DatasourceSkill,
+	DatasourceSkillDescriptor,
+	DatasourceSkillManifest,
+	PollingMetadata,
+	SourceDescription,
+} from "./types.ts";
+
+/**
+ * Adds operator-authored context to a configured datasource without changing
+ * its backend, access identity, or retrieval methods.
+ */
+export class DescribedDatasourceSkill implements DatasourceSkill {
+	private readonly skill: DatasourceSkill;
+	private readonly description: string;
+
+	constructor(skill: DatasourceSkill, description: string) {
+		this.skill = skill;
+		this.description = description;
+	}
+
+	describe(): DatasourceSkillDescriptor {
+		return { ...this.skill.describe(), description: this.description };
+	}
+
+	polling(): PollingMetadata {
+		return this.skill.polling();
+	}
+
+	index(): Promise<DatasourceIndexResult> {
+		return this.skill.index();
+	}
+
+	retrievalMethods(): readonly RetrievalMethod[] {
+		return this.skill.retrievalMethods();
+	}
+
+	describeSources(): readonly SourceDescription[] {
+		return this.skill.describeSources();
+	}
+
+	skillManifest(): DatasourceSkillManifest {
+		const manifest = this.skill.skillManifest();
+		return {
+			...manifest,
+			description: this.description,
+			content: `${manifest.content}\n\n## Operator description\n\n${this.description}`,
+		};
+	}
+}

--- a/src/datasource/skills/factory.ts
+++ b/src/datasource/skills/factory.ts
@@ -9,6 +9,7 @@
  */
 
 import { AliasedDatasourceSkill } from "../aliased-skill.ts";
+import { DescribedDatasourceSkill } from "../described-skill.ts";
 import type { DatasourceSkill } from "../types.ts";
 import { CloudDriveSkill } from "./cloud-drive/index.ts";
 import { DiscrawlClient, type DiscrawlOptions, DiscrawlSkill } from "./discrawl/index.ts";
@@ -30,6 +31,8 @@ import { type WacrawlOptions, WacrawlSkill } from "./wacrawl/index.ts";
 /** One configured datasource entry (the trusted `datasources.<name>` value). */
 export interface DatasourceSkillConfig {
 	readonly enabled?: boolean;
+	/** Operator-authored context shown to the agent for this connection. */
+	readonly description?: string;
 	/** Built-in datasource template used when the config key is a connection alias. */
 	readonly type?: string;
 	readonly instanceId?: string;
@@ -249,14 +252,18 @@ export function buildDatasourceSkills(
 			entry.instanceId === undefined && entry.type !== undefined ? { ...entry, instanceId: name } : entry;
 		const skill = builder(normalizedEntry, workspaceRoot, name);
 		const hasChannelFilter = (entry.channels?.ids?.length ?? 0) > 0 || (entry.channels?.names?.length ?? 0) > 0;
-		skills.push(
+		const aliased =
 			name !== templateName || hasChannelFilter
 				? new AliasedDatasourceSkill(skill, {
 						alias: name,
 						...(entry.channels?.ids !== undefined ? { channelIds: entry.channels.ids } : {}),
 						...(entry.channels?.names !== undefined ? { channelNames: entry.channels.names } : {}),
 					})
-				: skill,
+				: skill;
+		skills.push(
+			typeof entry.description === "string" && entry.description.trim().length > 0
+				? new DescribedDatasourceSkill(aliased, entry.description.trim())
+				: aliased,
 		);
 	}
 	return { skills, unknown };

--- a/src/datasource/skills/slack/index.ts
+++ b/src/datasource/skills/slack/index.ts
@@ -13,6 +13,7 @@ const SLACRAWL_PROFILE: CrawlerProfile = {
 	allowedEnvPrefixes: ["SLACRAWL_"],
 	syncArgs: (options) => [
 		...globalArgs(options),
+		"--json",
 		"sync",
 		...(options.syncSource !== undefined ? ["--source", options.syncSource] : []),
 	],

--- a/test/cli/config.datasources.test.ts
+++ b/test/cli/config.datasources.test.ts
@@ -222,6 +222,25 @@ describe("CLI config datasources wiring", () => {
 		expect(skills[0]?.describe().datasourceId).not.toBe(skills[1]?.describe().datasourceId);
 	});
 
+	it("includes operator-authored datasource descriptions in the agent skill", () => {
+		const configPath = writeConfig({
+			searchPaths: [tmpRoot],
+			workspacePath: tmpRoot,
+			datasources: {
+				"personal-drive": {
+					type: "cloud-drive",
+					description: "보통 프로젝트 문서와 계약서 검색에 사용하는 개인 Google Drive입니다.",
+					connector: { provider: "google-drive", remote: "personal:" },
+				},
+			},
+		});
+		const options = buildAgentOptions(resolveConfig({ flags: { config: configPath } }));
+		const skill = (options.datasourceSkills ?? [])[0];
+		expect(skill?.describe().description).toContain("개인 Google Drive");
+		expect(skill?.skillManifest().description).toContain("개인 Google Drive");
+		expect(skill?.skillManifest().content).toContain("계약서 검색");
+	});
+
 	it("registers connector and crawler aliases through their datasource type", () => {
 		const configPath = writeConfig({
 			searchPaths: [tmpRoot],

--- a/test/datasource/skills/slacrawl.test.ts
+++ b/test/datasource/skills/slacrawl.test.ts
@@ -89,7 +89,14 @@ describe("SlacrawlClient", () => {
 			hits: [{ id: "C1-1700000001-000100", content: "Release starts at seven", title: "#deployments" }],
 		});
 
-		expect(calls()[0]?.args).toEqual(["--config", join(root, "slacrawl.yaml"), "sync", "--source", "primary"]);
+		expect(calls()[0]?.args).toEqual([
+			"--config",
+			join(root, "slacrawl.yaml"),
+			"--json",
+			"sync",
+			"--source",
+			"primary",
+		]);
 		expect(calls()[1]?.args).toEqual(["--json", "search", "--limit", "5", "release"]);
 		expect(calls().every((call) => call.openai === null)).toBe(true);
 		expect(calls().every((call) => call.updateCheck === "1")).toBe(true);


### PR DESCRIPTION
## Summary
- Support slacrawl JSON sync output for local Slack Desktop wiretap indexing.
- Add operator-authored datasources.<name>.description context to descriptors and skill manifests.
- Document local Slack wiretap setup and datasource description configuration.

## Validation
- bunx vitest run test/datasource/skills/slacrawl.test.ts test/cli/config.datasources.test.ts test/datasource/aliased-skill.test.ts test/agent/connector-datasource-integration.test.ts: 25 tests passed
- bun run typecheck: passed
- bun run lint: passed
- bun run build: passed
- Live autorag refresh --method datasources: slack-local succeeded against the local Slack Desktop cache.

Closes #1481