### PR TITLE
Prefetch local retrieval context before agent search

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -772,7 +772,10 @@ export class AutoRAGAgent {
 			let timeout: NodeJS.Timeout | undefined;
 			try {
 				await Promise.race([
-					session.prompt(this.buildSearchPrompt(trimmedQuery, options)),
+					(async () => {
+						const initialRetrievalContext = await this.prefetchInitialRetrievalContext(trimmedQuery, options);
+						await session.prompt(this.buildSearchPrompt(trimmedQuery, options, initialRetrievalContext));
+					})(),
 					new Promise<never>((_, reject) => {
 						timeout = setTimeout(() => {
 							void Promise.resolve(session?.abort());
@@ -946,11 +949,52 @@ export class AutoRAGAgent {
 		return diagnostics;
 	}
 
-	buildSearchPrompt(query: string, options: RetrievalOptions): string {
+	private async prefetchInitialRetrievalContext(query: string, options: RetrievalOptions): Promise<string> {
+		const vectorMethod = this.methodRegistry
+			.getByType("vector")
+			.find((method) => method.describe().name === "minsync");
+		const bm25Method = this.methodRegistry.getByType("bm25").find((method) => method.describe().name === "bm25");
+		const [jikji, vector, bm25] = await Promise.all([
+			this.jikjiClient === undefined ? Promise.resolve(undefined) : this.findJikji(query, { topK: 5 }),
+			vectorMethod?.retrieve(query, { topK: 5, scope: options.scope }).catch(() => []),
+			bm25Method?.retrieve(query, { topK: 5, scope: options.scope }).catch(() => []),
+		]);
+		const sections: string[] = [];
+		if (jikji?.answerPack !== undefined) {
+			sections.push(
+				`Jikji initial candidates (preserve order when agent_should_not_rerank=true):\n${jikji.answerPack.answerPaths
+					.slice(0, 5)
+					.map((path, index) => `[${index + 1}] ${path}`)
+					.join("\n")}`,
+			);
+		}
+		const formatResults = (label: string, results: RetrievalResult[] | undefined): void => {
+			if (!results || results.length === 0) return;
+			sections.push(
+				`${label} initial candidates:\n${results
+					.slice(0, 5)
+					.map(
+						(result, index) =>
+							`[${index + 1}] ${result.source}\n${result.content.replace(/\s+/gu, " ").slice(0, 400)}`,
+					)
+					.join("\n")}`,
+			);
+		};
+		formatResults("MinSync semantic", vector);
+		formatResults("MinSync lexical BM25", bm25);
+		return sections.length === 0
+			? "No initial retrieval candidates were available; use the configured tools and report degradation honestly."
+			: sections.join("\n\n");
+	}
+
+	buildSearchPrompt(query: string, options: RetrievalOptions, initialRetrievalContext?: string): string {
 		const limit = typeof options.topK === "number" ? ` Return at most ${options.topK} curated results.` : "";
 		const scope = options.scope ? ` Restrict search to virtual path scope ${options.scope}.` : "";
 		return (
 			`Find and curate information for this original query: ${query}${limit}${scope}\n\n` +
+			`Initial retrieval context (Jikji, MinSync semantic, and MinSync lexical searches were run in parallel before this turn):\n` +
+			`${initialRetrievalContext ?? "Not preloaded; use the available retrieval tools."}\n\n` +
+			`Treat this as candidate evidence, verify important claims against source files, and use additional tools when needed. ` +
 			`Use the available retrieval tools to find candidates, then use bash to read and verify the relevant source files directly. ` +
 			`Judge relevance, conflicts, freshness, and sufficiency in this agent loop. Preserve real source paths and evidence excerpts in the result mapping.\n\n` +
 			`When finished, call ${EMIT_AUTORAG_RESULTS_TOOL_NAME} exactly once as your final action with the curated ` +

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -950,14 +950,13 @@ export class AutoRAGAgent {
 	}
 
 	private async prefetchInitialRetrievalContext(query: string, options: RetrievalOptions): Promise<string> {
-		const vectorMethod = this.methodRegistry
-			.getByType("vector")
-			.find((method) => method.describe().name === "minsync");
-		const bm25Method = this.methodRegistry.getByType("bm25").find((method) => method.describe().name === "bm25");
+		const retrieveOptions = { topK: 5, scope: options.scope };
 		const [jikji, vector, bm25] = await Promise.all([
-			this.jikjiClient === undefined ? Promise.resolve(undefined) : this.findJikji(query, { topK: 5 }),
-			vectorMethod?.retrieve(query, { topK: 5, scope: options.scope }).catch(() => []),
-			bm25Method?.retrieve(query, { topK: 5, scope: options.scope }).catch(() => []),
+			this.jikjiClient === undefined
+				? Promise.resolve(undefined)
+				: this.findJikji(query, { topK: 5 }).catch(() => undefined),
+			this.minSyncMethod?.retrieve(query, retrieveOptions).catch(() => []),
+			this.bm25Method?.retrieve(query, retrieveOptions).catch(() => []),
 		]);
 		const sections: string[] = [];
 		if (jikji?.answerPack !== undefined) {

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -90,7 +90,7 @@ Your job is to retrieve candidates, read the relevant source material directly, 
 
 ## Workflow
 
-1. **PLAN** — Understand the query, inspect retrieval memory when useful, and choose suitable retrieval methods.
+1. **PLAN** — Understand the query and review the preloaded initial retrieval context.
 2. **RETRIEVE** — Use MinSync BM25, MinSync vector, MinSync hybrid, combined retrieval, Jikji, datasource search, or direct filesystem discovery as appropriate.
 3. **READ** — Use \`bash\` to open and verify relevant local files. Do not curate from search snippets alone when source files are available.
 4. **JUDGE** — Evaluate relevance, sufficiency, conflicts, uncertainty, and temporal context.
@@ -103,6 +103,7 @@ ${toolLines.join("\n")}
 ${noSearchTools}
 ## Search Strategy
 
+- Before additional searching, inspect the initial retrieval context supplied with the query. It contains bounded Jikji, semantic MinSync, and lexical BM25 candidates collected in parallel; treat it as a starting slate, not as verified final evidence.
 - Start with the most specific exact term, identifier, filename glob, or regex that preserves the query intent.
 - Use \`search_all_documents\` when multiple configured retrieval methods can help.
 - Use MinSync-backed BM25 for exact terminology, MinSync vector search for semantic similarity, and \`search_all_documents\` when hybrid ranking over the same MinSync chunks can help.

--- a/test/agent/prefetch-initial-context.test.ts
+++ b/test/agent/prefetch-initial-context.test.ts
@@ -1,0 +1,143 @@
+import { randomUUID } from "node:crypto";
+import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Context } from "@earendil-works/pi-ai";
+import { type FauxProviderRegistration, fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { registerFauxProvider } from "@earendil-works/pi-ai/compat";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AutoRAGAgent } from "../../src/agent/agent.ts";
+import { EMIT_AUTORAG_RESULTS_TOOL_NAME } from "../../src/agent/emit-results-tool.ts";
+import { writeFakeMinSync } from "../helpers/fake-minsync.ts";
+
+let root: string;
+let docs: string;
+let registrations: FauxProviderRegistration[];
+
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), "autorag-prefetch-"));
+	docs = join(root, "docs");
+	registrations = [];
+	mkdirSync(docs, { recursive: true });
+	writeFileSync(
+		join(docs, "refund-policy.txt"),
+		"Refund exceptions require director approval before payout.\nFinance acknowledged the policy in the July review.\n",
+	);
+});
+
+afterEach(() => {
+	for (const registration of registrations) registration.unregister();
+	rmSync(root, { recursive: true, force: true });
+});
+
+function extractUserText(context: Context): string {
+	const chunks: string[] = [];
+	for (const message of context.messages) {
+		if (message.role !== "user") continue;
+		const content = message.content;
+		if (typeof content === "string") chunks.push(content);
+		else if (Array.isArray(content)) {
+			for (const part of content) {
+				if (part && typeof part === "object" && "text" in part && typeof part.text === "string") {
+					chunks.push(part.text);
+				}
+			}
+		}
+	}
+	return chunks.join("\n");
+}
+
+function writeFakeJikji(binaryPath: string): void {
+	writeFileSync(
+		binaryPath,
+		`#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "find") {
+	console.log(JSON.stringify({
+		answer_paths: ["refund-policy.txt"],
+		paths: ["refund-policy.txt"],
+		candidates: [{ path: "refund-policy.txt", next_read: "original", label: "refund" }],
+		evidence_pack: [{ path: "refund-policy.txt", next_read: "original" }],
+		handoff_action: "raw_fallback_after_retry",
+		tool_call_policy: { stop_after_find: false, forbidden_tools: [], allowed_followups: [] },
+		agent_should_not_rerank: false,
+	}));
+} else {
+	console.log(JSON.stringify({ prepared: true }));
+}
+`,
+	);
+	chmodSync(binaryPath, 0o755);
+}
+
+function emitModel(onPrompt?: (text: string) => void) {
+	const registration = registerFauxProvider({ api: `faux-${randomUUID()}`, models: [{ id: "prefetch-model" }] });
+	registration.setResponses([
+		(context) => {
+			onPrompt?.(extractUserText(context));
+			return fauxAssistantMessage(
+				[
+					fauxToolCall(EMIT_AUTORAG_RESULTS_TOOL_NAME, {
+						answer: "[1] Refund exceptions require director approval.",
+						results: [
+							{
+								number: 1,
+								title: "Refund approval",
+								summary: "Refund exceptions require director approval before payout.",
+								evidence: [{ excerpt: "director approval" }],
+								confidence: 0.9,
+							},
+						],
+						mapping: [
+							{ number: 1, source: "/docs/refund-policy.txt", method: "minsync", content: "director approval" },
+						],
+					}),
+				],
+				{ stopReason: "toolUse" },
+			);
+		},
+	]);
+	registrations.push(registration);
+	return registration.getModel();
+}
+
+describe("AutoRAGAgent prefetchInitialRetrievalContext", () => {
+	it("injects MinSync source paths into the first search prompt", async () => {
+		writeFakeJikji(join(root, "fake-jikji.mjs"));
+		writeFakeMinSync(join(root, "fake-minsync.mjs"));
+		const source = realpathSync(join(docs, "refund-policy.txt"));
+		let prompt = "";
+		const agent = new AutoRAGAgent({
+			model: emitModel((text) => {
+				prompt = text;
+			}),
+			searchPaths: [docs],
+			workspacePath: root,
+			memoryPath: join(root, "memory.json"),
+			minSync: { binaryPath: join(root, "fake-minsync.mjs"), autoInstall: false },
+			jikji: { binaryPath: join(root, "fake-jikji.mjs") },
+		});
+		await agent.refresh(true);
+		const response = await agent.searchDocuments("refund director approval");
+		expect(response.results).toHaveLength(1);
+		expect(prompt).toContain(source);
+	});
+
+	it("still emits structured results when Jikji prefetch throws", async () => {
+		const agent = new AutoRAGAgent({
+			model: emitModel(),
+			searchPaths: [docs],
+			workspacePath: root,
+			memoryPath: join(root, "memory.json"),
+			minSync: false,
+			bm25: false,
+			jikji: { binaryPath: join(root, "missing-jikji") },
+		});
+		(agent as unknown as { findJikji: () => Promise<never> }).findJikji = async () => {
+			throw new Error("jikji prefetch boom");
+		};
+		await expect(agent.searchDocuments("refund director approval")).resolves.toMatchObject({
+			results: [{ number: 1 }],
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- run Jikji, MinSync semantic, and MinSync BM25 retrieval in parallel before the agent prompt
- provide bounded initial candidates to the agent for grounded follow-up decisions
- update system prompt to prioritize and verify the preloaded slate

## Verification
- bun run lint
Checked 256 files in 593ms. No fixes applied.
bun run typecheck
bun run test

=== test/agent/agent-lifecycle.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  08:56:49
   Duration  843ms (transform 164ms, setup 0ms, import 770ms, tests 12ms, environment 0ms)


=== test/agent/agent.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  29 passed (29)
   Start at  08:56:50
   Duration  498ms (transform 165ms, setup 0ms, import 409ms, tests 36ms, environment 0ms)


=== test/agent/auto-refresh.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  08:56:51
   Duration  459ms (transform 157ms, setup 0ms, import 392ms, tests 16ms, environment 0ms)


=== test/agent/bash-tool.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  08:56:52
   Duration  335ms (transform 17ms, setup 0ms, import 59ms, tests 223ms, environment 0ms)


=== test/agent/connector-datasource-integration.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  08:56:52
   Duration  709ms (transform 278ms, setup 0ms, import 560ms, tests 96ms, environment 0ms)


=== test/agent/datasource-integration.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  08:56:53
   Duration  554ms (transform 160ms, setup 0ms, import 397ms, tests 106ms, environment 0ms)


=== test/agent/dupey-tool.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  08:56:54
   Duration  108ms (transform 13ms, setup 0ms, import 54ms, tests 2ms, environment 0ms)


=== test/agent/emit-results-tool.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  08:56:54
   Duration  114ms (transform 17ms, setup 0ms, import 60ms, tests 2ms, environment 0ms)


=== test/agent/feedback-numbers.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  08:56:54
   Duration  454ms (transform 156ms, setup 0ms, import 391ms, tests 11ms, environment 0ms)


=== test/agent/parser-mirror.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  08:56:55
   Duration  1.16s (transform 165ms, setup 0ms, import 406ms, tests 704ms, environment 0ms)


=== test/agent/refresh-status.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  08:56:56
   Duration  720ms (transform 269ms, setup 0ms, import 529ms, tests 139ms, environment 0ms)


=== test/agent/search-all-tool.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  08:56:57
   Duration  113ms (transform 16ms, setup 0ms, import 59ms, tests 4ms, environment 0ms)


=== test/agent/search-documents-live-e2e.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  08:56:57
   Duration  1.03s (transform 165ms, setup 0ms, import 417ms, tests 558ms, environment 0ms)


=== test/agent/search-documents.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  08:56:58
   Duration  469ms (transform 158ms, setup 0ms, import 399ms, tests 19ms, environment 0ms)


=== test/agent/search-minsync-tool.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  08:56:59
   Duration  155ms (transform 48ms, setup 0ms, import 99ms, tests 5ms, environment 0ms)


=== test/agent/system-prompt.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  08:56:59
   Duration  329ms (transform 77ms, setup 0ms, import 276ms, tests 2ms, environment 0ms)


=== test/agent/tool-merge.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  08:57:00
   Duration  459ms (transform 163ms, setup 0ms, import 402ms, tests 6ms, environment 0ms)


=== test/agent/watch-refresh.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  08:57:00
   Duration  77ms (transform 15ms, setup 0ms, import 20ms, tests 5ms, environment 0ms)


=== test/cli/commands.duplicates.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  08:57:00
   Duration  399ms (transform 186ms, setup 0ms, import 343ms, tests 3ms, environment 0ms)


=== test/cli/commands.feedback.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  08:57:01
   Duration  413ms (transform 193ms, setup 0ms, import 351ms, tests 9ms, environment 0ms)


=== test/cli/commands.health.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  08:57:02
   Duration  397ms (transform 182ms, setup 0ms, import 340ms, tests 2ms, environment 0ms)


=== test/cli/commands.index.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  13 passed (13)
   Start at  08:57:02
   Duration  690ms (transform 273ms, setup 0ms, import 537ms, tests 103ms, environment 0ms)


=== test/cli/commands.init.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  17 passed (17)
   Start at  08:57:03
   Duration  437ms (transform 199ms, setup 0ms, import 362ms, tests 23ms, environment 0ms)


=== test/cli/commands.memory.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  08:57:03
   Duration  419ms (transform 195ms, setup 0ms, import 356ms, tests 11ms, environment 0ms)


=== test/cli/commands.refresh-status.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  08:57:04
   Duration  729ms (transform 274ms, setup 0ms, import 539ms, tests 139ms, environment 0ms)


=== test/cli/commands.search.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  08:57:05
   Duration  600ms (transform 270ms, setup 0ms, import 541ms, tests 6ms, environment 0ms)


=== test/cli/commands.watch.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  08:57:06
   Duration  620ms (transform 265ms, setup 0ms, import 524ms, tests 45ms, environment 0ms)


=== test/cli/config.datasources.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  16 passed (16)
   Start at  08:57:06
   Duration  419ms (transform 187ms, setup 0ms, import 352ms, tests 12ms, environment 0ms)


=== test/cli/config.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  08:57:07
   Duration  409ms (transform 185ms, setup 0ms, import 346ms, tests 6ms, environment 0ms)


=== test/cli/dispatch.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  20 passed (20)
   Start at  08:57:08
   Duration  87ms (transform 25ms, setup 0ms, import 31ms, tests 3ms, environment 0ms)


=== test/cli/output.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  08:57:08
   Duration  76ms (transform 17ms, setup 0ms, import 22ms, tests 2ms, environment 0ms)


=== test/config/vitest-config.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  08:57:08
   Duration  112ms (transform 11ms, setup 0ms, import 57ms, tests 1ms, environment 0ms)


=== test/datasource/access-context.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  22 passed (22)
   Start at  08:57:08
   Duration  92ms (transform 28ms, setup 0ms, import 37ms, tests 3ms, environment 0ms)


=== test/datasource/aliased-skill.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  08:57:09
   Duration  74ms (transform 16ms, setup 0ms, import 21ms, tests 2ms, environment 0ms)


=== test/datasource/connector-skill.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  18 passed (18)
   Start at  08:57:09
   Duration  113ms (transform 39ms, setup 0ms, import 51ms, tests 12ms, environment 0ms)


=== test/datasource/polling.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  31 passed (31)
   Start at  08:57:09
   Duration  77ms (transform 17ms, setup 0ms, import 23ms, tests 3ms, environment 0ms)


=== test/datasource/registry.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  11 passed (11)
   Start at  08:57:09
   Duration  96ms (transform 31ms, setup 0ms, import 41ms, tests 3ms, environment 0ms)


=== test/datasource/result-filter.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  11 passed (11)
   Start at  08:57:10
   Duration  93ms (transform 29ms, setup 0ms, import 38ms, tests 3ms, environment 0ms)


=== test/datasource/scope.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  15 passed (15)
   Start at  08:57:10
   Duration  90ms (transform 28ms, setup 0ms, import 37ms, tests 2ms, environment 0ms)


=== test/datasource/skills/clawgallery/client.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  08:57:10
   Duration  491ms (transform 19ms, setup 0ms, import 25ms, tests 415ms, environment 0ms)


=== test/datasource/skills/clawgallery/skill.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  08:57:11
   Duration  250ms (transform 36ms, setup 0ms, import 197ms, tests 2ms, environment 0ms)


=== test/datasource/skills/discrawl/client.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  21 passed (21)
   Start at  08:57:11
   Duration  2.60s (transform 32ms, setup 0ms, import 43ms, tests 2.50s, environment 0ms)


=== test/datasource/skills/discrawl/skill.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  20 passed (20)
   Start at  08:57:14
   Duration  104ms (transform 39ms, setup 0ms, import 49ms, tests 4ms, environment 0ms)


=== test/datasource/skills/github.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  08:57:14
   Duration  123ms (transform 44ms, setup 0ms, import 56ms, tests 11ms, environment 0ms)


=== test/datasource/skills/gmail.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  08:57:14
   Duration  123ms (transform 44ms, setup 0ms, import 56ms, tests 13ms, environment 0ms)


=== test/datasource/skills/himalaya.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  08:57:15
   Duration  129ms (transform 56ms, setup 0ms, import 71ms, tests 5ms, environment 0ms)


=== test/datasource/skills/katok/client.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  28 passed (28)
   Start at  08:57:15
   Duration  5.46s (transform 28ms, setup 0ms, import 37ms, tests 5.37s, environment 0ms)


=== test/datasource/skills/katok/methods.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  16 passed (16)
   Start at  08:57:20
   Duration  104ms (transform 30ms, setup 0ms, import 39ms, tests 4ms, environment 0ms)


=== test/datasource/skills/katok/skill.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  18 passed (18)
   Start at  08:57:21
   Duration  100ms (transform 34ms, setup 0ms, import 44ms, tests 4ms, environment 0ms)


=== test/datasource/skills/mail-export.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  08:57:21
   Duration  144ms (transform 43ms, setup 0ms, import 74ms, tests 20ms, environment 0ms)


=== test/datasource/skills/notcrawl.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  08:57:21
   Duration  1.20s (transform 36ms, setup 0ms, import 46ms, tests 1.11s, environment 0ms)


=== test/datasource/skills/obsidian.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  9 passed (9)
   Start at  08:57:23
   Duration  569ms (transform 47ms, setup 0ms, import 59ms, tests 455ms, environment 0ms)


=== test/datasource/skills/rclone.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  11 passed (11)
   Start at  08:57:23
   Duration  219ms (transform 80ms, setup 0ms, import 135ms, tests 30ms, environment 0ms)


=== test/datasource/skills/rss.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  08:57:24
   Duration  134ms (transform 46ms, setup 0ms, import 66ms, tests 14ms, environment 0ms)


=== test/datasource/skills/slacrawl.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  08:57:24
   Duration  1.18s (transform 37ms, setup 0ms, import 47ms, tests 1.08s, environment 0ms)


=== test/datasource/skills/spotlight.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  10 passed (10)
   Start at  08:57:25
   Duration  118ms (transform 42ms, setup 0ms, import 54ms, tests 8ms, environment 0ms)


=== test/datasource/skills/telecrawl.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  08:57:26
   Duration  1.21s (transform 37ms, setup 0ms, import 48ms, tests 1.11s, environment 0ms)


=== test/datasource/skills/wacrawl.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  08:57:27
   Duration  1.19s (transform 36ms, setup 0ms, import 45ms, tests 1.10s, environment 0ms)


=== test/dupey/cli.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  08:57:28
   Duration  76ms (transform 17ms, setup 0ms, import 22ms, tests 2ms, environment 0ms)


=== test/dupey/filter.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  08:57:28
   Duration  76ms (transform 17ms, setup 0ms, import 23ms, tests 2ms, environment 0ms)


=== test/integration/full-flow.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  08:57:29
   Duration  457ms (transform 155ms, setup 0ms, import 391ms, tests 16ms, environment 0ms)


=== test/integration/jikji-flow.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  11 passed (11)
   Start at  08:57:29
   Duration  1.30s (transform 159ms, setup 0ms, import 397ms, tests 850ms, environment 0ms)


=== test/integration/minsync-first-sync.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  08:57:31
   Duration  3.41s (transform 199ms, setup 0ms, import 439ms, tests 2.92s, environment 0ms)


=== test/integration/minsync-flow.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  08:57:34
   Duration  1.36s (transform 155ms, setup 0ms, import 396ms, tests 915ms, environment 0ms)


=== test/integration/retrieval-scope-flow.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  08:57:36
   Duration  1.46s (transform 160ms, setup 0ms, import 397ms, tests 1.01s, environment 0ms)


=== test/integration/watch-refresh-flow.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  08:57:37
   Duration  680ms (transform 274ms, setup 0ms, import 539ms, tests 86ms, environment 0ms)


=== test/jikji/answer-pack.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  30 passed (30)
   Start at  08:57:38
   Duration  98ms (transform 20ms, setup 0ms, import 26ms, tests 20ms, environment 0ms)


=== test/jikji/diagnostics.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  11 passed (11)
   Start at  08:57:38
   Duration  77ms (transform 16ms, setup 0ms, import 21ms, tests 4ms, environment 0ms)


=== test/jikji/installer.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  10 passed (10)
   Start at  08:57:39
   Duration  252ms (transform 26ms, setup 0ms, import 33ms, tests 167ms, environment 0ms)


=== test/jikji/jikji-client.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  31 passed (31)
   Start at  08:57:39
   Duration  10.53s (transform 38ms, setup 0ms, import 48ms, tests 10.43s, environment 0ms)


=== test/manifest/manifest.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  08:57:50
   Duration  83ms (transform 15ms, setup 0ms, import 27ms, tests 6ms, environment 0ms)


=== test/memory/check-memory-tool.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  08:57:50
   Duration  148ms (transform 38ms, setup 0ms, import 85ms, tests 14ms, environment 0ms)


=== test/memory/memory.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  31 passed (31)
   Start at  08:57:50
   Duration  463ms (transform 48ms, setup 0ms, import 61ms, tests 349ms, environment 0ms)


=== test/memory/renderer.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  08:57:51
   Duration  75ms (transform 15ms, setup 0ms, import 20ms, tests 2ms, environment 0ms)


=== test/minsync/minsync.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  25 passed (25)
   Start at  08:57:51
   Duration  6.95s (transform 88ms, setup 0ms, import 147ms, tests 6.74s, environment 0ms)


=== test/mirror/sync.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  13 passed (13)
   Start at  08:57:58
   Duration  306ms (transform 70ms, setup 0ms, import 140ms, tests 107ms, environment 0ms)


=== test/observability/run-log.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  08:57:58
   Duration  75ms (transform 13ms, setup 0ms, import 19ms, tests 2ms, environment 0ms)


=== test/parser/archive-budget.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  08:57:59
   Duration  266ms (transform 49ms, setup 0ms, import 99ms, tests 115ms, environment 0ms)


=== test/parser/decode-text.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  14 passed (14)
   Start at  08:57:59
   Duration  211ms (transform 25ms, setup 0ms, import 35ms, tests 120ms, environment 0ms)


=== test/parser/hwp-markdown.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  08:57:59
   Duration  86ms (transform 20ms, setup 0ms, import 26ms, tests 2ms, environment 0ms)


=== test/parser/ocr.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  08:58:00
   Duration  185ms (transform 62ms, setup 0ms, import 116ms, tests 5ms, environment 0ms)


=== test/parser/parser.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  12 passed (12)
   Start at  08:58:00
   Duration  493ms (transform 60ms, setup 0ms, import 112ms, tests 326ms, environment 0ms)


=== test/parser/rhwp-adapter.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  52 passed (52)
   Start at  08:58:01
   Duration  111ms (transform 35ms, setup 0ms, import 45ms, tests 13ms, environment 0ms)


=== test/process/portable-spawn.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  08:58:01
   Duration  75ms (transform 14ms, setup 0ms, import 19ms, tests 3ms, environment 0ms)


=== test/retrieval/bm25.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  10 passed (10)
   Start at  08:58:01
   Duration  2.26s (transform 163ms, setup 0ms, import 401ms, tests 1.80s, environment 0ms)


=== test/retrieval/evidence-id.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  08:58:04
   Duration  75ms (transform 14ms, setup 0ms, import 20ms, tests 2ms, environment 0ms)


=== test/retrieval/merger.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  15 passed (15)
   Start at  08:58:04
   Duration  87ms (transform 23ms, setup 0ms, import 29ms, tests 4ms, environment 0ms)


=== test/retrieval/scope-resolution.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  08:58:04
   Duration  87ms (transform 25ms, setup 0ms, import 33ms, tests 2ms, environment 0ms)


=== test/security/redos.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  08:58:04
   Duration  99ms (transform 24ms, setup 0ms, import 32ms, tests 14ms, environment 0ms)


=== test/smoke.test.ts ===

 RUN  v4.1.11 /Volumes/SSD1/4/AutoRAG


 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  08:58:05
   Duration  578ms (transform 267ms, setup 0ms, import 524ms, tests 2ms, environment 0ms)


All 90 test files passed.
bun run build
Bundled 146 modules in 7ms

  index.js     0.49 MB  (entry point)
  cli/index.js  0.55 MB  (entry point) (90 test files passed; lint, typecheck, tests, build)