### PR TITLE
docs: add project governance (Marker ownership, NomaDamas operations)

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,99 @@
+# AutoRAG Project Governance
+
+This document describes how the AutoRAG project is owned, operated, and how
+decisions are made. It follows the precedent of company-owned open source
+projects that are operated by a non-profit community organization (for
+example, PyTorch under the PyTorch Foundation / Linux Foundation, or
+Kubernetes under the CNCF), where **ownership** and **day-to-day governance**
+are deliberately separated.
+
+## Organizations and Roles
+
+### Project Owner — Marker Inc.
+
+Marker Inc. (주식회사 마커) is the legal owner of the AutoRAG project. Marker
+Inc. holds the project copyright (jointly with NomaDamas, per the
+[LICENSE](LICENSE)), the source repository, and other project assets.
+
+### Operating Organization — NomaDamas
+
+NomaDamas is a non-profit open-source organization (an AI open-source hacker
+house). NomaDamas operates and manages AutoRAG day to day on behalf of the
+community and the owner.
+
+### Project Lead
+
+**Dongkyu Kim ([@vkehfdl1](https://github.com/vkehfdl1))** is the project
+lead for both NomaDamas and Marker Inc. with respect to AutoRAG. The project
+lead coordinates between the two organizations, represents the project
+publicly, and is the final point of escalation for any decision not
+explicitly assigned below.
+
+### Maintainers
+
+Direct commit (write) access to the repository is limited to:
+
+- Members of NomaDamas, and
+- External maintainers explicitly approved by NomaDamas.
+
+Maintainers review and merge pull requests, triage issues, cut releases
+under the agreed roadmap, and steward code quality.
+
+### Contributors
+
+Everyone else in the community. External contributions are actively
+welcomed through issues and pull requests — no membership in either
+organization is required to contribute.
+
+## Decision Making
+
+### Decisions made by NomaDamas (day-to-day operation)
+
+NomaDamas is responsible for the overall management of the project,
+including:
+
+- Code review and pull request approval / merging
+- Issue triage, prioritization, and labeling
+- Roadmap and release planning
+- Technical direction, architecture, and coding standards
+- Approval of external maintainers
+
+NomaDamas decides by maintainer consensus wherever possible. When consensus
+cannot be reached, the project lead decides.
+
+### Decisions reserved to Marker Inc. (ownership matters)
+
+Final authority over ownership-level matters rests with the project owner,
+Marker Inc., including:
+
+- Transferring the repository to another organization or owner
+- Deleting or archiving the repository
+- Changing the project license
+- Other fundamental matters concerning project ownership and assets
+
+These decisions are made by Marker Inc., represented by the project lead.
+
+## Contributing
+
+- Contributions are made via pull requests against `main` and are reviewed
+  by the maintainers.
+- All contributions are licensed under the project's
+  [MIT License](LICENSE).
+- All participants are expected to follow the
+  [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Becoming a Maintainer
+
+- NomaDamas members may be granted maintainer rights by NomaDamas.
+- External contributors may be approved as maintainers by NomaDamas after
+  sustained, high-quality contributions, typically by nomination from an
+  existing maintainer and sign-off from the project lead.
+- Maintainers who become inactive for an extended period may be moved to
+  emeritus status by NomaDamas; they can be reinstated on return.
+
+## Amending This Document
+
+Changes to this document are made via pull request and require approval by
+NomaDamas and the project lead. Changes to the "Project Owner" section or
+the "Decisions reserved to Marker Inc." section additionally require
+explicit approval from Marker Inc.


### PR DESCRIPTION
## Summary

Adds `GOVERNANCE.md` at the repository root, documenting how AutoRAG is owned and operated. The model follows the precedent of company-owned open source projects operated by a non-profit community organization (e.g. PyTorch under the PyTorch Foundation / Linux Foundation, Kubernetes under the CNCF), separating **ownership** from **day-to-day governance**:

- **Project owner: Marker Inc. (주식회사 마커)** — holds the copyright (jointly with NomaDamas, per the MIT LICENSE), the repository, and project assets.
- **Operating organization: NomaDamas** — the non-profit AI open-source hacker house that runs day-to-day management: code review, PR approval, issue triage/prioritization, roadmap and release planning, and maintainer approval.
- **Community contributions** are actively welcomed; no membership is required to contribute.
- **Ownership-level decisions** (repository transfer, repository deletion/archival, license changes, and other fundamental ownership matters) are reserved to Marker Inc.
- **Project lead:** Dongkyu Kim (@vkehfdl1) for both NomaDamas and Marker Inc.
- **Maintainers (write access):** NomaDamas members or external maintainers explicitly approved by NomaDamas.

The document also covers how to become a maintainer and how this governance document itself can be amended (ownership sections additionally require Marker Inc. approval).

🤖 Generated with a coding agent