### PR TITLE
release: v2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorag/librarian",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Self-evolving librarian agent on Pi framework with pluggable retrieval methods",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Patch release cutting `v2.4.1` after the progressive search streaming work in #1523.

Fixes shipped since `v2.4.0`:

- **Baseline retrieval returned no candidates whenever a duplicate chunk was present.** The dedup filter compared positions against a `Map` that keeps the *last* duplicate, so any repeated `(source, content)` pair dropped the entire candidate list instead of just the repeat.
- **Existing installs failed on every command.** A persisted `minSync.binaryPath` was rejected by the config allowlist, throwing `ConfigError` before any command could run. The legacy key is now ignored, matching the existing BM25 precedent.
- `RetrievalMethodRegistry.getByType` widened to the descriptor union so datasource methods declaring `type: "bm25"` stay reachable.
- Replaced a hardcoded Korean progress string in library code with English.
- Removed stale skill-doc references advertising `--method bm25`, which the CLI now rejects.

## Verification

- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `node_modules/.bin/vitest run` — 964 tests across 104 files passing (the same command the release workflow runs)
- Manual QA on the built CLI: `--help`, `status`, `refresh --method minsync,parsed`, `evidence` usage/error paths, and a regression check that a config carrying legacy `minSync.binaryPath` now starts instead of hard-failing

Tagging `v2.4.1` after merge triggers the npm publish + GitHub release workflow.