### PR TITLE
feat(p2p): add local peer persona targeting

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -85,6 +85,7 @@ import {
 	type MergedJikjiPolicy,
 } from "./jikji-find-tool.ts";
 import { loadLocalAutoRAGModel } from "./local-model.ts";
+import { createRecommendPeerTargetsTool, RECOMMEND_PEER_TARGETS_TOOL_NAME } from "./peer-target-tool.ts";
 import { createSearchAllDocumentsTool, SEARCH_ALL_DOCUMENTS_TOOL_NAME } from "./search-all-tool.ts";
 import { createSearchBM25DocumentsTool, SEARCH_BM25_DOCUMENTS_TOOL_NAME } from "./search-bm25-tool.ts";
 import {
@@ -409,6 +410,7 @@ export class AutoRAGAgent {
 		const bashTool = createBashTool({
 			cwd: this.workspaceProjectRoot,
 		});
+		const peerTargetTool = this.remoteSession ? undefined : createRecommendPeerTargetsTool(this.workspaceProjectRoot);
 
 		const jikjiFindTool = this.jikjiClient !== undefined ? createJikjiFindTool(this) : undefined;
 
@@ -425,6 +427,7 @@ export class AutoRAGAgent {
 			SEARCH_ALL_DOCUMENTS_TOOL_NAME,
 			JIKJI_FIND_TOOL_NAME,
 			SCAN_DUPLICATE_DOCUMENTS_TOOL_NAME,
+			RECOMMEND_PEER_TARGETS_TOOL_NAME,
 		]);
 		const droppedCallerToolNames: string[] = [];
 		const callerTools = (options.tools ?? []).filter((tool) => {
@@ -450,6 +453,7 @@ export class AutoRAGAgent {
 			emitResultsTool,
 			...(scanDuplicateDocumentsTool !== undefined ? [scanDuplicateDocumentsTool] : []),
 			...(jikjiFindTool !== undefined ? [jikjiFindTool] : []),
+			...(peerTargetTool !== undefined ? [peerTargetTool] : []),
 		];
 		const seenToolNames = new Set<string>();
 		const tools = orderedTools.filter((tool) => {

--- a/src/agent/peer-target-tool.ts
+++ b/src/agent/peer-target-tool.ts
@@ -1,0 +1,55 @@
+import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
+import { Type } from "typebox";
+import { loadSimplexPeerRegistry, rankSimplexPeerTargets } from "../p2p/simplex-server.ts";
+
+export const RECOMMEND_PEER_TARGETS_TOOL_NAME = "recommend_peer_targets";
+
+const recommendPeerTargetsSchema = Type.Object({
+	query: Type.String({ description: "Question or topic to match against local peer personas." }),
+});
+
+export interface PeerTargetRecommendation {
+	readonly alias: string;
+	readonly matchedTerms: readonly string[];
+	readonly displayName?: string;
+	readonly description?: string;
+}
+
+export interface RecommendPeerTargetsDetails {
+	readonly method: "recommend_peer_targets";
+	readonly resultCount: number;
+	readonly matches: readonly PeerTargetRecommendation[];
+}
+
+export function createRecommendPeerTargetsTool(
+	workspacePath: string,
+): AgentTool<typeof recommendPeerTargetsSchema, RecommendPeerTargetsDetails> {
+	return {
+		name: RECOMMEND_PEER_TARGETS_TOOL_NAME,
+		label: "Recommend Peer Targets",
+		description:
+			"Recommend local peer personas to ask about a topic using explainable keyword matches. Read-only; never contacts peers.",
+		parameters: recommendPeerTargetsSchema,
+		async execute(_toolCallId, params): Promise<AgentToolResult<RecommendPeerTargetsDetails>> {
+			const registry = loadSimplexPeerRegistry(workspacePath);
+			const matches = rankSimplexPeerTargets(params.query, registry).map((match) => {
+				const peer = registry[match.alias];
+				return {
+					alias: match.alias,
+					matchedTerms: match.matchedTerms,
+					...(peer?.displayName !== undefined ? { displayName: peer.displayName } : {}),
+					...(peer?.description !== undefined ? { description: peer.description } : {}),
+				};
+			});
+			const details: RecommendPeerTargetsDetails = {
+				method: "recommend_peer_targets",
+				resultCount: matches.length,
+				matches,
+			};
+			return {
+				content: [{ type: "text", text: JSON.stringify(details) }],
+				details,
+			};
+		},
+	};
+}

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -42,6 +42,11 @@ export function buildSystemPrompt(config: SystemPromptConfig): string {
 		toolLine(config, "load_datasource_skill", "load instructions for an authorized datasource"),
 		toolLine(config, "scan_duplicate_documents", "read-only dupey scan of configured local document roots"),
 		toolLine(config, "check_memory", "inspect advisory retrieval hints from prior feedback"),
+		toolLine(
+			config,
+			"recommend_peer_targets",
+			"recommend local peer personas to ask about a topic without contacting them",
+		),
 		toolLine(config, "emit_autorag_results", "return the final structured answer and number-to-source mapping"),
 		...config.toolNames
 			.filter(
@@ -56,6 +61,7 @@ export function buildSystemPrompt(config: SystemPromptConfig): string {
 						"load_datasource_skill",
 						"scan_duplicate_documents",
 						"check_memory",
+						"recommend_peer_targets",
 						"emit_autorag_results",
 					].includes(name),
 			)

--- a/src/cli/commands/p2p.ts
+++ b/src/cli/commands/p2p.ts
@@ -1,5 +1,10 @@
 import { listPendingPeerRequests, loadPendingPeerRequest, writePeerRequestDecision } from "../../p2p/approval-store.ts";
-import { loadSimplexPeerRegistry, type SimplexPeerRecord, saveSimplexPeerRegistry } from "../../p2p/simplex-server.ts";
+import {
+	loadSimplexPeerRegistry,
+	rankSimplexPeerTargets,
+	type SimplexPeerRecord,
+	saveSimplexPeerRegistry,
+} from "../../p2p/simplex-server.ts";
 import { ConfigError, resolveConfig, resolveConfigPath } from "../config.ts";
 import { renderError } from "../output.ts";
 import type { CommandContext } from "./types.ts";
@@ -26,9 +31,12 @@ export async function runP2p(ctx: CommandContext): Promise<number> {
 		ctx.stdout(`Usage: autorag p2p <subcommand> [options]
 
 Subcommands:
-  peers                     List trusted peers (alias, contactId, addedAt)
-  peers --add <alias> --contact-id <n>   Trust a peer's SimpleX contact id
+  peers                     List trusted peers and local persona metadata
+  peers --add <alias> --contact-id <n> [persona flags]   Trust/update a peer
+  peers --edit <alias> [persona flags]                   Update local persona
   peers --remove <alias>    Remove a peer from the registry
+  peers --show <alias>      Show one peer and local persona
+  peers --rank <query>      Rank local peers by keyword overlap (no send)
   requests                  List pending peer-query approvals
   requests approve <id>     Allow sending the pending response
   requests deny <id>        Refuse the pending response without document content
@@ -52,6 +60,10 @@ Peers connect via SimpleX addresses printed by \`autorag serve\`.
 		case "peers": {
 			const remove = flags.remove;
 			const add = flags.add;
+			const edit = flags.edit;
+			const show = flags.show;
+			const rank = flags.rank;
+			const persona = readPersonaFlags(flags);
 			if (remove !== undefined) {
 				if (typeof remove !== "string" || remove.length === 0) {
 					ctx.stderr(renderError(new ConfigError("--remove requires a peer alias."), { json: ctx.json }));
@@ -66,6 +78,23 @@ Peers connect via SimpleX addresses printed by \`autorag serve\`.
 				saveSimplexPeerRegistry(workspace, registry);
 				if (ctx.json) ctx.stdout(JSON.stringify({ ok: true, removed: remove }));
 				else ctx.stdout(`Removed peer: ${remove}`);
+				return 0;
+			}
+			if (typeof show === "string") {
+				const peer = loadSimplexPeerRegistry(workspace)[show];
+				if (peer === undefined) {
+					ctx.stderr(renderError(new ConfigError(`Peer not found: ${show}`), { json: ctx.json }));
+					return 2;
+				}
+				if (ctx.json) ctx.stdout(JSON.stringify({ ok: true, alias: show, ...peer }));
+				else ctx.stdout(`${show}: ${JSON.stringify(peer)}`);
+				return 0;
+			}
+			if (typeof rank === "string") {
+				const matches = rankSimplexPeerTargets(rank, loadSimplexPeerRegistry(workspace));
+				if (ctx.json) ctx.stdout(JSON.stringify({ ok: true, query: rank, matches }));
+				else if (matches.length === 0) ctx.stdout("No matching peers.");
+				else for (const match of matches) ctx.stdout(`${match.alias}: ${match.matchedTerms.join(", ")}`);
 				return 0;
 			}
 			if (add !== undefined) {
@@ -84,11 +113,30 @@ Peers connect via SimpleX addresses printed by \`autorag serve\`.
 					return 2;
 				}
 				const registry = loadSimplexPeerRegistry(workspace);
-				const record: SimplexPeerRecord = { contactId, addedAt: new Date().toISOString() };
+				const existing = registry[add];
+				const record: SimplexPeerRecord = {
+					...(existing ?? {}),
+					contactId,
+					addedAt: existing?.addedAt ?? new Date().toISOString(),
+					...persona,
+				};
 				registry[add] = record;
 				saveSimplexPeerRegistry(workspace, registry);
 				if (ctx.json) ctx.stdout(JSON.stringify({ ok: true, alias: add, contactId }));
 				else ctx.stdout(`Added peer: ${add} (contactId ${contactId})`);
+				return 0;
+			}
+			if (typeof edit === "string") {
+				const registry = loadSimplexPeerRegistry(workspace);
+				const existing = registry[edit];
+				if (existing === undefined) {
+					ctx.stderr(renderError(new ConfigError(`Peer not found: ${edit}`), { json: ctx.json }));
+					return 2;
+				}
+				registry[edit] = { ...existing, ...persona };
+				saveSimplexPeerRegistry(workspace, registry);
+				if (ctx.json) ctx.stdout(JSON.stringify({ ok: true, alias: edit, ...registry[edit] }));
+				else ctx.stdout(`Updated peer: ${edit}`);
 				return 0;
 			}
 
@@ -98,7 +146,7 @@ Peers connect via SimpleX addresses printed by \`autorag serve\`.
 				ctx.stdout(
 					JSON.stringify({
 						ok: true,
-						peers: entries.map(([alias, peer]) => ({ alias, contactId: peer.contactId, addedAt: peer.addedAt })),
+						peers: entries.map(([alias, peer]) => ({ alias, ...peer })),
 					}),
 				);
 			} else if (entries.length === 0) {
@@ -108,7 +156,9 @@ Peers connect via SimpleX addresses printed by \`autorag serve\`.
 				ctx.stdout(`${"Alias".padEnd(24)} ${"Contact ID".padEnd(12)} Added At`);
 				ctx.stdout("-".repeat(72));
 				for (const [alias, peer] of entries) {
-					ctx.stdout(`${alias.padEnd(24)} ${String(peer.contactId).padEnd(12)} ${peer.addedAt}`);
+					ctx.stdout(
+						`${alias.padEnd(24)} ${String(peer.contactId).padEnd(12)} ${peer.displayName ?? ""} ${peer.addedAt}`,
+					);
 				}
 			}
 			return 0;
@@ -171,4 +221,24 @@ Peers connect via SimpleX addresses printed by \`autorag serve\`.
 			return 2;
 		}
 	}
+}
+
+function readPersonaFlags(
+	flags: CommandContext["flags"],
+): Pick<SimplexPeerRecord, "displayName" | "description" | "role" | "org" | "accessHint"> {
+	const accessHint = flags["access-hint"];
+	return {
+		...(typeof flags["display-name"] === "string" ? { displayName: flags["display-name"] } : {}),
+		...(typeof flags.description === "string" ? { description: flags.description } : {}),
+		...(typeof flags.role === "string" ? { role: flags.role } : {}),
+		...(typeof flags.org === "string" ? { org: flags.org } : {}),
+		...(typeof accessHint === "string"
+			? {
+					accessHint: accessHint
+						.split(",")
+						.map((value) => value.trim())
+						.filter(Boolean),
+				}
+			: {}),
+	};
 }

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -2,9 +2,9 @@ import { existsSync } from "node:fs";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import { completeSimple } from "@earendil-works/pi-ai/compat";
 import { AutoRAGAgent } from "../../agent/agent.ts";
+import { planSourceRoots, sourceIdentifier } from "../../filesystem/source-paths.ts";
 import type { InjectionClassifierModel } from "../../p2p/injection-classifier.ts";
 import { PolicyStore } from "../../p2p/policy.ts";
-import { planSourceRoots, sourceIdentifier } from "../../filesystem/source-paths.ts";
 import {
 	type SimplexPeerServer,
 	type StartSimplexPeerServerOptions,
@@ -116,8 +116,8 @@ export async function runServe(ctx: CommandContext, deps: ServeCommandDeps = {})
 					error instanceof ConfigError
 						? error
 						: new ConfigError(
-							`P2P injection classifier requires a configured model: ${error instanceof Error ? error.message : "resolve failed"}.`,
-						),
+								`P2P injection classifier requires a configured model: ${error instanceof Error ? error.message : "resolve failed"}.`,
+							),
 					{ json: ctx.json, debug: ctx.debug },
 				),
 			);
@@ -153,12 +153,12 @@ export async function runServe(ctx: CommandContext, deps: ServeCommandDeps = {})
 			searchTimeoutMs: p2p.searchTimeoutMs,
 			...(resolvedModel !== undefined
 				? {
-					model: resolvedModel.model,
-					...(resolvedModel.apiKey !== undefined ? { apiKey: resolvedModel.apiKey } : {}),
-					...(resolvedModel.providerApiKeys !== undefined
-						? { providerApiKeys: resolvedModel.providerApiKeys }
-						: {}),
-				}
+						model: resolvedModel.model,
+						...(resolvedModel.apiKey !== undefined ? { apiKey: resolvedModel.apiKey } : {}),
+						...(resolvedModel.providerApiKeys !== undefined
+							? { providerApiKeys: resolvedModel.providerApiKeys }
+							: {}),
+					}
 				: {}),
 		});
 		const policyStore = new PolicyStore({
@@ -198,7 +198,7 @@ export async function runServe(ctx: CommandContext, deps: ServeCommandDeps = {})
 			...(p2p.quotas !== undefined ? { quotas: p2p.quotas } : {}),
 		} as StartSimplexPeerServerOptions);
 	} catch (error) {
-		await transport.close().catch(() => { });
+		await transport.close().catch(() => {});
 		const status = error instanceof ConfigError ? 2 : 1;
 		ctx.stderr(renderError(error, { json: ctx.json, debug: ctx.debug }));
 		return status;
@@ -208,7 +208,7 @@ export async function runServe(ctx: CommandContext, deps: ServeCommandDeps = {})
 	try {
 		address = await transport.getOrCreateAddress();
 	} catch (error) {
-		await transport.close().catch(() => { });
+		await transport.close().catch(() => {});
 		ctx.stderr(
 			renderError(error instanceof Error ? error : new ConfigError("address creation failed"), {
 				json: ctx.json,
@@ -232,10 +232,10 @@ export async function runServe(ctx: CommandContext, deps: ServeCommandDeps = {})
 	const wait = deps.waitUntilStopped ?? defaultWaitUntilStopped;
 	try {
 		await wait(server);
-		await transport.close().catch(() => { });
+		await transport.close().catch(() => {});
 		return 0;
 	} catch (error) {
-		await transport.close().catch(() => { });
+		await transport.close().catch(() => {});
 		ctx.stderr(renderError(error, { json: ctx.json, debug: ctx.debug }));
 		return 1;
 	}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -50,6 +50,14 @@ const VALUE_FLAGS = new Set([
 	"remove",
 	"add",
 	"contact-id",
+	"edit",
+	"show",
+	"rank",
+	"display-name",
+	"description",
+	"role",
+	"org",
+	"access-hint",
 ]);
 
 const COMMANDS = [
@@ -102,7 +110,10 @@ Commands:
   serve                Start the P2P peer query server over SimpleX
                        (--port N  --force)
   p2p                  SimpleX peer trust management
-                       (peers [--add <alias> --contact-id <n>] [--remove <alias>])
+                       (peers [--add <alias> --contact-id <n>] [--edit <alias>]
+                        [--display-name <name>] [--description <text>]
+                        [--role <role>] [--org <org>] [--access-hint <csv>]
+                        [--show <alias>] [--rank <query>] [--remove <alias>])
                        (requests [approve|deny <id>])
   p2p policy list      Show effective merged sharing policy (virtual-path keys)
   p2p policy set       Set a sharing rule: <source-glob> <private|never|always|peers> [--peer fp...]

--- a/src/p2p/simplex-server.ts
+++ b/src/p2p/simplex-server.ts
@@ -67,9 +67,45 @@ export interface SimplexPeerRecord {
 	/** SimpleX contact id of the peer (stable per profile). */
 	readonly contactId: number;
 	readonly addedAt: string;
+	readonly displayName?: string;
+	readonly description?: string;
+	readonly role?: string;
+	readonly org?: string;
+	readonly accessHint?: readonly string[];
 }
 
 export type SimplexPeerRegistry = Record<string, SimplexPeerRecord>;
+
+export interface PeerTargetMatch {
+	readonly alias: string;
+	readonly score: number;
+	readonly matchedTerms: readonly string[];
+}
+
+const TARGET_TOKEN_PATTERN = /[\p{L}\p{N}]+/gu;
+
+function targetTokens(value: string): Set<string> {
+	return new Set((value.toLocaleLowerCase().match(TARGET_TOKEN_PATTERN) ?? []).filter((token) => token.length > 1));
+}
+
+/** Rank local peer records by explainable keyword overlap; never sends a request. */
+export function rankSimplexPeerTargets(query: string, registry: SimplexPeerRegistry): readonly PeerTargetMatch[] {
+	const queryTerms = targetTokens(query);
+	if (queryTerms.size === 0) return [];
+
+	return Object.entries(registry)
+		.map(([alias, peer]) => {
+			const peerTerms = targetTokens(
+				[alias, peer.displayName, peer.description, peer.role, peer.org, ...(peer.accessHint ?? [])]
+					.filter((value): value is string => value !== undefined)
+					.join(" "),
+			);
+			const matchedTerms = [...queryTerms].filter((term) => peerTerms.has(term)).sort();
+			return { alias, score: matchedTerms.length, matchedTerms };
+		})
+		.filter((match) => match.score > 0)
+		.sort((left, right) => right.score - left.score || left.alias.localeCompare(right.alias));
+}
 
 const PEERS_DIR = join(".autorag", "p2p");
 const PEERS_FILENAME = "simplex-peers.json";
@@ -89,7 +125,19 @@ export function loadSimplexPeerRegistry(workspacePath: string): SimplexPeerRegis
 				typeof (record as Record<string, unknown>).contactId === "number" &&
 				typeof (record as Record<string, unknown>).addedAt === "string"
 			) {
-				registry[alias] = record as SimplexPeerRecord;
+				const raw = record as Record<string, unknown>;
+				const accessHint = Array.isArray(raw.accessHint)
+					? raw.accessHint.filter((value): value is string => typeof value === "string")
+					: undefined;
+				registry[alias] = {
+					contactId: raw.contactId as number,
+					addedAt: raw.addedAt as string,
+					...(typeof raw.displayName === "string" ? { displayName: raw.displayName } : {}),
+					...(typeof raw.description === "string" ? { description: raw.description } : {}),
+					...(typeof raw.role === "string" ? { role: raw.role } : {}),
+					...(typeof raw.org === "string" ? { org: raw.org } : {}),
+					...(accessHint !== undefined ? { accessHint } : {}),
+				};
 			}
 		}
 		return registry;

--- a/src/p2p/simplex-transport.ts
+++ b/src/p2p/simplex-transport.ts
@@ -97,7 +97,7 @@ function extractTextFromChatItem(item: unknown): { chatItemId: number; text: str
 
 async function waitForPort(port: number, proc: ChildProcess, timeoutMs: number): Promise<void> {
 	const deadline = Date.now() + timeoutMs;
-	for (; ;) {
+	for (;;) {
 		if (proc.exitCode !== null) {
 			throw new SimplexError(`simplex-chat exited with code ${proc.exitCode} before the WebSocket server started`);
 		}

--- a/test/agent/peer-target-tool.test.ts
+++ b/test/agent/peer-target-tool.test.ts
@@ -1,0 +1,90 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { afterEach, describe, expect, it } from "vitest";
+import { AutoRAGAgent } from "../../src/agent/agent.ts";
+
+const FIXTURE_DIR = "test/fixtures/sample-project";
+const workspaces: string[] = [];
+
+afterEach(() => {
+	for (const workspace of workspaces.splice(0)) rmSync(workspace, { recursive: true, force: true });
+});
+
+function writePeerRegistry(workspace: string): void {
+	writeFileSync(
+		join(workspace, ".autorag", "p2p", "simplex-peers.json"),
+		JSON.stringify({
+			alice: {
+				contactId: 42,
+				addedAt: "2026-01-01T00:00:00.000Z",
+				displayName: "Alice",
+				description: "Finance and budget specialist",
+				role: "finance lead",
+			},
+			bob: {
+				contactId: 43,
+				addedAt: "2026-01-01T00:00:00.000Z",
+				displayName: "Bob",
+				description: "Design documents",
+			},
+		}),
+	);
+}
+
+function registeredTools(agent: AutoRAGAgent): readonly AgentTool[] {
+	return (
+		agent as unknown as {
+			readonly innerAgent: { readonly state: { readonly tools: readonly AgentTool[] } };
+		}
+	).innerAgent.state.tools;
+}
+
+describe("peer persona target tool", () => {
+	it("recommends local peers with matched terms and persona details", async () => {
+		const workspace = mkdtempSync(join(tmpdir(), "autorag-peer-target-"));
+		workspaces.push(workspace);
+		mkdirSync(join(workspace, ".autorag", "p2p"), { recursive: true });
+		writePeerRegistry(workspace);
+		const agent = new AutoRAGAgent({
+			searchPaths: [FIXTURE_DIR],
+			workspacePath: workspace,
+			memoryPath: join(workspace, "memory.json"),
+			minSync: false,
+			jikji: false,
+		});
+		const tool = registeredTools(agent).find((candidate) => candidate.name === "recommend_peer_targets");
+
+		expect(tool).toBeDefined();
+		const result = await tool?.execute("test-call", { query: "finance budget" });
+
+		expect(result?.details).toEqual({
+			method: "recommend_peer_targets",
+			resultCount: 1,
+			matches: [
+				{
+					alias: "alice",
+					matchedTerms: ["budget", "finance"],
+					displayName: "Alice",
+					description: "Finance and budget specialist",
+				},
+			],
+		});
+	});
+
+	it("is not registered for remote sessions", () => {
+		const workspace = mkdtempSync(join(tmpdir(), "autorag-peer-target-"));
+		workspaces.push(workspace);
+		const agent = new AutoRAGAgent({
+			searchPaths: [FIXTURE_DIR],
+			workspacePath: workspace,
+			memoryPath: join(workspace, "memory.json"),
+			remoteSession: true,
+			minSync: false,
+			jikji: false,
+		});
+
+		expect(registeredTools(agent).map((tool) => tool.name)).not.toContain("recommend_peer_targets");
+	});
+});

--- a/test/cli/commands.p2p.test.ts
+++ b/test/cli/commands.p2p.test.ts
@@ -101,6 +101,46 @@ describe("autorag p2p peers", () => {
 		expect(stdout.join("\n")).toMatch(/No peers registered/i);
 	});
 
+	it("stores and shows local persona metadata without policy hints", async () => {
+		const add = await runP2p(
+			makeCtx({
+				positionals: ["peers"],
+				flags: {
+					config: join(root, "config.json"),
+					add: "alice",
+					"contact-id": "42",
+					"display-name": "Alice",
+					description: "Finance owner",
+					role: "Manager",
+					org: "Finance",
+					"access-hint": "budget,tax",
+					"default-policy-hint": "always",
+				},
+			}),
+		);
+		expect(add).toBe(0);
+		const peer = loadSimplexPeerRegistry(root).alice;
+		expect(peer).toMatchObject({
+			displayName: "Alice",
+			description: "Finance owner",
+			role: "Manager",
+			org: "Finance",
+			accessHint: ["budget", "tax"],
+		});
+		expect(peer).not.toHaveProperty("defaultPolicyHint");
+
+		const output: string[] = [];
+		await runP2p(
+			makeCtx({
+				positionals: ["peers"],
+				flags: { config: join(root, "config.json"), show: "alice" },
+				json: true,
+				stdout: (line) => output.push(line),
+			}),
+		);
+		expect(JSON.parse(output[0] ?? "{}")).not.toHaveProperty("defaultPolicyHint");
+	});
+
 	it("rejects removing an unknown peer", async () => {
 		const stderr: string[] = [];
 		const code = await runP2p(

--- a/test/p2p/simplex-server.test.ts
+++ b/test/p2p/simplex-server.test.ts
@@ -6,6 +6,7 @@ import type { SearchDocumentsResponse } from "../../src/agent/search-documents.t
 import { listPendingPeerRequests, writePeerRequestDecision } from "../../src/p2p/approval-store.ts";
 import {
 	querySimplexPeer,
+	rankSimplexPeerTargets,
 	type SimplexPeerRegistry,
 	type SimplexPeerServer,
 	startSimplexPeerServer,
@@ -141,6 +142,31 @@ const PEER_CONTACT_ID = 2;
 function peers(): SimplexPeerRegistry {
 	return { "client-agent": { contactId: PEER_CONTACT_ID, addedAt: new Date().toISOString() } };
 }
+
+describe("local peer persona target ranking", () => {
+	it("ranks by explainable keyword overlap and ignores peers with no match", () => {
+		const matches = rankSimplexPeerTargets("finance budget", {
+			alice: {
+				contactId: 42,
+				addedAt: "2026-01-01T00:00:00.000Z",
+				displayName: "Alice",
+				org: "Finance",
+				accessHint: ["budget", "tax"],
+			},
+			bob: {
+				contactId: 43,
+				addedAt: "2026-01-01T00:00:00.000Z",
+				description: "Design documents",
+			},
+		});
+
+		expect(matches).toEqual([{ alias: "alice", score: 2, matchedTerms: ["budget", "finance"] }]);
+	});
+
+	it("returns no candidates for an empty query", () => {
+		expect(rankSimplexPeerTargets("!!!", peers())).toEqual([]);
+	});
+});
 
 async function lastResponse(transport: FakeTransport, minCount = 1): Promise<PeerQueryResponse> {
 	const responsesOf = () =>


### PR DESCRIPTION
## Summary

- add local-only persona metadata to the SimpleX peer registry
- add deterministic keyword-overlap peer target ranking and a read-only agent tool
- add CLI persona management and ranking commands
- exclude the recommendation tool from remote sessions
- remove `defaultPolicyHint` from the model and scope

## Scope

This PR implements the approved minimal scope for #1537. Ranking is intentionally simple and explainable: tokenized keyword overlap only. It does not use embeddings, an LLM planner, networking, automatic outbound sends, multi-peer queries, or response merging. Actual confirmed outbound request integration is tracked separately in #1544.

## Verification

- RED: focused tests failed before implementation for missing persona persistence and ranking.
- GREEN: focused P2P/CLI/agent tests passed.
- `bun run test` passed.
- `bun run typecheck` passed.
- `bun run build` passed.
- changed-file Biome check passed.
- LSP diagnostics passed for changed files.
- real CLI QA passed for add/show/rank; output contains persona fields and no `defaultPolicyHint`.

Closes #1537
