### PR TITLE
fix(agent): align bash cancellation with oh-my-pi

### DIFF
--- a/scripts/manual-qa/issue-1500-process-tree.mjs
+++ b/scripts/manual-qa/issue-1500-process-tree.mjs
@@ -5,6 +5,7 @@ import { createBashTool } from "../../src/agent/bash-tool.ts";
 
 const workspace = mkdtempSync(join(tmpdir(), "autorag-issue-1500-"));
 const pidPath = join(workspace, "child.pid");
+let allPassed = true;
 
 const waitForFile = async (path) => {
 	if (existsSync(path)) return;
@@ -43,9 +44,11 @@ try {
 	const timeoutResult = await timeoutExecution;
 	const timeoutElapsedMs = Math.round(performance.now() - timeoutStarted);
 	const timeoutText = timeoutResult.content[0].text;
+	const timeoutPass = timeoutResult.details.timedOut && !isAlive(childPid) && timeoutText.includes("command timed out after 120ms");
+	allPassed &&= timeoutPass;
 	console.log(JSON.stringify({
 		scenario: "timeout process tree",
-		pass: timeoutResult.details.timedOut && !isAlive(childPid) && timeoutText.includes("command timed out after 120ms"),
+		pass: timeoutPass,
 		elapsedMs: timeoutElapsedMs,
 		childPid,
 		childAlive: isAlive(childPid),
@@ -53,9 +56,11 @@ try {
 	}));
 
 	const failedResult = await tool.execute("manual-failure", { command: "printf fail >&2; exit 7" });
+	const failedPass = failedResult.details.exitCode === 7 && failedResult.content[0].text.includes("exit code 7");
+	allPassed &&= failedPass;
 	console.log(JSON.stringify({
 		scenario: "failed command",
-		pass: failedResult.details.exitCode === 7 && failedResult.content[0].text.includes("exit code 7"),
+		pass: failedPass,
 		exitCode: failedResult.details.exitCode,
 		text: failedResult.content[0].text,
 	}));
@@ -69,13 +74,16 @@ try {
 	const abortChildPid = Number(readFileSync(abortPidPath, "utf8"));
 	controller.abort();
 	const abortResult = await abortExecution;
+	const abortPass = !abortResult.details.timedOut && !isAlive(abortChildPid);
+	allPassed &&= abortPass;
 	console.log(JSON.stringify({
 		scenario: "abort process tree",
-		pass: !abortResult.details.timedOut && !isAlive(abortChildPid),
+		pass: abortPass,
 		childPid: abortChildPid,
 		childAlive: isAlive(abortChildPid),
 	}));
 } finally {
 	rmSync(workspace, { recursive: true, force: true });
 	console.log(JSON.stringify({ cleanup: "removed temporary workspace", workspace }));
+	if (!allPassed) process.exitCode = 1;
 }

--- a/src/agent/bash-tool.ts
+++ b/src/agent/bash-tool.ts
@@ -7,6 +7,7 @@ export const BASH_TOOL_NAME = "bash";
 
 const DEFAULT_TIMEOUT_MS = 120_000;
 const DEFAULT_MAX_OUTPUT_BYTES = 131_072;
+const KILL_EXIT_GRACE_MS = 5_000;
 
 const bashSchema = Type.Object({
 	command: Type.String({
@@ -40,6 +41,7 @@ const CLOUD_CONTENT_COMMAND = /\b(?:rg|ripgrep|grep|egrep|fgrep|cat|less|more|he
 interface RunResult {
 	readonly output: string;
 	readonly exitCode: number | undefined;
+	readonly aborted: boolean;
 	readonly timedOut: boolean;
 	readonly truncated: boolean;
 }
@@ -52,13 +54,19 @@ function runCommand(
 	signal?: AbortSignal,
 ): Promise<RunResult> {
 	return new Promise((resolve) => {
+		if (signal?.aborted) {
+			resolve({ output: "", exitCode: undefined, aborted: true, timedOut: false, truncated: false });
+			return;
+		}
 		const shell = process.platform === "win32" ? "bash.exe" : "/bin/bash";
-		const child = spawn(shell, ["-c", command], { cwd, detached: true });
+		const child = spawn(shell, ["-c", command], { cwd, detached: process.platform !== "win32" });
 		const chunks: Buffer[] = [];
 		let total = 0;
 		let truncated = false;
 		let timedOut = false;
+		let aborted = false;
 		let settled = false;
+		let killGraceTimer: ReturnType<typeof setTimeout> | undefined;
 
 		const collect = (data: Buffer) => {
 			if (total >= maxOutputBytes) {
@@ -83,38 +91,62 @@ function runCommand(
 			if (settled) return;
 			settled = true;
 			clearTimeout(timer);
+			if (killGraceTimer !== undefined) clearTimeout(killGraceTimer);
 			signal?.removeEventListener("abort", onAbort);
-			resolve({ output: Buffer.concat(chunks).toString("utf8"), exitCode, timedOut, truncated });
+			resolve({ output: Buffer.concat(chunks).toString("utf8"), exitCode, aborted, timedOut, truncated });
 		};
 
 		const killProcessTree = () => {
 			if (child.pid === undefined) return;
 			if (process.platform === "win32") {
-				spawnSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: "ignore" });
+				try {
+					const result = spawnSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+						stdio: "ignore",
+						timeout: KILL_EXIT_GRACE_MS,
+					});
+					if (result.status === 0) return;
+				} catch {
+					// Fall through to the direct-process fallback.
+				}
+				try {
+					child.kill("SIGKILL");
+				} catch {
+					// The process may already have exited.
+				}
 				return;
 			}
 			try {
 				process.kill(-child.pid, "SIGKILL");
-			} catch (error) {
-				if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+			} catch {
+				try {
+					child.kill("SIGKILL");
+				} catch {
+					// The process may already have exited.
+				}
 			}
+		};
+
+		const releaseAfterKill = () => {
+			child.stdout?.destroy();
+			child.stderr?.destroy();
+			killGraceTimer = setTimeout(() => finish(undefined), KILL_EXIT_GRACE_MS);
 		};
 
 		const timer = setTimeout(() => {
 			timedOut = true;
 			killProcessTree();
-			child.stdout?.destroy();
-			child.stderr?.destroy();
-			setTimeout(() => finish(undefined), 50);
+			releaseAfterKill();
 		}, timeoutMs);
 
 		const onAbort = () => {
+			aborted = true;
 			killProcessTree();
-			child.stdout?.destroy();
-			child.stderr?.destroy();
-			setTimeout(() => finish(undefined), 50);
+			releaseAfterKill();
 		};
-		signal?.addEventListener("abort", onAbort, { once: true });
+		if (signal) {
+			if (signal.aborted) onAbort();
+			else signal.addEventListener("abort", onAbort, { once: true });
+		}
 
 		child.on("error", () => finish(undefined));
 		child.on("close", (code) => finish(code === null ? undefined : code));
@@ -178,7 +210,7 @@ export function createBashTool(options: BashToolOptions): AgentTool<typeof bashS
 			const run = await runCommand(command, cwd, timeoutMs, maxOutputBytes, signal);
 
 			const parts: string[] = [];
-			parts.push(run.output.length > 0 ? run.output : "(no output)");
+			parts.push(run.output.length > 0 ? run.output : run.aborted ? "(command aborted)" : "(no output)");
 			if (run.timedOut) parts.push(`\n(command timed out after ${timeoutMs}ms and was killed)`);
 			if (run.truncated) parts.push(`\n(output truncated at ${maxOutputBytes} bytes)`);
 			if (run.exitCode !== undefined && run.exitCode !== 0 && !run.timedOut) {

--- a/src/agent/bash-tool.ts
+++ b/src/agent/bash-tool.ts
@@ -1,4 +1,4 @@
-import { spawn, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 import { Type } from "typebox";
 import { classifyFilesystemRoot, isDatalessPlaceholder } from "../filesystem/cloud-placeholder.ts";
@@ -31,7 +31,9 @@ export interface BashToolOptions {
 export interface BashToolDetails {
 	readonly method: "bash";
 	readonly command: string;
+	readonly aborted: boolean;
 	readonly exitCode: number | undefined;
+	readonly terminationFailed: boolean;
 	readonly timedOut: boolean;
 	readonly truncated: boolean;
 }
@@ -42,6 +44,7 @@ interface RunResult {
 	readonly output: string;
 	readonly exitCode: number | undefined;
 	readonly aborted: boolean;
+	readonly terminationFailed: boolean;
 	readonly timedOut: boolean;
 	readonly truncated: boolean;
 }
@@ -55,7 +58,14 @@ function runCommand(
 ): Promise<RunResult> {
 	return new Promise((resolve) => {
 		if (signal?.aborted) {
-			resolve({ output: "", exitCode: undefined, aborted: true, timedOut: false, truncated: false });
+			resolve({
+				output: "",
+				exitCode: undefined,
+				aborted: true,
+				terminationFailed: false,
+				timedOut: false,
+				truncated: false,
+			});
 			return;
 		}
 		const shell = process.platform === "win32" ? "bash.exe" : "/bin/bash";
@@ -67,6 +77,11 @@ function runCommand(
 		let aborted = false;
 		let settled = false;
 		let killGraceTimer: ReturnType<typeof setTimeout> | undefined;
+		let terminationRequested = false;
+		let terminationStarted = false;
+		let terminationSettled = false;
+		let terminationFailed = false;
+		let pendingExitCode: number | undefined;
 
 		const collect = (data: Buffer) => {
 			if (total >= maxOutputBytes) {
@@ -89,59 +104,86 @@ function runCommand(
 
 		const finish = (exitCode: number | undefined) => {
 			if (settled) return;
+			if (terminationRequested && !terminationSettled) {
+				pendingExitCode = exitCode;
+				return;
+			}
 			settled = true;
 			clearTimeout(timer);
 			if (killGraceTimer !== undefined) clearTimeout(killGraceTimer);
 			signal?.removeEventListener("abort", onAbort);
-			resolve({ output: Buffer.concat(chunks).toString("utf8"), exitCode, aborted, timedOut, truncated });
+			resolve({
+				output: Buffer.concat(chunks).toString("utf8"),
+				exitCode,
+				aborted,
+				terminationFailed,
+				timedOut,
+				truncated,
+			});
 		};
 
-		const killProcessTree = () => {
-			if (child.pid === undefined) return;
+		const killDirectChild = (): boolean => {
+			try {
+				return child.kill("SIGKILL");
+			} catch {
+				return false;
+			}
+		};
+
+		const killProcessTree = async (): Promise<boolean> => {
+			if (child.pid === undefined) return true;
 			if (process.platform === "win32") {
-				try {
-					const result = spawnSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
-						stdio: "ignore",
-						timeout: KILL_EXIT_GRACE_MS,
-					});
-					if (result.status === 0) return;
-				} catch {
-					// Fall through to the direct-process fallback.
-				}
-				try {
-					child.kill("SIGKILL");
-				} catch {
-					// The process may already have exited.
-				}
-				return;
+				return await new Promise<boolean>((resolve) => {
+					const killer = spawn("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: "ignore" });
+					let completed = false;
+					const graceTimer = setTimeout(() => {
+						if (completed) return;
+						completed = true;
+						killer.kill();
+						resolve(killDirectChild());
+					}, KILL_EXIT_GRACE_MS);
+					const finishKill = (success: boolean) => {
+						if (completed) return;
+						completed = true;
+						clearTimeout(graceTimer);
+						if (!success) killDirectChild();
+						resolve(success);
+					};
+					killer.on("error", () => finishKill(false));
+					killer.on("close", (code) => finishKill(code === 0));
+				});
 			}
 			try {
 				process.kill(-child.pid, "SIGKILL");
+				return true;
 			} catch {
-				try {
-					child.kill("SIGKILL");
-				} catch {
-					// The process may already have exited.
-				}
+				killDirectChild();
+				return false;
 			}
 		};
 
-		const releaseAfterKill = () => {
+		const releaseAfterKill = async () => {
+			if (terminationStarted) return;
+			terminationStarted = true;
+			const killed = await killProcessTree();
+			terminationSettled = true;
+			terminationFailed = !killed;
 			child.stdout?.destroy();
 			child.stderr?.destroy();
 			killGraceTimer = setTimeout(() => finish(undefined), KILL_EXIT_GRACE_MS);
+			if (pendingExitCode !== undefined) finish(pendingExitCode);
 		};
 
 		const timer = setTimeout(() => {
 			timedOut = true;
-			killProcessTree();
-			releaseAfterKill();
+			terminationRequested = true;
+			void releaseAfterKill();
 		}, timeoutMs);
 
 		const onAbort = () => {
 			aborted = true;
-			killProcessTree();
-			releaseAfterKill();
+			terminationRequested = true;
+			void releaseAfterKill();
 		};
 		if (signal) {
 			if (signal.aborted) onAbort();
@@ -172,7 +214,15 @@ export function createBashTool(options: BashToolOptions): AgentTool<typeof bashS
 			if (command.length === 0) {
 				return {
 					content: [{ type: "text", text: "Command was empty; nothing was run." }],
-					details: { method: "bash", command: "", exitCode: undefined, timedOut: false, truncated: false },
+					details: {
+						method: "bash",
+						command: "",
+						aborted: false,
+						exitCode: undefined,
+						terminationFailed: false,
+						timedOut: false,
+						truncated: false,
+					},
 				};
 			}
 			const cwd = typeof params.cwd === "string" && params.cwd.length > 0 ? params.cwd : options.cwd;
@@ -188,7 +238,15 @@ export function createBashTool(options: BashToolOptions): AgentTool<typeof bashS
 									"Use the configured cloud-drive datasource or a materialized local file.",
 							},
 						],
-						details: { method: "bash", command, exitCode: undefined, timedOut: false, truncated: false },
+						details: {
+							method: "bash",
+							command,
+							aborted: false,
+							exitCode: undefined,
+							terminationFailed: false,
+							timedOut: false,
+							truncated: false,
+						},
 					};
 				}
 				if (await isDatalessPlaceholder(cwd)) {
@@ -201,7 +259,15 @@ export function createBashTool(options: BashToolOptions): AgentTool<typeof bashS
 									"Use the configured cloud-drive datasource or materialize the file first.",
 							},
 						],
-						details: { method: "bash", command, exitCode: undefined, timedOut: false, truncated: false },
+						details: {
+							method: "bash",
+							command,
+							aborted: false,
+							exitCode: undefined,
+							terminationFailed: false,
+							timedOut: false,
+							truncated: false,
+						},
 					};
 				}
 			}
@@ -216,13 +282,16 @@ export function createBashTool(options: BashToolOptions): AgentTool<typeof bashS
 			if (run.exitCode !== undefined && run.exitCode !== 0 && !run.timedOut) {
 				parts.push(`\n(exit code ${run.exitCode})`);
 			}
+			if (run.terminationFailed) parts.push("\n(process termination failed)");
 
 			return {
 				content: [{ type: "text", text: parts.join("") }],
 				details: {
 					method: "bash",
 					command,
+					aborted: run.aborted,
 					exitCode: run.exitCode,
+					terminationFailed: run.terminationFailed,
 					timedOut: run.timedOut,
 					truncated: run.truncated,
 				},

--- a/test/agent/bash-tool.test.ts
+++ b/test/agent/bash-tool.test.ts
@@ -107,6 +107,26 @@ describe("createBashTool", () => {
 		expect(result.details.timedOut).toBe(true);
 	});
 
+	it("does not run a command when the signal is already aborted", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		const markerPath = join(tmpDir, "already-aborted-ran");
+		const tool = createBashTool({ cwd: tmpDir, timeoutMs: 1_000 });
+
+		const result = await tool.execute(
+			"call-already-aborted",
+			{ command: `printf ran > ${markerPath}` },
+			controller.signal,
+		);
+
+		expect(existsSync(markerPath)).toBe(false);
+		expect(result.content[0]).toMatchObject({
+			type: "text",
+			text: expect.stringContaining("(command aborted)"),
+		});
+		expect(result.details.timedOut).toBe(false);
+	});
+
 	it("kills a process tree and resolves on process tree timeout", async () => {
 		const pidPath = join(tmpDir, "timeout-child.pid");
 		const tool = createBashTool({ cwd: tmpDir, timeoutMs: 100 });

--- a/test/agent/bash-tool.test.ts
+++ b/test/agent/bash-tool.test.ts
@@ -144,6 +144,8 @@ describe("createBashTool", () => {
 		]);
 
 		expect(result.details.timedOut).toBe(true);
+		expect(result.details.terminationFailed).toBe(false);
+		expect(result.details.aborted).toBe(false);
 		expect(result.content[0]).toMatchObject({
 			type: "text",
 			text: expect.stringContaining("(command timed out after 100ms and was killed)"),
@@ -172,6 +174,8 @@ describe("createBashTool", () => {
 		]);
 
 		expect(result.details.timedOut).toBe(false);
+		expect(result.details.aborted).toBe(true);
+		expect(result.details.terminationFailed).toBe(false);
 		expect(isProcessAlive(childPid)).toBe(false);
 	});
 


### PR DESCRIPTION
## Summary

Follow oh-my-pi's subprocess lifecycle behavior for AutoRAG's bash tool after #1502. This PR addresses the cancellation and cleanup gaps identified in #1515.

## Changes

- Do not spawn a command when the caller's `AbortSignal` is already aborted.
- Report an explicit `(command aborted)` result for pre-aborted commands.
- Use a bounded 5-second exit grace period instead of resolving unconditionally after 50ms.
- Wait for the child close path where possible while still avoiding hangs from inherited stdio.
- Use POSIX process groups only on POSIX, matching oh-my-pi; use Windows `taskkill /T /F` on Windows.
- Handle process-kill failures without uncaught exceptions, with direct child termination as fallback.
- Make manual QA exit nonzero when any scenario reports `pass: false`.
- Add regression coverage for already-aborted signals.

## Verification

- `bun test test/agent/bash-tool.test.ts` - 12 passed
- `bun run typecheck` - passed
- `bun run build` - passed
- `node scripts/manual-qa/issue-1500-process-tree.mjs` - timeout, abort, and nonzero-exit scenarios passed

## Scope

This PR follows oh-my-pi's process-group/session boundary. It does not claim to contain a deliberately daemonized descendant that creates a new session; that limitation remains documented in #1515.

## Issue links

Fixes #1515
Related to #1502
Related to #1500