### PR TITLE
docs(skills): document local EmbeddingGemma as the default embedder

### DIFF
--- a/skills/autorag-lite-setup/SKILL.md
+++ b/skills/autorag-lite-setup/SKILL.md
@@ -94,6 +94,11 @@ autorag lite refresh --force --json
 - MinSync and Jikji auto-install on first use by default. If they are missing
   or broken, run a full refresh or return to setup rather than silently
   degrading to lexical-only search.
+- MinSync's default embedder is local EmbeddingGemma (768 dimensions, served
+  locally via Ollama): no embedder flags and no API key are needed, and no
+  corpus text leaves the machine. During setup, verify the local model is
+  available (`ollama pull embeddinggemma` with `ollama serve` running);
+  override it only when intentionally using a remote embedder.
 - Exact duplicate exclusion during refresh is enabled by default via the
   external `dupey` CLI. Missing dupey is non-fatal; refresh continues without
   it. Set `"excludeExactDuplicates": false` to index every copy.

--- a/skills/autorag-setup/SKILL.md
+++ b/skills/autorag-setup/SKILL.md
@@ -140,7 +140,14 @@ each exact canonical-text hash, and excludes older copies from the mirror. Set
 `"excludeExactDuplicates": false` to index every copy. Missing dupey is
 non-fatal; refresh continues without this optimization.
 
-Optional MinSync embedder settings:
+MinSync's default embedder is local EmbeddingGemma (768 dimensions, served
+locally via Ollama). The default needs no embedder flags and no API key, and
+no corpus text is sent to a remote embedding service. During setup, verify the
+local model is available (`ollama pull embeddinggemma` with `ollama serve`
+running) instead of silently falling back.
+
+Override the embedder only when intentionally using a different, for example
+remote, provider:
 
 ```bash
 autorag init \
@@ -152,7 +159,8 @@ autorag init \
 ```
 
 Only store the environment-variable name, never its value. Dimension and batch
-size must be positive integers.
+size must be positive integers, and the dimension must match the embedder
+(EmbeddingGemma is 768; text-embedding-3-small is 1536).
 
 ## Configure datasource skills when requested
 


### PR DESCRIPTION
## Summary

MinSync's own default embedder is moving to local EmbeddingGemma (768 dimensions, served via Ollama). Align both setup skills with that default:

- `autorag-setup`: the embedder section now leads with the local EmbeddingGemma default — no embedder flags and no API key needed, no corpus text sent to a remote embedding service, and setup verifies the local model (`ollama pull embeddinggemma` with `ollama serve` running). The OpenAI flag example is reframed as an intentional remote override, with a note that the dimension must match the embedder (EmbeddingGemma 768 vs text-embedding-3-small 1536).
- `autorag-lite-setup`: adds the same default-embedder guidance to the refresh section.

## Verification

- Frontmatter (`name`/`description`/`license`) intact on both files.
- Read-through QA of both edited sections.
- `git diff --stat` touches only the two SKILL.md files (15 insertions, 2 deletions).

Note: accompanies the upstream MinSync default-embedder change; until that lands, `minsync init` still defaults to `openai:text-embedding-3-small`.
