### PR TITLE
release: v2.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorag/librarian",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Self-evolving librarian agent on Pi framework with pluggable retrieval methods",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Bump @autorag/librarian to 2.4.2. Tag v2.4.2 after merge triggers the npm publish workflow.