### PR TITLE
fix(minsync): invalidate cursor before chunk rebuild

### DIFF
--- a/src/minsync/client.ts
+++ b/src/minsync/client.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { configuredMaxChunkSize, minSyncConfigPath, rewriteEmbedderConfig } from "./embedder-config.ts";
 import { spawnProcess } from "./process.ts";
@@ -91,12 +91,14 @@ export class MinSyncClient {
 			return { ok: false, synced: 0, workspacePath: this.workspacePath, reason: checkFailure };
 		}
 		const chunkSizeChanged = this.maxChunkSize !== undefined && configuredChunkSize !== this.maxChunkSize;
+		if (chunkSizeChanged) rmSync(cursorPath, { force: true });
 		const syncArgs =
 			existsSync(cursorPath) && !chunkSizeChanged
 				? ["sync", "--format", "json"]
 				: ["sync", "--full", "--format", "json"];
 		const result = await this.spawn(syncArgs, spawnOpts);
 		if (!result.ok) {
+			if (chunkSizeChanged) rmSync(cursorPath, { force: true });
 			restoreConfig();
 			return {
 				ok: false,
@@ -106,6 +108,7 @@ export class MinSyncClient {
 			};
 		}
 		if (!existsSync(cursorPath)) {
+			if (chunkSizeChanged) rmSync(cursorPath, { force: true });
 			restoreConfig();
 			return { ok: false, synced: 0, workspacePath: this.workspacePath, reason: "not-ready: missing cursor" };
 		}

--- a/test/minsync/minsync.test.ts
+++ b/test/minsync/minsync.test.ts
@@ -902,9 +902,12 @@ max_chunk_size = 4096
 		writeFileSync(
 			minsyncBinary,
 			`#!/usr/bin/env node
-import { appendFileSync } from "node:fs";
+import { appendFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
 const args = process.argv.slice(2);
-appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({ args }) + "\\n");
+const cursor = join(process.cwd(), ".minsync", "cursor.json");
+const entry = { args, ...(args[0] === "sync" ? { cursorExists: existsSync(cursor) } : {}) };
+appendFileSync(${JSON.stringify(logPath)}, JSON.stringify(entry) + "\\n");
 if (args[0] === "check") process.stdout.write('{"embedder_ok":true,"vectorstore_ok":true}');
 if (args[0] === "sync") process.exit(1);
 `,
@@ -920,6 +923,11 @@ if (args[0] === "sync") process.exit(1);
 
 		expect(result).toMatchObject({ ok: false, reason: "sync-failed" });
 		expect(readFileSync(minSyncConfigPath(minsyncWorkspace), "utf8")).toBe(originalConfig);
+		expect(existsSync(join(minsyncConfigDir, "cursor.json"))).toBe(false);
+		const syncCall = loggedCalls()
+			.map((line) => JSON.parse(line) as { args: string[]; cursorExists?: boolean })
+			.find((call) => call.args[0] === "sync");
+		expect(syncCall?.cursorExists).toBe(false);
 	});
 
 	it("uses the MinSync chunk size for BM25-only indexing", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #1497. When minSync.maxChunkSize changes, invalidate the existing MinSync cursor before the forced full rebuild. If the rebuild fails or does not produce a new cursor, keep the cursor invalidated so a later run cannot incorrectly use incremental sync with the old index state.

## Validation

- unx vitest run test/minsync/minsync.test.ts -t 'forces a full sync when the configured chunk size changes|restores the previous config when a forced full sync fails|uses the MinSync chunk size for BM25-only indexing' — passed.
- unx vitest run test/retrieval/bm25.test.ts — 11 passed.
- un run build — passed.
- un run typecheck — passed.
- Changed-file Biome check and git diff --check — passed.
- The broader local suite remains limited by unrelated 60-second agent lifecycle/tool-call-limit test timeouts on this Windows host; GitHub CI for #1497 passed on build, macOS, and Windows.
