### PR TITLE
fix(datasource): complete diagnostic propagation

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -133,7 +133,8 @@ export interface AutoRAGMinSyncRefreshResult {
 	readonly reason?: string;
 }
 
-export interface AutoRAGRefreshResult extends ParsedMirrorSyncResult {
+export interface AutoRAGRefreshResult extends Omit<ParsedMirrorSyncResult, "diagnostics"> {
+	readonly diagnostics: readonly SearchDocumentDiagnostic[];
 	readonly bm25?: BM25SyncResult;
 	readonly minsync?: AutoRAGMinSyncRefreshResult;
 	readonly datasources?: readonly DatasourceIndexResult[];
@@ -650,7 +651,7 @@ export class AutoRAGAgent {
 		if (trimmedQuery.length === 0) {
 			this.lastQuery = trimmedQuery;
 			this.lastSessionId = sessionId;
-			return createEmptySearchDocumentsResponse(sessionId, trimmedQuery, this.sessions);
+			return createEmptySearchDocumentsResponse(sessionId, trimmedQuery, this.sessions, this.startupDiagnostics);
 		}
 		options = this.normalizeRetrievalOptions(options);
 
@@ -927,7 +928,13 @@ export class AutoRAGAgent {
 						...(minsync.reason !== undefined ? { reason: minsync.reason } : {}),
 					}
 				: undefined;
-			return { ...(bm25 ? { ...summary, bm25 } : summary), minsync: publicMinsync, datasources };
+			return {
+				...(bm25 ? { ...summary } : summary),
+				diagnostics: [...this.startupDiagnostics, ...summary.diagnostics],
+				...(bm25 ? { bm25 } : {}),
+				minsync: publicMinsync,
+				datasources,
+			};
 		} catch (error) {
 			this.refreshState = {
 				...this.refreshState,

--- a/src/agent/search-documents.ts
+++ b/src/agent/search-documents.ts
@@ -87,6 +87,7 @@ export function createEmptySearchDocumentsResponse(
 	sessionId: string,
 	query: string,
 	sessions: SearchSessions,
+	diagnostics: readonly SearchDocumentDiagnostic[] = [],
 ): SearchDocumentsResponse {
 	sessions.set(sessionId, { query, registry: new Map() });
 	return {
@@ -96,7 +97,7 @@ export function createEmptySearchDocumentsResponse(
 		answer: "",
 		searched: 0,
 		warnings: ["empty-query"],
-		diagnostics: [],
+		diagnostics: [...diagnostics],
 	};
 }
 

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -739,10 +739,11 @@ export function buildAgentOptions(config: CliConfig): Omit<AutoRAGAgentOptions, 
 		const { skills, unknown } = buildDatasourceSkills(config.datasources, config.workspacePath);
 		if (skills.length > 0) opts.datasourceSkills = skills;
 		if (unknown.length > 0) {
+			const safeNames = unknown.map((name) => name.replace(/[^A-Za-z0-9._-]/g, "?").slice(0, 80));
 			const diagnostic: SearchDocumentDiagnostic = {
 				code: "unknown-datasource-skill",
 				severity: "warning",
-				message: `Unknown datasource skill(s) in config were skipped: ${unknown.join(", ")}`,
+				message: `Unknown datasource skill(s) in config were skipped: ${safeNames.join(", ")}`,
 				source: "datasources",
 			};
 			opts.startupDiagnostics = [diagnostic];

--- a/src/datasource/skills/factory.ts
+++ b/src/datasource/skills/factory.ts
@@ -259,10 +259,14 @@ export function buildDatasourceSkills(
 	const unknown: string[] = [];
 	for (const [name, raw] of Object.entries(config ?? {})) {
 		if (raw === false) continue;
+		if (raw !== true && (typeof raw !== "object" || raw === null || Array.isArray(raw))) {
+			unknown.push(name);
+			continue;
+		}
 		const entry: DatasourceSkillConfig = raw === true ? {} : raw;
 		if (entry.enabled === false) continue;
 		const templateName = entry.type ?? name;
-		const builder = BUILDERS[templateName];
+		const builder = Object.hasOwn(BUILDERS, templateName) ? BUILDERS[templateName] : undefined;
 		if (builder === undefined) {
 			unknown.push(name);
 			continue;

--- a/test/agent/refresh-status.test.ts
+++ b/test/agent/refresh-status.test.ts
@@ -116,6 +116,31 @@ describe("getRefreshStatus", () => {
 		);
 	});
 
+	it("includes startup diagnostics in refresh results", async () => {
+		const agent = makeAgent({
+			startupDiagnostics: [
+				{
+					code: "unknown-datasource-skill",
+					severity: "warning",
+					message: "Unknown datasource skill(s) in config were skipped: dropbox",
+					source: "datasources",
+				},
+			],
+		});
+
+		const result = await agent.refresh(true);
+
+		expect(result.diagnostics).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					code: "unknown-datasource-skill",
+					severity: "warning",
+					source: "datasources",
+				}),
+			]),
+		);
+	});
+
 	it("emits a watch-limited diagnostic when startWatchRefresh exceeds the watcher cap", async () => {
 		const agent = makeAgent();
 		const handle = agent.startWatchRefresh({

--- a/test/agent/search-documents.test.ts
+++ b/test/agent/search-documents.test.ts
@@ -139,4 +139,31 @@ describe("AutoRAGAgent searchDocuments", () => {
 
 		await expect(agent.searchDocuments("  ")).resolves.toMatchObject({ query: "", answer: "", results: [] });
 	});
+
+	it("preserves startup diagnostics for blank queries", async () => {
+		const agent = new AutoRAGAgent({
+			model: modelFor(),
+			searchPaths: ["test/fixtures/sample-project"],
+			workspacePath: root,
+			memoryPath: join(root, "memory.json"),
+			startupDiagnostics: [
+				{
+					code: "unknown-datasource-skill",
+					severity: "warning",
+					message: "Unknown datasource skill(s) in config were skipped: dropbox",
+					source: "datasources",
+				},
+			],
+		});
+
+		await expect(agent.searchDocuments("  ")).resolves.toMatchObject({
+			diagnostics: [
+				expect.objectContaining({
+					code: "unknown-datasource-skill",
+					severity: "warning",
+					source: "datasources",
+				}),
+			],
+		});
+	});
 });

--- a/test/cli/config.datasources.test.ts
+++ b/test/cli/config.datasources.test.ts
@@ -82,6 +82,64 @@ describe("CLI config datasources wiring", () => {
 		]);
 	});
 
+	it("skips malformed datasource entries without constructing connectors", () => {
+		const configPath = writeConfig({
+			searchPaths: [tmpRoot],
+			workspacePath: tmpRoot,
+			datasources: {
+				rss: 0,
+				dropbox: null,
+			},
+		});
+
+		const options = buildAgentOptions(resolveConfig({ flags: { config: configPath } }));
+
+		expect(options.datasourceSkills ?? []).toEqual([]);
+		expect(options.startupDiagnostics).toEqual([
+			expect.objectContaining({
+				code: "unknown-datasource-skill",
+				message: "Unknown datasource skill(s) in config were skipped: rss, dropbox",
+			}),
+		]);
+	});
+
+	it("treats inherited object properties as unknown datasource names", () => {
+		const configPath = writeConfig({
+			searchPaths: [tmpRoot],
+			workspacePath: tmpRoot,
+			datasources: {
+				toString: {},
+				alias: { type: "constructor" },
+			},
+		});
+
+		const options = buildAgentOptions(resolveConfig({ flags: { config: configPath } }));
+
+		expect(options.datasourceSkills ?? []).toEqual([]);
+		expect(options.startupDiagnostics).toEqual([
+			expect.objectContaining({
+				message: "Unknown datasource skill(s) in config were skipped: toString, alias",
+			}),
+		]);
+	});
+
+	it("sanitizes unknown datasource names before exposing diagnostics", () => {
+		const unsafeName = "/private/var/tmp/secret\n\u001b[31m";
+		const configPath = writeConfig({
+			searchPaths: [tmpRoot],
+			workspacePath: tmpRoot,
+			datasources: { [unsafeName]: {} },
+		});
+
+		const options = buildAgentOptions(resolveConfig({ flags: { config: configPath } }));
+		const diagnostics = JSON.stringify(options.startupDiagnostics);
+
+		expect(diagnostics).not.toContain("/private/var/tmp");
+		expect(diagnostics).not.toContain("\n");
+		expect(diagnostics).not.toContain("\u001b");
+		expect(diagnostics).toContain("?private?var?tmp?secret");
+	});
+
 	it("materializes WhatsApp through the external wacrawl backend", () => {
 		const configPath = writeConfig({
 			searchPaths: [tmpRoot],


### PR DESCRIPTION
## Summary
- propagate startup diagnostics through refresh results and empty searches
- reject malformed/prototype datasource builder entries before connector construction
- sanitize unknown datasource identifiers before diagnostics are rendered

## Verification
- 29 targeted tests passed
- bun run typecheck
- bun run build
- bun run lint
- manual refresh and empty-search diagnostic smoke

Follow-up to #1487.