### PR TITLE
docs(setup): document OrcaRouter as a named model provider

### DIFF
--- a/skills/autorag-setup/SKILL.md
+++ b/skills/autorag-setup/SKILL.md
@@ -108,6 +108,30 @@ flags may be omitted. For a custom endpoint, add `api`, `baseUrl`, and
 }
 ```
 
+Other OpenAI-compatible meta-routers work the same way. For example,
+[OrcaRouter](https://www.orcarouter.ai) exposes many models and a routing layer
+behind one endpoint, so it is configured as a named provider:
+
+```json
+{
+  "searchPaths": ["/path/to/documents"],
+  "model": {
+    "provider": "orcarouter",
+    "id": "openai/gpt-5.5",
+    "api": "openai-completions",
+    "baseUrl": "https://api.orcarouter.ai/v1",
+    "apiKeyEnv": "ORCAROUTER_API_KEY"
+  }
+}
+```
+
+OrcaRouter API keys start with `sk-orca-`. Keep the provider prefix in the
+model id (`openai/gpt-5.5`, `anthropic/claude-sonnet-5`, or `orcarouter/auto`):
+the gateway routes on the fully namespaced id. Because the AutoRAG librarian
+loop depends on tool calling, prefer a pinned model known to support tools
+(such as `openai/gpt-5.5`) over the `orcarouter/auto` router, whose routed
+upstream can vary per request.
+
 Use `--force` only when intentionally replacing an existing config. Legacy cwd
 `autorag.config.json` is a migration source only and is never deleted by init.
 


### PR DESCRIPTION
## Summary

AutoRAG is a self-evolving librarian agent for document collections: a Pi agent loop that retrieves, reads, judges, and curates. Its model provider comes from the user's authenticated runtime, and the setup skill already documents OpenAI-compatible endpoints as named providers (OpenRouter being the reference example). This PR adds [OrcaRouter](https://www.orcarouter.ai) as a first-class named provider in that documentation, mirroring the existing OpenRouter entry.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models, but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a named provider means AutoRAG users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint, screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- `skills/autorag-setup/SKILL.md`: added an OrcaRouter example next to the OpenRouter example in the "Configure one search model" section, using the same `provider` / `id` / `api` / `baseUrl` / `apiKeyEnv` shape AutoRAG already resolves for any OpenAI-compatible endpoint.
- Documented the two things that differ from OpenRouter's example: `sk-orca-` key prefix, and the requirement to keep the provider namespace in the model id (`openai/gpt-5.5`, `anthropic/claude-sonnet-5`, or `orcarouter/auto`) because the gateway routes on the fully namespaced id.
- Noted that the librarian loop depends on tool calling, so a pinned tool-capable model (e.g. `openai/gpt-5.5`) is preferred over the `orcarouter/auto` router, whose routed upstream can vary per request.

## Verification

- Config resolution verified with AutoRAG's own `resolveConfig` / `resolveAgentModel` against the documented `orcarouter` config: provider `orcarouter`, base URL `https://api.orcarouter.ai/v1`, API `openai-completions`, API key picked up from `ORCAROUTER_API_KEY`.
- Live endpoint verified against the documented config path: `POST /v1/chat/completions` returned HTTP 200 for `orcarouter/auto`, `openai/gpt-5.5`, and `anthropic/claude-sonnet-5` (with the `Authorization: Bearer` header and `HTTP-Referer` / `X-Title` attribution headers).
- `biome check`, `tsc --noEmit`, and the CLI config/init/health test files all pass.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
