### PR TITLE
docs(skills): wizard-style datasource probing in setup skills

### DIFF
--- a/skills/autorag-lite-setup/SKILL.md
+++ b/skills/autorag-lite-setup/SKILL.md
@@ -57,14 +57,31 @@ Config resolution follows the usual order: `--config`, `AUTORAG_CONFIG`,
 include `AUTORAG_HOME`, `AUTORAG_CONFIG`, `AUTORAG_SEARCH_PATHS`,
 `AUTORAG_WORKSPACE`, and `AUTORAG_MEMORY_PATH`.
 
-## Configure datasources when requested
+## Probe and configure datasources (setup wizard)
 
-Datasource skills belong in trusted config and remain default-deny. Prefer
-`autorag lite ui --no-open` to connect datasources; it writes the same trusted
-`datasources` / `datasourceAccess` fields as a hand-edited config, stores
-env-var names rather than secrets, and binds a loopback address by default.
-Do not bind non-loopback hosts unless the user explicitly allowed remote
-access.
+`autorag lite ui` is still in development — do not recommend it for datasource
+setup. Configure datasources directly in trusted config, wizard-style:
+
+1. Probe every datasource for setup feasibility before asking the user
+   anything: the backing CLI exists (`katok`, `discrawl`, `slacrawl`,
+   `wacrawl`, `telecrawl`, `notcrawl`, `qmd`, `mailcrawl`, `rclone`), its
+   local store or archive is present, and any credentials it needs are
+   available as environment variables or in the tool's own external
+   configuration.
+2. Auto-configure every datasource that probes feasible — write its trusted
+   `datasources` / `datasourceAccess` entries without asking. For example,
+   when Slack (`slacrawl`) and Discord (`discrawl`) are installed, set both up
+   automatically.
+3. Skip every datasource that probes infeasible (for example Notion or
+   Telegram when their CLIs are not installed) and always report the skipped
+   list to the user, with what is missing for each.
+4. Set up a skipped datasource only when the user explicitly asks for it:
+   install or authenticate the backing CLI first, then configure it.
+5. E-mail datasources (`gmail`, `mail-export`, `mailcrawl`) matter to most
+   users — always probe them and report their status, even when they end up
+   skipped.
+
+Datasource skills belong in trusted config and remain default-deny.
 
 Config keys may be builtin template names (`kakao`, `whatsapp`, `telegram`,
 `slack`, `discord`, `clawgallery`, `notion`, `github`, `cloud-drive`, `gmail`,
@@ -72,7 +89,8 @@ Config keys may be builtin template names (`kakao`, `whatsapp`, `telegram`,
 aliases with `"type": "<template>"`. Unknown names are skipped with an
 `unknown-datasource-skill` warning; they do not fail config resolution.
 `datasourceAccess.allowedTags` and `allowedScopes` narrow trusted access and
-can never grant it.
+can never grant it. Store only env-var names such as `tokenEnv` or
+`apiKeyEnv`, never credential values.
 
 ## Build and refresh indexes
 
@@ -95,8 +113,11 @@ autorag lite refresh --force --json
   or broken, run a full refresh or return to setup rather than silently
   degrading to lexical-only search.
 - Exact duplicate exclusion during refresh is enabled by default via the
-  external `dupey` CLI. Missing dupey is non-fatal; refresh continues without
-  it. Set `"excludeExactDuplicates": false` to index every copy.
+  external `dupey` CLI. Install dupey during setup when it is missing
+  (`command -v dupey || cargo install dupey`) and tell the user the feature is
+  available; when installation is impossible, refresh continues without it
+  and the user is told duplicate exclusion is off. Set
+  `"excludeExactDuplicates": false` to index every copy.
 
 Retrieval requires a completed refresh. `autorag lite retrieve` before any
 refresh exits with code 2 and an `index-not-ready` diagnostic; a successful
@@ -112,10 +133,12 @@ autorag lite watch
 ```
 
 Prefer non-daemon `autorag lite watch --once` from cron, launchd, a systemd
-user timer, or Task Scheduler, typically every 15 to 30 minutes. Use the same
-config as retrieval, avoid overlapping runs, and keep logs outside source
-trees. `--immediate` triggers a first refresh on start and `--debounce-ms N`
-tunes change coalescing.
+user timer, or Task Scheduler, hourly by default (every 1 hour; shorten only
+when the user asks for fresher indexes). Use the same config as retrieval,
+avoid overlapping runs, and keep logs outside source trees. `--immediate`
+triggers a first refresh on start and `--debounce-ms N` tunes change
+coalescing. Once the schedule is installed, tell the user right away that
+hourly freshness is set up.
 
 ## Status and index maintenance
 
@@ -147,6 +170,8 @@ accepting silently degraded search.
 ## Completion condition
 
 Setup is complete only when the CLI is installed, roots are approved, a
-non-secret model-free config is written, `refresh` has built the requested
-indexes, `status` reports healthy indexes, and any requested watch schedule is
-installed or verified.
+non-secret model-free config is written, every datasource has been probed and
+the auto-configured and skipped lists reported to the user, dupey is installed
+or its absence reported, `refresh` has built the requested indexes, `status`
+reports healthy indexes, and any requested watch schedule is installed or
+verified with the user told it is active.

--- a/skills/autorag-setup/SKILL.md
+++ b/skills/autorag-setup/SKILL.md
@@ -136,9 +136,12 @@ defaults to true; requires the Rust toolchain).
 
 Exact duplicate exclusion is enabled by default. AutoRAG invokes the external
 `dupey` CLI before parsed-mirror indexing, keeps the newest filesystem copy for
-each exact canonical-text hash, and excludes older copies from the mirror. Set
-`"excludeExactDuplicates": false` to index every copy. Missing dupey is
-non-fatal; refresh continues without this optimization.
+each exact canonical-text hash, and excludes older copies from the mirror.
+Install dupey during setup when it is missing (`command -v dupey || cargo
+install dupey`) and tell the user the feature is available; when installation
+is impossible, refresh continues without this optimization and the user is
+told duplicate exclusion is off. Set `"excludeExactDuplicates": false` to
+index every copy.
 
 Optional MinSync embedder settings:
 
@@ -154,12 +157,29 @@ autorag init \
 Only store the environment-variable name, never its value. Dimension and batch
 size must be positive integers.
 
-## Configure datasource skills when requested
+## Probe and configure datasource skills (setup wizard)
 
-Prefer `autorag ui --no-open` to connect datasources. It writes the same trusted
-`datasources` / `datasourceAccess` fields as a hand-edited config, stores
-env-var names rather than secrets, and prints a loopback URL (`127.0.0.1`).
-Do not bind non-loopback hosts unless the user explicitly set `ui.allowRemote`.
+`autorag ui` is still in development — do not recommend it for datasource
+setup. Configure datasources directly in trusted config, wizard-style:
+
+1. Probe every datasource for setup feasibility before asking the user
+   anything: the backing CLI exists (`katok`, `discrawl`, `slacrawl`,
+   `wacrawl`, `telecrawl`, `notcrawl`, `qmd`, `mailcrawl`, `rclone`), its
+   local store or archive is present, and any credentials it needs are
+   available as environment variables or in the tool's own external
+   configuration.
+2. Auto-configure every datasource that probes feasible — write its trusted
+   `datasources` / `datasourceAccess` entries without asking. For example,
+   when Slack (`slacrawl`) and Discord (`discrawl`) are installed, set both up
+   automatically.
+3. Skip every datasource that probes infeasible (for example Notion or
+   Telegram when their CLIs are not installed) and always report the skipped
+   list to the user, with what is missing for each.
+4. Set up a skipped datasource only when the user explicitly asks for it:
+   install or authenticate the backing CLI first, then configure it.
+5. E-mail datasources (`gmail`, `mail-export`, `mailcrawl`) matter to most
+   users — always probe them and report their status, even when they end up
+   skipped.
 
 Datasource skills belong in trusted config and remain default-deny. Builtin
 template names are `kakao`, `whatsapp`, `telegram`, `slack`, `discord`,
@@ -228,10 +248,12 @@ autorag search "summarize the collection" --top-k 3 --json --debug
 ## Keep indexes fresh
 
 For continuous freshness, create or verify an OS-appropriate scheduled
-`autorag watch --once` job, typically every 15–30 minutes. Prefer cron or
-launchd on macOS, cron or a user systemd timer on Linux, and Task Scheduler on
-Windows. Use the same config as search, avoid overlapping runs, and keep logs
-outside source trees.
+`autorag watch --once` job, hourly by default (every 1 hour; shorten only when
+the user asks for fresher indexes). Prefer cron or launchd on macOS, cron or a
+user systemd timer on Linux, and Task Scheduler on Windows. Use the same
+config as search, avoid overlapping runs, and keep logs outside source trees.
+Once the schedule is installed, tell the user right away that hourly freshness
+is set up.
 
 ## Environment overrides
 
@@ -246,6 +268,9 @@ outside source trees.
 ## Completion condition
 
 Setup is complete only when the CLI is installed, roots are approved, a
-non-secret single-model config is written, `status` is acceptable, live `health`
+non-secret single-model config is written, every datasource has been probed
+and the auto-configured and skipped lists reported to the user, dupey is
+installed or its absence reported, `status` is acceptable, live `health`
 passes, `refresh` builds the requested indexes, one real structured search
-succeeds, and any requested ongoing schedule is installed or verified.
+succeeds, and any requested ongoing schedule is installed or verified with the
+user told it is active.

--- a/test/cli/skill-docs.test.ts
+++ b/test/cli/skill-docs.test.ts
@@ -76,9 +76,11 @@ describe("parent-agent skill docs", () => {
 		expect(setup).toMatch(/they do not fail config resolution/);
 	});
 
-	it("lists builtin datasource templates and the loopback UI", () => {
+	it("lists builtin datasource templates and probes them wizard-style", () => {
 		const setup = readSkill("autorag-setup");
-		expect(setup).toContain("autorag ui --no-open");
+		expect(setup).toContain("wizard-style");
+		expect(setup).toContain("do not recommend it for datasource");
+		expect(setup).not.toContain("autorag ui --no-open");
 		for (const name of BUILTIN_DATASOURCE_SKILL_NAMES) {
 			expect(setup).toContain(name);
 		}


### PR DESCRIPTION
## Summary

- Mark `autorag ui` / `autorag lite ui` as in-development and no longer recommend them for datasource setup.
- Replace the datasource connection guidance in both `autorag-setup` and `autorag-lite-setup` with an installation-wizard flow: probe every datasource for setup feasibility (backing CLI, local store, credentials), auto-configure the feasible ones (e.g. Slack/Discord when `slacrawl`/`discrawl` are installed), skip infeasible ones and report the skipped list with what is missing, and set up a skipped datasource only when the user explicitly asks. E-mail datasources (`gmail`, `mail-export`, `mailcrawl`) are always probed and their status reported.
- Default the watch schedule to hourly (was 15-30 minutes) and instruct the agent to tell the user immediately once the schedule is installed.
- Install `dupey` by default during setup (`cargo install dupey` when missing) and report duplicate-exclusion availability to the user instead of silently continuing without it.

## Verification

- Frontmatter (`name`/`description`/`license`) parses on both edited SKILL.md files.
- Read-through QA of both files: wizard flow, UI deprecation, hourly watch, and dupey guidance present; safety, exit codes, supported formats, and completion conditions intact.
- `git diff --stat` touches only the two SKILL.md files (83 insertions, 33 deletions).
