### PR TITLE
fix: report insufficient Java version for PDF parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,19 @@ bun install -g @autorag/librarian   # autorag CLI
 bun add github:NomaDamas/AutoRAG-2.0
 ```
 
+PDF parsing requires **Java 11 or newer** because the bundled
+`@opendataloader/pdf` runtime is compiled for Java 11. This applies to
+Windows, macOS, and Linux. Verify the runtime that will be selected from
+`PATH` before indexing PDFs:
+
+```bash
+java -version
+```
+
+On Windows, ensure a Java 11+ installation appears before older Java
+installations in `PATH` (or set `JAVA_HOME` to the Java 11+ installation and
+start a new shell). Java 8 is not supported by the PDF parser.
+
 Git-based installs build `dist/` via the `prepare` script and require Bun on the installing machine.
 External tool binaries auto-install on first use into `<workspace>/.autorag/bin`: **MinSync** downloads a verified GitHub release asset (on by default; `minSync.autoInstall: false` to opt out), and **Jikji** compiles the [`jikji-cli`](https://crates.io/crates/jikji-cli) crate via cargo (requires the [Rust toolchain](https://rustup.rs); `jikji.autoInstall: false` to opt out). New `autorag init` configs enable Jikji find-first discovery by default. KakaoTalk (`katok`) and Discord (`discrawl`) stay manual, optional installs. All of them degrade gracefully when missing — core BM25 search works without any of them.
 

--- a/src/agent/search-documents.ts
+++ b/src/agent/search-documents.ts
@@ -21,6 +21,7 @@ export type SearchDocumentDiagnosticCode =
 	| "minsync-unavailable"
 	| "parser-skipped"
 	| "parser-failed"
+	| "pdf-java-version"
 	| "duplicate-excluded"
 	| "unsupported-file"
 	| "stale-index"

--- a/src/mirror/sync.ts
+++ b/src/mirror/sync.ts
@@ -7,7 +7,7 @@ import { createDefaultParserRegistry, type DefaultParserRegistryOptions } from "
 import { ParseError } from "../parser/errors.ts";
 import type { ParserRegistry } from "../parser/registry.ts";
 import { normalizeMarkdown } from "../parser/text.ts";
-import type { ParseOutput } from "../parser/types.ts";
+import type { ParseOutput, Parser } from "../parser/types.ts";
 import { loadMirrorIndex, type ParsedMirrorEntry, type ParsedMirrorIndex, saveMirrorIndex } from "./index-store.ts";
 import { parsedMirrorIndexPath, parsedOutputPath } from "./paths.ts";
 
@@ -56,6 +56,7 @@ export type ParsedMirrorDiagnosticCode =
 	| "unsupported-file"
 	| "parser-skipped"
 	| "parser-failed"
+	| "pdf-java-version"
 	| "duplicate-excluded"
 	| "deleted-mirror"
 	| "stale-index"
@@ -84,6 +85,19 @@ interface CurrentEntry {
 	readonly sourcePath: string;
 	readonly sizeBytes: number;
 	readonly mtimeNs: number;
+}
+
+function parserFailureCode(parser: Parser, error: ParseError): ParsedMirrorDiagnosticCode {
+	return parser.name === "opendataloader-pdf" && /UnsupportedClassVersionError/.test(error.message)
+		? "pdf-java-version"
+		: "parser-failed";
+}
+
+function parserFailureMessage(parser: Parser, error: ParseError): string {
+	if (parserFailureCode(parser, error) === "pdf-java-version") {
+		return "PDF parsing requires Java 11 or newer; the Java runtime selected from PATH is too old.";
+	}
+	return "The registered parser failed on this file; it was skipped during indexing.";
 }
 
 export async function syncParsedMirrors(options: ParsedMirrorSyncOptions): Promise<ParsedMirrorSyncResult> {
@@ -171,9 +185,9 @@ export async function syncParsedMirrors(options: ParsedMirrorSyncOptions): Promi
 				handledPrevious.add(entry.virtualPath);
 				skipped += 1;
 				diagnostics.push({
-					code: "parser-failed",
+					code: parserFailureCode(parser, error),
 					severity: "warning",
-					message: "The registered parser failed on this file; it was skipped during indexing.",
+					message: parserFailureMessage(parser, error),
 					source: entry.virtualPath,
 				});
 				sinceCheckpoint += 1;

--- a/test/mirror/sync.test.ts
+++ b/test/mirror/sync.test.ts
@@ -19,7 +19,7 @@ import {
 	saveMirrorIndex,
 	syncParsedMirrors,
 } from "../../src/mirror/index.ts";
-import { createDefaultParserRegistry } from "../../src/parser/index.ts";
+import { createDefaultParserRegistry, ParseError, Parser, ParserRegistry } from "../../src/parser/index.ts";
 
 let root: string;
 let source: string;
@@ -238,6 +238,38 @@ describe("syncParsedMirrors", () => {
 		expect(result.scanned).toBe(1);
 		expect(result.written).toBe(1);
 		expect(diag).toBeUndefined();
+		expect(JSON.stringify(result.diagnostics)).not.toContain(root);
+	});
+
+	class FailingPdfParser extends Parser {
+		readonly name = "opendataloader-pdf";
+		readonly extensions = [".pdf"];
+
+		async parse(input: { readonly virtualPath: string }): Promise<never> {
+			throw new ParseError(
+				this.name,
+				input.virtualPath,
+				new Error("UnsupportedClassVersionError: class file version 55.0"),
+			);
+		}
+	}
+
+	it("reports the Java runtime requirement when PDF parsing uses an old Java", async () => {
+		writeFileSync(join(source, "legacy.pdf"), Buffer.from("pdf"));
+
+		const result = await syncParsedMirrors({
+			root,
+			searchPaths: [source],
+			registry: new ParserRegistry([new FailingPdfParser()]),
+		});
+		const diag = result.diagnostics.find((d) => d.source === "/docs/legacy.pdf");
+
+		expect(diag).toEqual({
+			code: "pdf-java-version",
+			severity: "warning",
+			message: "PDF parsing requires Java 11 or newer; the Java runtime selected from PATH is too old.",
+			source: "/docs/legacy.pdf",
+		});
 		expect(JSON.stringify(result.diagnostics)).not.toContain(root);
 	});
 


### PR DESCRIPTION
## Summary

OpenDataLoader PDF parsing fails when an older Java runtime is first on PATH, but mirror refresh reports only a generic parser failure. This change reports the Java 11+ requirement for the known class-version failure while preserving generic diagnostics for other parser errors.

Fixes #1514

## Verification

- Focused mirror tests
- `make lint`
- `make typecheck`
- `git diff --check`

## Reviewers

@vkehfdl1