### PR TITLE
fix(datasource): skip unknown configured skills in CLI commands

### DIFF
--- a/docs/manual-qa-datasources.md
+++ b/docs/manual-qa-datasources.md
@@ -56,8 +56,9 @@ mapping. Configure credentials in notcrawl itself, then set
 
 ### Setup & wiring
 - [x] `buildDatasourceSkills` materializes every configured skill from the
-      trusted `datasources` config section; unknown names are rejected at
-      `buildAgentOptions` with a `ConfigError`.
+      trusted `datasources` config section; unknown names are skipped at
+      `buildAgentOptions` with an `unknown-datasource-skill` diagnostic so
+      unrelated search/status commands still run.
 - [x] Skills register their retrieval methods through the existing
       `RetrievalMethodRegistry` pipeline on agent construction.
 

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -208,6 +208,8 @@ export interface AutoRAGAgentOptions {
 	excludeExactDuplicates?: boolean;
 	datasourceSkills?: readonly DatasourceSkill[];
 	datasourceAccess?: DatasourceAccessContextOptions;
+	/** Non-fatal diagnostics from config/agent construction (e.g. skipped unknown datasources). */
+	startupDiagnostics?: readonly SearchDocumentDiagnostic[];
 	/** Maximum time a model/tool search may run before it is aborted. */
 	searchTimeoutMs?: number;
 	/** Maximum number of retrieval/tool executions allowed in one search. */
@@ -276,6 +278,7 @@ export class AutoRAGAgent {
 	private readonly jikjiClient: JikjiClient | undefined;
 	private readonly datasourceSkills: readonly DatasourceSkill[];
 	private readonly datasourceAccessOptions: DatasourceAccessContextOptions;
+	private readonly startupDiagnostics: readonly SearchDocumentDiagnostic[];
 	private readonly datasourceAgentSkills: readonly Skill[];
 	private readonly parserOptions: DefaultParserRegistryOptions | undefined;
 	private readonly dupeyOptions: DupeyCliOptions | false;
@@ -305,6 +308,7 @@ export class AutoRAGAgent {
 			normalizeVirtualPath(`/${skill.describe().name}`),
 		);
 		this.datasourceAccessOptions = options.datasourceAccess ?? {};
+		this.startupDiagnostics = options.startupDiagnostics ?? [];
 		this.datasourceAgentSkills = this.buildAuthorizedDatasourceSkills();
 
 		this.configuredSearchPaths = options.searchPaths.map((searchPath) => resolve(searchPath));
@@ -816,7 +820,7 @@ export class AutoRAGAgent {
 
 	/** Path-opaque component diagnostics (e.g. BM25 readiness) for the search response. */
 	private collectComponentDiagnostics(): SearchDocumentDiagnostic[] {
-		const diagnostics: SearchDocumentDiagnostic[] = [];
+		const diagnostics: SearchDocumentDiagnostic[] = [...this.startupDiagnostics];
 		if (this.droppedCallerToolNames.length > 0) {
 			diagnostics.push({
 				code: "caller-tool-dropped",
@@ -951,6 +955,7 @@ export class AutoRAGAgent {
 			parserOptions: this.parserOptions,
 		});
 		const diagnostics: SearchDocumentDiagnostic[] = [
+			...this.startupDiagnostics,
 			...this.refreshState.mirrorDiagnostics.map(toSearchDiagnostic),
 			...staleDiagnostics.map(toSearchDiagnostic),
 			...this.refreshState.jikjiDiagnostics.map((d) => ({

--- a/src/agent/search-documents.ts
+++ b/src/agent/search-documents.ts
@@ -31,7 +31,8 @@ export type SearchDocumentDiagnosticCode =
 	| "jikji-find-failed"
 	| "refresh-failed"
 	| "watch-failed"
-	| "watch-limited";
+	| "watch-limited"
+	| "unknown-datasource-skill";
 
 export interface SearchDocumentDiagnostic {
 	readonly code: SearchDocumentDiagnosticCode;

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -9,6 +9,7 @@ import {
 	type LocalAutoRAGModel,
 	loadLocalAutoRAGModel,
 } from "../agent/local-model.ts";
+import type { SearchDocumentDiagnostic } from "../agent/search-documents.ts";
 import { resolveAutoRAGHome } from "../config/home.ts";
 import type { DatasourceAccessContextOptions } from "../datasource/access-context.ts";
 import { buildDatasourceSkills, type DatasourcesConfig } from "../datasource/skills/factory.ts";
@@ -736,10 +737,16 @@ export function buildAgentOptions(config: CliConfig): Omit<AutoRAGAgentOptions, 
 	opts.excludeExactDuplicates = config.excludeExactDuplicates ?? true;
 	if (config.datasources !== undefined) {
 		const { skills, unknown } = buildDatasourceSkills(config.datasources, config.workspacePath);
-		if (unknown.length > 0) {
-			throw new ConfigError(`Unknown datasource skill(s) in config: ${unknown.join(", ")}`);
-		}
 		if (skills.length > 0) opts.datasourceSkills = skills;
+		if (unknown.length > 0) {
+			const diagnostic: SearchDocumentDiagnostic = {
+				code: "unknown-datasource-skill",
+				severity: "warning",
+				message: `Unknown datasource skill(s) in config were skipped: ${unknown.join(", ")}`,
+				source: "datasources",
+			};
+			opts.startupDiagnostics = [diagnostic];
+		}
 	}
 	if (config.datasourceAccess !== undefined) opts.datasourceAccess = config.datasourceAccess;
 	return opts as Omit<AutoRAGAgentOptions, "model">;

--- a/test/agent/refresh-status.test.ts
+++ b/test/agent/refresh-status.test.ts
@@ -91,6 +91,31 @@ describe("getRefreshStatus", () => {
 		expect(status.components.minsync).toBe("unavailable");
 		expect(JSON.stringify(status)).not.toContain(root);
 	});
+
+	it("surfaces unknown-datasource-skill startup diagnostics on status", async () => {
+		const agent = makeAgent({
+			startupDiagnostics: [
+				{
+					code: "unknown-datasource-skill",
+					severity: "warning",
+					message: "Unknown datasource skill(s) in config were skipped: dropbox",
+					source: "datasources",
+				},
+			],
+		});
+		const status = await agent.getRefreshStatus();
+		expect(status.diagnostics).toEqual(
+			expect.arrayContaining([
+				{
+					code: "unknown-datasource-skill",
+					severity: "warning",
+					message: "Unknown datasource skill(s) in config were skipped: dropbox",
+					source: "datasources",
+				},
+			]),
+		);
+	});
+
 	it("emits a watch-limited diagnostic when startWatchRefresh exceeds the watcher cap", async () => {
 		const agent = makeAgent();
 		const handle = agent.startWatchRefresh({

--- a/test/cli/commands.refresh-status.test.ts
+++ b/test/cli/commands.refresh-status.test.ts
@@ -120,6 +120,46 @@ describe("runRefresh + runStatus (cli)", () => {
 		expect(statusOut[0]).not.toContain("indexPath");
 	});
 
+	it("skips unknown datasource entries and reports a non-fatal diagnostic", async () => {
+		const configDir = join(process.env.HOME as string, ".autorag");
+		mkdirSync(configDir, { recursive: true });
+		writeFileSync(
+			join(configDir, "config.json"),
+			`${JSON.stringify(
+				{
+					searchPaths: ["docs"],
+					workspacePath: root,
+					memoryPath: join(root, "memory.json"),
+					bm25: { forceEngine: "typescript-fallback" },
+					minSync: false,
+					datasources: {
+						"discord-nomadamas": {},
+						"slack-local": {},
+					},
+				},
+				null,
+				2,
+			)}\n`,
+		);
+
+		const stderr: string[] = [];
+		const statusOut: string[] = [];
+		const code = await runStatus(
+			makeCtx({
+				stdout: (line) => statusOut.push(line),
+				stderr: (line) => stderr.push(line),
+			}),
+		);
+		expect(code).toBe(0);
+		expect(stderr.join("\n")).not.toContain("Unknown datasource skill");
+		expect(statusOut).toHaveLength(1);
+		const status = JSON.parse(statusOut[0]) as { diagnostics: Array<{ code: string; message: string }> };
+		expect(status.diagnostics.some((diagnostic) => diagnostic.code === "unknown-datasource-skill")).toBe(true);
+		expect(statusOut[0]).toContain("discord-nomadamas");
+		expect(statusOut[0]).toContain("slack-local");
+		expect(statusOut[0]).not.toContain(root);
+	});
+
 	it("reports idle and stale before any refresh has run", async () => {
 		writeConfig({ forceEngine: "typescript-fallback" });
 

--- a/test/cli/commands.search.test.ts
+++ b/test/cli/commands.search.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Model } from "@earendil-works/pi-ai";
@@ -102,6 +102,40 @@ describe("runSearch", () => {
 			}),
 		});
 		expect(options).toMatchObject({ topK: 3, scope: "/docs" });
+	});
+
+	it("does not fail agent construction for unknown datasource names", async () => {
+		const configPath = join(root, "config.json");
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				searchPaths: [root],
+				workspacePath: root,
+				datasources: { "discord-nomadamas": {}, "slack-local": {} },
+			}),
+		);
+		let received: { startupDiagnostics?: unknown; datasourceSkills?: unknown } = {};
+		const { ctx, stdout, stderr } = context(["find a local document"], { config: configPath });
+		const code = await runSearch(ctx, {
+			agentFactory: (options) => {
+				received = {
+					startupDiagnostics: options.startupDiagnostics,
+					datasourceSkills: options.datasourceSkills,
+				};
+				return { searchDocuments: async () => response };
+			},
+		});
+		expect(code).toBe(0);
+		expect(stderr.join("\n")).not.toMatch(/Unknown datasource/);
+		expect(received.datasourceSkills ?? []).toEqual([]);
+		expect(received.startupDiagnostics).toEqual([
+			expect.objectContaining({
+				code: "unknown-datasource-skill",
+				severity: "warning",
+				source: "datasources",
+			}),
+		]);
+		expect(JSON.parse(stdout[0]).answer).toBe("[1] answer");
 	});
 });
 

--- a/test/cli/config.datasources.test.ts
+++ b/test/cli/config.datasources.test.ts
@@ -59,13 +59,27 @@ describe("CLI config datasources wiring", () => {
 		expect(options.datasourceAccess).toBeUndefined();
 	});
 
-	it("rejects unknown datasource skill names with a ConfigError", () => {
+	it("skips unknown datasource skill names and keeps known skills", () => {
 		const configPath = writeConfig({
 			searchPaths: [tmpRoot],
 			workspacePath: tmpRoot,
-			datasources: { dropbox: {} },
+			datasources: {
+				rss: { connector: { feeds: [{ url: "https://feeds.example.com/a.xml" }] } },
+				"discord-nomadamas": {},
+				"slack-local": {},
+			},
 		});
-		expect(() => buildAgentOptions(resolveConfig({ flags: { config: configPath } }))).toThrow(ConfigError);
+		const options = buildAgentOptions(resolveConfig({ flags: { config: configPath } }));
+		const skills = (options.datasourceSkills ?? []) as readonly DatasourceSkill[];
+		expect(skills.map((skill) => skill.describe().name)).toEqual(["rss"]);
+		expect(options.startupDiagnostics).toEqual([
+			{
+				code: "unknown-datasource-skill",
+				severity: "warning",
+				message: "Unknown datasource skill(s) in config were skipped: discord-nomadamas, slack-local",
+				source: "datasources",
+			},
+		]);
 	});
 
 	it("materializes WhatsApp through the external wacrawl backend", () => {


### PR DESCRIPTION
## Summary

Fixes #1483. A stale or future `datasources` entry whose name/`type` is not a built-in skill no longer fails `autorag status`, `autorag search`, or `autorag refresh` during config-to-agent construction.

Unknown names are skipped. Known skills still materialize. Status JSON reports a non-fatal `unknown-datasource-skill` diagnostic listing the skipped config keys.

`buildDatasourceSkills()` already collected unknown names without throwing; `buildAgentOptions()` was the fail-fast layer. That throw is now a startup diagnostic on the agent.

## Test plan

- [x] TDD: failing tests first for mixed known/unknown datasources (`discord-nomadamas`, `slack-local`), CLI `status`/`search`, and agent status diagnostics
- [x] `bun test test/cli/config.datasources.test.ts test/cli/commands.refresh-status.test.ts test/cli/commands.search.test.ts test/agent/refresh-status.test.ts`
- [x] `bunx biome check` on changed files and `bunx tsc --noEmit`
- [x] Manual QA against the issue reproduction:
  - `autorag status --config ./config.json --json` exits 0 and includes `unknown-datasource-skill`
  - `autorag search --config ./config.json --json "find a local document"` no longer dies on unknown skills and still finds the local fixture
  - `autorag refresh --config ./config.json --json --method parsed` exits 0